### PR TITLE
Added support for using local LLMs via ollama

### DIFF
--- a/latentscope/models/__init__.py
+++ b/latentscope/models/__init__.py
@@ -5,6 +5,7 @@ from .providers.mistralai import MistralAIEmbedProvider, MistralAIChatProvider
 from .providers.cohereai import CohereAIEmbedProvider
 from .providers.togetherai import TogetherAIEmbedProvider
 from .providers.voyageai import VoyageAIEmbedProvider
+from .providers.ollama import OllamaEmbedProvider, OllamaChatProvider
 from .providers.nltk import NLTKChatProvider
 
 # We use a universal id system for models where its:
@@ -62,6 +63,8 @@ def get_embedding_model(id):
         return TogetherAIEmbedProvider(model['name'], model['params'])
     if model['provider'] == "voyageai":
         return VoyageAIEmbedProvider(model['name'], model['params'])
+    if model['provider'] == "ollama":
+        return OllamaEmbedProvider(model['name'], model['params'])
 
 
 def get_chat_model_list():
@@ -92,4 +95,7 @@ def get_chat_model(id):
         return MistralAIChatProvider(model['name'], model['params'])
     if model['provider'] == "nltk":
         return NLTKChatProvider(model['name'], model['params'])
+    if model['provider'] == "ollama":
+        return OllamaChatProvider(model['name'], model['params'])
+    
 

--- a/latentscope/models/chat_models.json
+++ b/latentscope/models/chat_models.json
@@ -48,5 +48,13 @@
         "params": {
             "max_tokens": 128000
         }
+    },
+    {
+        "provider": "ollama",
+        "name": "llama3.2",
+        "id": "llama3.2",
+        "params": {
+            "max_tokens": 128000
+        }
     }
 ]

--- a/latentscope/models/embedding_models.json
+++ b/latentscope/models/embedding_models.json
@@ -57,6 +57,30 @@
         "truncation": true,
         "max_tokens": 16000
     }
-}
+  },
+  {
+      "provider": "ollama",
+      "name": "mxbai-embed-large",
+      "id": "mxbai-embed-large",
+      "params": {
+          "num_ctx": 512
+      }
+  },
+  {
+      "provider": "ollama",
+      "name": "nomic-embed-text",
+      "id": "nomic-embed-text",
+      "params": {
+          "num_ctx": 8192
+      }
+  },
+  {
+      "provider": "ollama",
+      "name": "all-minilm",
+      "id": "all-minilm",
+      "params": {
+          "num_ctx": 256
+      }
+  }
 
 ]

--- a/latentscope/models/providers/ollama.py
+++ b/latentscope/models/providers/ollama.py
@@ -1,0 +1,46 @@
+import os
+import time
+from .base import EmbedModelProvider, ChatModelProvider
+
+import os
+import time
+from .base import EmbedModelProvider, ChatModelProvider
+
+class OllamaEmbedProvider(EmbedModelProvider):
+    def load_model(self):
+        from ollama import Client
+        self.client = Client(host='http://localhost:11434')
+        import tiktoken
+        self.encoder = tiktoken.get_encoding("cl100k_base")
+
+    def embed(self, inputs, dimensions=None):
+        # Currently not doing any fancy encoding, just sending the text as is
+        inputs = [b.replace("\n", " ") for b in inputs]
+
+        # This can probably be done more efficiently in a batched manner.
+        embeddings = []
+        for input_text in inputs:
+            response = self.client.embeddings(
+                model=self.name, 
+                prompt=input_text,
+                options={"temperature": 0, "num_ctx": self.params["num_ctx"]}
+            )
+            embeddings.append(response["embedding"])
+
+        return embeddings
+
+class OllamaChatProvider(ChatModelProvider):
+    def load_model(self):
+        from ollama import Client
+        self.client = Client(host='http://localhost:11434')
+        import tiktoken
+        self.encoder = tiktoken.get_encoding("cl100k_base")
+
+    def chat(self, messages):
+        response = self.client.chat(
+            model=self.name,
+            messages=messages
+        )
+
+        return response["message"]["content"]
+


### PR DESCRIPTION
This is basic support, enabling a few embedding models as well as Llama-3.2 for chat.
The tokenizer used is currently the cl100k_base encoding by way of tiktoken.