### PR TITLE
feat: Support custom OpenAI base URL via env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,11 @@
 # Used by dotenv package to load environment variables in scripts and python_server
+# Copy this file to .env and replace the XXX with the actual keys / URLs
 OPENAI_API_KEY=XXX
+OPENAI_BASE_URL=XXX # optional, defaults to https://api.openai.com
+
 VOYAGE_API_KEY=XXX
 TOGETHER_API_KEY=XXX
 COHERE_API_KEY=XXX
 MISTRAL_API_KEY=XXX
+
 LATENT_SCOPE_DATA='~/latent-scope-data'

--- a/latentscope/models/providers/openai.py
+++ b/latentscope/models/providers/openai.py
@@ -12,7 +12,13 @@ class OpenAIEmbedProvider(EmbedModelProvider):
         if api_key is None:
             print("ERROR: No API key found for OpenAI")
             print("Missing 'OPENAI_API_KEY' variable in:", f"{os.getcwd()}/.env")
-        self.client = OpenAI(api_key=api_key)
+
+        base_url = get_key("OPENAI_BASE_URL")
+        if base_url is not None:
+            self.client = OpenAI(api_key=api_key, base_url=base_url)
+        else:
+            self.client = OpenAI(api_key=api_key)
+
         self.encoder = tiktoken.encoding_for_model(self.name)
 
     def embed(self, inputs, dimensions=None):


### PR DESCRIPTION
## Motivation

- Enable people to use latent-scope with a proxy server / alternative provider of OpenAI compatible endpoints
- Fixes #42 

## Changes

- Updates the example `.env` file 
- Updates the OpenAI model to use the custom base_url if available

## Testing

- I don't know of a public openai compatible proxy, but you can verify the env variable is working by
  - Running w/ no new env variable - openai should work as before
  - Run w/ a bad URL - calls to the openAI model should fail