### PR TITLE
feat: plan and experiment for late interaction model support

### DIFF
--- a/docs/late-interaction-plan.md
+++ b/docs/late-interaction-plan.md
@@ -1,0 +1,352 @@
+# Late Interaction Model Support — Implementation Plan
+
+Late interaction models (ColBERT, ColPali, etc.) produce one vector *per token or patch* rather
+than a single vector per input row. This document describes how to support them in latent-scope
+without breaking the existing single-vector pipeline.
+
+---
+
+## Core Design Decisions
+
+### 1. Embedding as the Lance base; rest of pipeline stays as files
+
+The pipeline branches freely: multiple embeddings per dataset, multiple UMAPs per embedding,
+multiple clusters per UMAP. A single Lance table per **scope** (the final merge) already exists;
+that stays. The new addition is a Lance table per **embedding** that holds the raw vectors.
+
+```
+dataset/
+  embeddings/
+    embedding-001.h5          ← kept for backward compat (single-vector)
+    embedding-001.json         ← metadata (add interaction_type, storage_sizes)
+    embedding-001.lance/       ← NEW: Lance table for all embeddings going forward
+  umaps/
+    umap-001.parquet           ← unchanged (row-level x,y)
+    umap-001.pkl               ← unchanged (saved UMAP model)
+    umap-001.json              ← unchanged
+  clusters/                    ← unchanged
+  scopes/
+    scopes-001.lance/          ← unchanged (final merged, ANN-indexed table)
+```
+
+**For single-vector models:** Lance table has `row_id + vector`. The .h5 file is still written
+for backward compat with existing UMAP/cluster code until those scripts are updated.
+
+**For late-interaction models:** Lance table has `row_id + token_vectors + mean_vector`.
+No .h5 is needed — `mean_vector` replaces it for all downstream steps.
+
+### 2. Mean pool is the bridge to the existing pipeline
+
+Every late-interaction embedding run computes and stores a mean-pool of the token vectors.
+This single vector per row is what UMAP, clustering, and the scope ANN index use — the
+existing pipeline is completely unchanged.
+
+The per-token vectors are a parallel layer used only for:
+- Late-interaction (MaxSim) search
+- Token-level UMAP exploration (optional, separate step)
+
+### 3. LanceDB multi-vector is used natively — no custom MaxSim
+
+LanceDB ≥ 0.20 supports `list<list<float32>>` columns with built-in MaxSim late interaction.
+The search API is identical: `tbl.search(query_tokens).metric("cosine")`.
+No custom Python reranking loop is needed.
+
+---
+
+## Storage Schema
+
+### Single-vector embedding (current + going forward)
+```
+embedding-001 lance:
+  row_id    int64
+  vector    fixed_size_list<float32>[D]
+```
+
+### Late-interaction embedding
+```
+embedding-001 lance:
+  row_id        int64
+  token_vectors list<fixed_size_list<float32>[D]>   ← MaxSim search target
+  mean_vector   fixed_size_list<float32>[D]          ← UMAP / ANN fallback
+```
+
+### Scope lance table (late-interaction)
+```
+scopes-001 lance:
+  ...all existing columns...
+  vector        list<fixed_size_list<float32>[D]>    ← renamed from mean, now multi-vec
+  mean_vector   fixed_size_list<float32>[D]          ← kept for ANN index fallback
+```
+
+---
+
+## Size Estimation (pre-flight)
+
+Before embed runs, estimate output sizes and show them in the UI:
+
+```
+N  = row count from input.parquet  (known)
+D  = model output dimension        (from embedding_models.json)
+T  = avg tokens per row            (sample 50 rows, tokenize, take mean)
+                                   or use max_seq_length as upper bound
+
+Single-vector:
+  embeddings (float32) = N × D × 4 bytes
+  embeddings (float16) = N × D × 2 bytes
+
+Late-interaction:
+  token vectors (float32) = N × T_avg × D × 4 bytes
+  token vectors (float16) = N × T_avg × D × 2 bytes
+  mean vectors             = N × D × 4 bytes  (always float32)
+```
+
+Show both uncompressed and estimated Lance-compressed sizes.
+Lance's built-in compression typically yields 1.3–1.8× on float32 embeddings.
+
+---
+
+## Detection of Late-Interaction Models
+
+### From HuggingFace (🤗- prefix models)
+
+Detection happens in `TransformersEmbedProvider.load_model()` after the model loads.
+Two complementary checks:
+
+**Check 1 — sentence-transformers Pooling module:**
+```python
+from sentence_transformers.models import Pooling
+has_pooling = any(isinstance(m, Pooling) for m in self.model.modules())
+# ColBERT/ColPali: no Pooling module → late interaction
+```
+
+**Check 2 — probe output shape:**
+```python
+sample = self.model.encode(["test"], convert_to_tensor=False)
+# sample[0] is (D,) for single-vector, (T, D) for late-interaction
+is_late = hasattr(sample[0][0], '__len__')
+```
+
+Probe wins in ambiguous cases. Result stored as `self.interaction_type = "late" | "single"`.
+
+### From embedding_models.json (known models)
+Add explicit field to catalog entries:
+```json
+{
+  "id": "transformers-colbert-ir___colbertv2.0",
+  "interaction_type": "late",
+  "dimensions": 128,
+  "max_seq_length": 128,
+  "providers": ["transformers"]
+}
+```
+
+### From custom models
+User specifies `"interaction_type": "late"` in their custom model config JSON.
+
+### Fallback
+If detection fails or is ambiguous, default to `"single"` and warn.
+
+---
+
+## Files to Change
+
+### `requirements.txt`
+- `lancedb~=0.19.0` → `lancedb~=0.30.0`
+
+### `latentscope/models/embedding_models.json`
+- Add `interaction_type` field to all existing entries (default `"single"`)
+- Add ColBERT and ColPali model entries with `"interaction_type": "late"`
+
+### `latentscope/models/providers/transformers.py`
+- `TransformersEmbedProvider.load_model()`: run detection, set `self.interaction_type`
+- `TransformersEmbedProvider.embed()`: for late interaction, return `list[np.ndarray]`
+  where each element is shape `(T_i, D)` — ragged is fine
+- `TransformersEmbedProvider.embed_mean()`: new helper, returns `(B, D)` mean pool
+  for a batch (used by embed.py to write mean_vector column)
+
+### `latentscope/scripts/embed.py`
+
+**New functions:**
+- `estimate_embed_cost(dataset_id, text_column, model_id, sample_n=50)` → dict with
+  `{rows, dimensions, avg_tokens, token_bytes_f32, token_bytes_f16, mean_bytes}`
+- `write_lance_embedding(dataset_path, embedding_id, row_id, vector_or_tokens, mean_vector=None)`
+  — appends to the embedding Lance table
+
+**Modified `embed()` function:**
+- After model.load_model(), check `model.interaction_type`
+- For `"single"`: write .h5 as today + write Lance table with `vector` column
+- For `"late"`: write Lance table with `token_vectors` + `mean_vector` columns;
+  also write .h5 with mean_vectors for backward compat with umapper
+- Log actual compressed sizes to metadata JSON after write
+
+**Updated `embedding-XXX.json` metadata:**
+```json
+{
+  "id": "embedding-001",
+  "model_id": "...",
+  "interaction_type": "late",
+  "dimensions": 128,
+  "avg_tokens_per_row": 47.3,
+  "total_tokens": 4730000,
+  "storage": {
+    "lance_bytes": 1247832064,
+    "h5_mean_bytes": 51200000
+  }
+}
+```
+
+### `latentscope/scripts/umapper.py`
+- Detect `interaction_type` from embedding metadata JSON
+- For `"late"`: read `mean_vector` from Lance table instead of `embeddings` from .h5
+  (`tbl.to_lance().to_batches(columns=["mean_vector"])`)
+- For `"single"`: read from .h5 as today (no change)
+- UMAP output (row-level x,y parquet) is identical in both cases
+
+### `latentscope/scripts/scope.py` — `export_lance()`
+- For `"late"` embeddings: read `token_vectors` from embedding Lance table;
+  write as the `vector` column of the scope Lance table (LanceDB multi-vector)
+- Also write `mean_vector` column for ANN fallback
+- ANN index is created on `mean_vector` (single-vector, fast);
+  multi-vector `vector` column uses LanceDB's native multi-vector indexing
+
+### `latentscope/server/search.py`
+- For `"late"` scopes: encode query with the original model to get token vectors;
+  pass token vector array to `tbl.search()` — LanceDB handles MaxSim automatically
+- API response shape is unchanged (`indices`, `distances`, `search_embedding`)
+- `search_embedding` in response becomes the mean of query tokens (for display)
+
+### `latentscope/server/app.py` (row detail endpoint)
+- When fetching a row that has `token_vectors`, optionally return them
+  (controlled by query param `?include_tokens=true`)
+- This powers the token-level exploration UI
+
+---
+
+## Frontend Changes
+
+### Embed step (`web/src/components/Setup/Embed.jsx` or similar)
+
+**Pre-flight cost panel** — shown before embed starts:
+```
+Model: colbert-ir/colbertv2.0  [late interaction]
+Rows: 100,000
+Est. avg tokens/row: ~47
+─────────────────────────────────────────────
+Token vectors (float32):  ~2.4 GB
+Token vectors (float16):  ~1.2 GB  ← recommended
+Mean vectors:             ~51 MB
+─────────────────────────────────────────────
+[float16]  [float32]   ← precision selector
+```
+
+**Interaction type badge** on each embedding card in the UI.
+
+### UMAP step
+No UI changes required — UMAP uses mean_vectors transparently.
+Optionally: show a note "using mean-pool of token vectors" when embedding is late-interaction.
+
+### Search / exploration
+**Token detail view** — when clicking a data point that came from a late-interaction embedding,
+show a mini scatter of its token projections (using the saved UMAP model's transform output
+computed on demand or pre-computed in the experiments step).
+
+This is optional / phase 2. Core search works immediately via MaxSim with no UI changes.
+
+---
+
+## Tests and Fixtures
+
+### Test fixtures
+```
+tests/fixtures/
+  tiny_late_interaction/
+    input.parquet              ← 20 rows, "text" column
+  mock_colbert_output.py       ← generates (T, D) numpy arrays deterministically
+```
+
+A mock provider is better than loading a real model in tests:
+```python
+class MockLateInteractionProvider:
+    interaction_type = "late"
+    def embed(self, texts, **kwargs):
+        # returns list of (T_i, D) arrays, T_i varies by text length
+        return [np.random.randn(max(3, len(t.split())), 16).astype(np.float32)
+                for t in texts]
+    def embed_mean(self, texts, **kwargs):
+        return np.stack([v.mean(0) for v in self.embed(texts)])
+```
+
+### Test cases
+
+**`tests/test_embed_late_interaction.py`**
+- `test_detection_from_pooling_module()` — mock ST model with/without Pooling module
+- `test_detection_from_output_shape()` — mock provider returning (T, D) vs (D,)
+- `test_embed_writes_lance_schema()` — embed with mock provider, check Lance table columns
+- `test_embed_writes_mean_h5()` — late interaction embed writes valid .h5 mean vectors
+- `test_cost_estimation()` — `estimate_embed_cost()` returns plausible numbers
+- `test_metadata_json_fields()` — check `interaction_type`, `avg_tokens_per_row`, `storage` keys
+
+**`tests/test_umapper_late_interaction.py`**
+- `test_umap_reads_mean_from_lance()` — umapper reads mean_vector column, produces (N, 2) output
+
+**`tests/test_search_late_interaction.py`**
+- `test_maxsim_search_via_lance()` — scope with multi-vector column, search returns indices
+
+**`tests/test_scope_late_interaction.py`**
+- `test_export_lance_multivector_schema()` — check `vector` column is `list<list<float32>>`
+
+---
+
+## Suggested Implementation Order
+
+```
+Phase 1 — Functional late-interaction end-to-end (no UI changes)
+  1. requirements.txt: bump lancedb to 0.30.0
+  2. embedding_models.json: add interaction_type field + ColBERT entries
+  3. transformers.py: detection + late-interaction embed() return shape
+  4. embed.py: write Lance table for late interaction; .h5 mean for compat
+  5. scope.py: export multi-vector Lance table
+  6. search.py: pass token query to Lance for MaxSim
+  7. Tests: fixtures + embed/search tests
+
+Phase 2 — UMAP reads from Lance
+  8. umapper.py: read mean_vector from Lance (removes h5 dependency for late interaction)
+  9. Tests: umapper tests
+
+Phase 3 — Cost estimation + UI
+  10. embed.py: estimate_embed_cost()
+  11. API endpoint for cost estimation
+  12. Frontend: pre-flight cost panel, interaction type badge
+
+Phase 4 — Token exploration
+  13. app.py: token_vectors in row detail response
+  14. Frontend: token mini-scatter in detail panel
+```
+
+---
+
+## Experiment: Token Projection via Saved UMAP
+
+See `experiments/umap_token_projection.py`.
+
+**Quick simulation run** (no model needed):
+```bash
+python experiments/umap_token_projection.py mydata embedding-001 umap-001 \
+    --simulate --n_tokens 8 --noise_scale 0.05
+```
+
+**Real ColBERT run** (requires pylate or sentence-transformers):
+```bash
+pip install pylate
+python experiments/umap_token_projection.py mydata embedding-001 umap-001 \
+    --model colbert-ir/colbertv2.0 --max_rows 1000
+```
+
+Output: `data/mydata/experiments/token_projection_embedding-001_umap-001.parquet`
+with columns `[row_id, token_idx, x, y, mean_x, mean_y, spread]` — directly overlayable
+on the existing UMAP scatter.
+
+The key question this experiment answers: **how spread out are token projections relative to
+the full UMAP coordinate space?** If `relative_spread < 0.05`, tokens form tight clouds that
+are useful for per-document token exploration. If spread is larger, token projections may
+overlap across documents and are better used for corpus-level token topology analysis.

--- a/experiments/umap_token_projection.py
+++ b/experiments/umap_token_projection.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python
+"""
+Experiment: Project token/patch vectors through a UMAP model trained on mean vectors.
+
+Tests the hypothesis that token vectors for a document will cluster near their
+document's mean-pool UMAP position, making per-token exploration useful.
+
+Usage:
+    python experiments/umap_token_projection.py <dataset_id> <embedding_id> <umap_id>
+
+    # With a real late-interaction model (e.g. colbert-ir/colbertv2.0):
+    python experiments/umap_token_projection.py mydata embedding-001 umap-001 \
+        --model colbert-ir/colbertv2.0
+
+    # Simulation mode (no model required, uses gaussian noise around mean):
+    python experiments/umap_token_projection.py mydata embedding-001 umap-001 \
+        --simulate --n_tokens 8 --noise_scale 0.05
+
+Results are written to:
+    <data_dir>/<dataset_id>/experiments/umap_token_projection_<embedding_id>_<umap_id>.parquet
+
+That parquet has columns: row_id, token_idx, x, y, mean_x, mean_y, spread
+allowing direct overlay on the existing UMAP scatter plot.
+"""
+
+import os
+import sys
+import argparse
+import pickle
+import numpy as np
+
+
+def load_mean_embeddings(dataset_path, embedding_id):
+    import h5py
+    path = os.path.join(dataset_path, "embeddings", f"{embedding_id}.h5")
+    with h5py.File(path, "r") as f:
+        embeddings = np.array(f["embeddings"], dtype=np.float32)
+    print(f"Loaded mean embeddings: {embeddings.shape}")
+    return embeddings
+
+
+def load_umap_model(dataset_path, umap_id):
+    path = os.path.join(dataset_path, "umaps", f"{umap_id}.pkl")
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            f"No saved UMAP model at {path}. "
+            "Re-run UMAP with model saving enabled (it saves by default)."
+        )
+    with open(path, "rb") as f:
+        model = pickle.load(f)
+    print(f"Loaded UMAP model from {path}")
+    return model
+
+
+def load_existing_umap_coords(dataset_path, umap_id):
+    """Load the pre-computed UMAP coords so we can compare against transform() output."""
+    import pandas as pd
+    path = os.path.join(dataset_path, "umaps", f"{umap_id}.parquet")
+    df = pd.read_parquet(path)
+    return df[["x", "y"]].values.astype(np.float32)
+
+
+def simulate_token_vectors(mean_embeddings, n_tokens, noise_scale, seed=42):
+    """
+    Simulate token vectors by adding gaussian noise around the mean.
+    This is a stand-in for real late-interaction model output.
+    noise_scale controls how spread out the tokens are relative to the mean.
+    """
+    rng = np.random.default_rng(seed)
+    N, D = mean_embeddings.shape
+    # (N, T, D): each token is the mean + small perturbation
+    token_vecs = (
+        mean_embeddings[:, None, :]
+        + rng.normal(0, noise_scale, (N, n_tokens, D)).astype(np.float32)
+    )
+    # L2-normalize each token vector (ColBERT normalizes its outputs)
+    norms = np.linalg.norm(token_vecs, axis=-1, keepdims=True)
+    token_vecs = token_vecs / np.maximum(norms, 1e-8)
+    return token_vecs  # (N, T, D)
+
+
+def embed_tokens_with_model(texts, model_name, device="cpu"):
+    """
+    Encode texts with a real late-interaction model (e.g. ColBERT via pylate).
+    Returns a ragged list of arrays, each shape (T_i, D).
+    Falls back to sentence-transformers with output_value='token_embeddings'.
+    """
+    try:
+        from pylate import models as pylate_models
+        model = pylate_models.ColBERT(model_name, device=device)
+        token_vecs = model.encode(
+            texts,
+            is_query=False,
+            convert_to_numpy=True,
+            show_progress_bar=True,
+        )
+        # pylate returns list of (T_i, D) arrays
+        return token_vecs
+    except ImportError:
+        pass
+
+    # Fallback: sentence-transformers with token_embeddings output
+    from sentence_transformers import SentenceTransformer
+    st_model = SentenceTransformer(model_name, trust_remote_code=True)
+    token_vecs = st_model.encode(
+        texts,
+        output_value="token_embeddings",
+        convert_to_numpy=True,
+        show_progress_bar=True,
+    )
+    # Returns list of (T_i, D) tensors/arrays
+    return [t.numpy() if hasattr(t, "numpy") else t for t in token_vecs]
+
+
+def project_tokens_batched(umap_model, token_vecs_flat, batch_size=10_000):
+    """
+    Project a large (N*T, D) array through umap_model.transform() in batches.
+    UMAP transform is stateless per-point so batching is safe.
+    """
+    n = len(token_vecs_flat)
+    results = []
+    for start in range(0, n, batch_size):
+        end = min(start + batch_size, n)
+        batch = token_vecs_flat[start:end]
+        coords = umap_model.transform(batch)
+        results.append(coords)
+        print(f"  projected {end}/{n} token vectors", end="\r", flush=True)
+    print()
+    return np.concatenate(results, axis=0)  # (N*T, 2)
+
+
+def normalize_coords(coords, reference_coords):
+    """
+    Apply the same [-1, 1] normalization the UMAP pipeline uses,
+    derived from the reference (mean) coordinate range.
+    """
+    min_xy = reference_coords.min(axis=0)
+    max_xy = reference_coords.max(axis=0)
+    return 2 * (coords - min_xy) / (max_xy - min_xy + 1e-8) - 1
+
+
+def compute_spread(token_coords, mean_coords):
+    """
+    For each row, compute the mean distance of its token projections
+    from the document's mean-pool UMAP coordinate.
+    Returns (N, T) distances.
+    """
+    # token_coords: (N, T, 2), mean_coords: (N, 2)
+    diff = token_coords - mean_coords[:, None, :]  # (N, T, 2)
+    return np.linalg.norm(diff, axis=-1)  # (N, T)
+
+
+def build_results_dataframe(token_coords, mean_coords, spread, row_ids=None):
+    """
+    Build a long-form dataframe with one row per (document, token) pair.
+    Columns: row_id, token_idx, x, y, mean_x, mean_y, spread
+    """
+    import pandas as pd
+    N, T, _ = token_coords.shape
+    row_id_col = np.repeat(row_ids if row_ids is not None else np.arange(N), T)
+    token_idx_col = np.tile(np.arange(T), N)
+    x_col = token_coords[:, :, 0].ravel()
+    y_col = token_coords[:, :, 1].ravel()
+    mean_x_col = np.repeat(mean_coords[:, 0], T)
+    mean_y_col = np.repeat(mean_coords[:, 1], T)
+    spread_col = spread.ravel()
+
+    return pd.DataFrame({
+        "row_id":    row_id_col,
+        "token_idx": token_idx_col,
+        "x":         x_col.astype(np.float32),
+        "y":         y_col.astype(np.float32),
+        "mean_x":    mean_x_col.astype(np.float32),
+        "mean_y":    mean_y_col.astype(np.float32),
+        "spread":    spread_col.astype(np.float32),
+    })
+
+
+def print_summary(spread, existing_coords, projected_mean_coords):
+    """Print diagnostic statistics."""
+    print("\n=== Results ===")
+    print(f"Token spread from document mean (UMAP units):")
+    print(f"  mean:   {spread.mean():.4f}")
+    print(f"  median: {np.median(spread):.4f}")
+    print(f"  p95:    {np.percentile(spread, 95):.4f}")
+    print(f"  max:    {spread.max():.4f}")
+
+    # Check how well transform() reproduces the saved UMAP coords
+    if existing_coords is not None and projected_mean_coords is not None:
+        coord_err = np.linalg.norm(existing_coords - projected_mean_coords, axis=1)
+        print(f"\nTransform vs saved coords error (mean: {coord_err.mean():.4f}, max: {coord_err.max():.4f})")
+        print("(small error = UMAP transform is consistent with the original fit)")
+
+    coord_range = spread.max() - spread.min()
+    relative_spread = spread.mean() / 2.0  # coords are in [-1, 1], range=2
+    print(f"\nRelative spread (fraction of full UMAP range): {relative_spread:.3f}")
+    if relative_spread < 0.02:
+        print("→ Tokens cluster very tightly around mean. Token projection is useful for detail.")
+    elif relative_spread < 0.10:
+        print("→ Moderate token spread. Tokens visible as small clouds around each document point.")
+    else:
+        print("→ High token spread. Tokens may overlap across documents — consider clustering tokens.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("dataset_id", help="Dataset id (directory name in LATENT_SCOPE_DATA)")
+    parser.add_argument("embedding_id", help="Embedding id, e.g. embedding-001")
+    parser.add_argument("umap_id", help="UMAP id, e.g. umap-001")
+    parser.add_argument("--model", default=None,
+                        help="HuggingFace model name for real token embeddings (e.g. colbert-ir/colbertv2.0)")
+    parser.add_argument("--simulate", action="store_true",
+                        help="Use gaussian simulation instead of a real model")
+    parser.add_argument("--n_tokens", type=int, default=8,
+                        help="Tokens per document in simulation mode (default: 8)")
+    parser.add_argument("--noise_scale", type=float, default=0.05,
+                        help="Noise magnitude in simulation mode (default: 0.05)")
+    parser.add_argument("--max_rows", type=int, default=None,
+                        help="Limit to first N rows (useful for quick tests)")
+    parser.add_argument("--batch_size", type=int, default=10_000,
+                        help="UMAP projection batch size (default: 10000)")
+    parser.add_argument("--device", default="cpu", help="Device for model inference (default: cpu)")
+    args = parser.parse_args()
+
+    from latentscope.util import get_data_dir
+    DATA_DIR = get_data_dir()
+    dataset_path = os.path.join(DATA_DIR, args.dataset_id)
+
+    # --- Load mean embeddings and UMAP model ---
+    mean_embeddings = load_mean_embeddings(dataset_path, args.embedding_id)
+    if args.max_rows:
+        mean_embeddings = mean_embeddings[:args.max_rows]
+        print(f"Limited to {args.max_rows} rows")
+    N, D = mean_embeddings.shape
+
+    umap_model = load_umap_model(dataset_path, args.umap_id)
+    existing_coords = load_existing_umap_coords(dataset_path, args.umap_id)
+    if args.max_rows:
+        existing_coords = existing_coords[:args.max_rows]
+
+    # --- Project mean embeddings (sanity check) ---
+    print("Projecting mean embeddings (sanity check)...")
+    projected_mean = umap_model.transform(mean_embeddings)  # (N, 2)
+
+    # Normalize to [-1, 1] using the saved coord range as reference
+    projected_mean_norm = normalize_coords(projected_mean, existing_coords)
+
+    # --- Get token vectors ---
+    if args.simulate or args.model is None:
+        print(f"\nSimulation mode: {args.n_tokens} tokens/doc, noise_scale={args.noise_scale}")
+        token_vecs = simulate_token_vectors(
+            mean_embeddings, args.n_tokens, args.noise_scale
+        )  # (N, T, D)
+        T = args.n_tokens
+
+        # Project all tokens
+        print(f"Projecting {N * T} token vectors in batches of {args.batch_size}...")
+        flat_tokens = token_vecs.reshape(-1, D)
+        flat_coords = project_tokens_batched(umap_model, flat_tokens, args.batch_size)
+        flat_coords_norm = normalize_coords(flat_coords, existing_coords)
+        token_coords = flat_coords_norm.reshape(N, T, 2)
+
+    else:
+        print(f"\nReal model mode: {args.model}")
+        import pandas as pd
+        input_df = pd.read_parquet(os.path.join(dataset_path, "input.parquet"))
+        # Detect text column from embedding metadata
+        import json
+        with open(os.path.join(dataset_path, "embeddings", f"{args.embedding_id}.json")) as f:
+            emb_meta = json.load(f)
+        text_col = emb_meta.get("text_column", "text")
+        texts = input_df[text_col].tolist()
+        if args.max_rows:
+            texts = texts[:args.max_rows]
+
+        print(f"Encoding {len(texts)} texts with {args.model}...")
+        token_vecs_ragged = embed_tokens_with_model(texts, args.model, args.device)
+        # token_vecs_ragged: list of (T_i, D) arrays — variable length per doc
+
+        # Project each doc's tokens; store as ragged then flatten
+        print(f"Projecting token vectors...")
+        all_row_ids, all_token_idxs, all_xs, all_ys, all_mean_xs, all_mean_ys, all_spreads = \
+            [], [], [], [], [], [], []
+
+        for i, (doc_tokens, m_coord) in enumerate(zip(token_vecs_ragged, projected_mean_norm)):
+            doc_tokens = np.array(doc_tokens, dtype=np.float32)
+            doc_coords = umap_model.transform(doc_tokens)  # (T_i, 2)
+            doc_coords_norm = normalize_coords(doc_coords, existing_coords)
+            T_i = len(doc_coords_norm)
+            spread_i = np.linalg.norm(doc_coords_norm - m_coord[None, :], axis=1)
+            all_row_ids.extend([i] * T_i)
+            all_token_idxs.extend(range(T_i))
+            all_xs.extend(doc_coords_norm[:, 0].tolist())
+            all_ys.extend(doc_coords_norm[:, 1].tolist())
+            all_mean_xs.extend([m_coord[0]] * T_i)
+            all_mean_ys.extend([m_coord[1]] * T_i)
+            all_spreads.extend(spread_i.tolist())
+            if (i + 1) % 100 == 0:
+                print(f"  {i+1}/{N}", end="\r", flush=True)
+        print()
+
+        import pandas as pd
+        results_df = pd.DataFrame({
+            "row_id": all_row_ids,
+            "token_idx": all_token_idxs,
+            "x": np.array(all_xs, dtype=np.float32),
+            "y": np.array(all_ys, dtype=np.float32),
+            "mean_x": np.array(all_mean_xs, dtype=np.float32),
+            "mean_y": np.array(all_mean_ys, dtype=np.float32),
+            "spread": np.array(all_spreads, dtype=np.float32),
+        })
+        # Write results and exit early (ragged path)
+        out_dir = os.path.join(dataset_path, "experiments")
+        os.makedirs(out_dir, exist_ok=True)
+        out_path = os.path.join(out_dir, f"token_projection_{args.embedding_id}_{args.umap_id}.parquet")
+        results_df.to_parquet(out_path, index=False)
+        spread_arr = np.array(all_spreads)
+        print_summary(spread_arr.reshape(-1, 1), existing_coords, projected_mean_norm)
+        print(f"\nResults written to: {out_path}")
+        return
+
+    # --- Fixed-T path (simulation) ---
+    spread = compute_spread(token_coords, projected_mean_norm)  # (N, T)
+    results_df = build_results_dataframe(token_coords, projected_mean_norm, spread)
+
+    # --- Write output ---
+    out_dir = os.path.join(dataset_path, "experiments")
+    os.makedirs(out_dir, exist_ok=True)
+    out_path = os.path.join(
+        out_dir,
+        f"token_projection_{args.embedding_id}_{args.umap_id}.parquet"
+    )
+    results_df.to_parquet(out_path, index=False)
+
+    print_summary(spread, existing_coords, projected_mean_norm)
+    print(f"\nResults written to: {out_path}")
+    print(f"Columns: {list(results_df.columns)}")
+    print(f"Rows: {len(results_df):,} ({N} docs × {T} tokens)")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -171,4 +171,4 @@ Werkzeug~=3.0.1
 widgetsnbextension~=4.0.9
 yarl~=1.9.4
 zipp~=3.17.0
-lancedb~=0.19.0
+lancedb~=0.30.0


### PR DESCRIPTION
- Bump lancedb 0.19.0 → 0.30.0 (adds native multi-vector/MaxSim support)
- Add docs/late-interaction-plan.md: full implementation plan covering
  detection, storage schema, pipeline changes, frontend, and tests
- Add experiments/umap_token_projection.py: standalone script to test
  whether token/patch vectors can be projected through a UMAP model
  trained on mean-pooled vectors (simulation + real ColBERT model modes)

https://claude.ai/code/session_01HSf1U3KSRn1V5P7C3JuagK