### PR TITLE
Replace HDF5 embeddings with LanceDB storage and add late interaction support

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -1,0 +1,61 @@
+# Data Format Migrations
+
+This file documents breaking changes to data formats and how to migrate between versions. It is intended for both human operators and AI agents managing latent-scope datasets.
+
+---
+
+## Version History
+
+### v1.1 — LanceDB Embedding Storage (April 2026)
+
+**Change:** Embedding vectors are now stored in LanceDB tables (Lance format v2.2) instead of HDF5 files. This provides ~50% storage reduction via automatic BSS + LZ4 compression, native vector search, and support for late interaction models (ColBERT/ColPali per-token vectors).
+
+**Old format:**
+```
+{dataset}/embeddings/embedding-001.h5      # HDF5 with "embeddings" dataset
+{dataset}/embeddings/embedding-001.json    # metadata
+```
+
+**New format:**
+```
+{dataset}/lancedb/emb-embedding-001/       # LanceDB table directory
+{dataset}/embeddings/embedding-001.json    # metadata (unchanged)
+```
+
+**Backward compatibility:**
+- All `load_embeddings()` calls automatically fall back to HDF5 if no LanceDB table exists
+- Existing scopes, UMAPs, and clusters continue to work without migration
+- New embeddings are always written to LanceDB
+
+**When to migrate:**
+- Migration is optional for existing datasets
+- Recommended for storage savings and to enable late interaction search
+- Required if you want to use ColBERT/ColPali models on existing datasets
+
+**How to migrate:**
+- **UI:** On the Embedding setup step, embeddings stored in HDF5 show an "HDF5" badge. Click "Migrate to LanceDB" to convert.
+- **API:** `POST /datasets/{dataset}/embeddings/{embedding}/migrate`
+- **Python:**
+  ```python
+  from latentscope.util.embedding_store import migrate_hdf5_to_lancedb
+  result = migrate_hdf5_to_lancedb(data_dir, dataset_id, embedding_id)
+  ```
+- **CLI resume:** If you resume an interrupted HDF5 embedding via `ls-embed --rerun`, it automatically migrates the existing HDF5 data to LanceDB before continuing.
+
+**After migration:**
+- The HDF5 file is NOT deleted (safe to remove manually after verifying)
+- All downstream pipeline steps (UMAP, cluster, scope) work identically
+- Search uses LanceDB's native ANN index for faster queries
+
+**Agent instructions:**
+To check if a dataset needs migration, call `GET /datasets/{dataset}/embeddings/{embedding}/format`. The response includes `{"format": "hdf5"|"lancedb"|"none"}`. If `"hdf5"`, call `POST .../migrate` to convert. The metadata JSON file does not change — only the vector storage location moves.
+
+---
+
+### v1.0 — Initial Format
+
+**Embedding storage:** HDF5 files with a single `"embeddings"` dataset of shape `(N, D)` as float32.
+
+**Cluster storage:** Parquet files with `cluster` and `raw_cluster` columns. Labels in separate parquet with `label`, `description`, `indices`, `hull` columns. EVoC clusters store empty hull arrays `[]` since convex hulls are not meaningful for embedding-space clusters.
+
+**Scope storage:** JSON metadata + Parquet with all columns joined. LanceDB used for scope-level vector search (separate from embedding storage).

--- a/latentscope/models/__init__.py
+++ b/latentscope/models/__init__.py
@@ -1,11 +1,13 @@
 import json
-from .providers.transformers import TransformersEmbedProvider, TransformersChatProvider
-from .providers.openai import OpenAIEmbedProvider, OpenAIChatProvider
-from .providers.mistralai import MistralAIEmbedProvider, MistralAIChatProvider
+
 from .providers.cohereai import CohereAIEmbedProvider
-from .providers.togetherai import TogetherAIEmbedProvider
-from .providers.voyageai import VoyageAIEmbedProvider
+from .providers.late_interaction import ColBERTEmbedProvider, ColPaliEmbedProvider
+from .providers.mistralai import MistralAIChatProvider, MistralAIEmbedProvider
 from .providers.nltk import NLTKChatProvider
+from .providers.openai import OpenAIChatProvider, OpenAIEmbedProvider
+from .providers.togetherai import TogetherAIEmbedProvider
+from .providers.transformers import TransformersChatProvider, TransformersEmbedProvider
+from .providers.voyageai import VoyageAIEmbedProvider
 
 # Universal model ID scheme:
 #   <provider>-<model-name>  where "/" in the model name is replaced by "___"
@@ -36,7 +38,7 @@ def get_embedding_model_list():
     """Return the list of available embedding models."""
     from importlib.resources import files
     embedding_path = files('latentscope.models').joinpath('embedding_models.json')
-    with open(embedding_path, "r") as f:
+    with open(embedding_path) as f:
         return json.load(f)
 
 
@@ -49,18 +51,32 @@ def get_embedding_model_dict(model_id):
     return model
 
 
+def _parse_colbert_model_id(model_id):
+    """Return the model name from a colbert model_id, or None if not colbert."""
+    if model_id.startswith("colbert-"):
+        # Strip the "colbert-" prefix and restore "/" from "___"
+        return model_id[len("colbert-"):].replace("___", "/")
+    return None
+
+
 def get_embedding_model(model_id):
     """Return a ModelProvider instance for the given embedding model id."""
+    # Check for ColBERT/late interaction models first
+    colbert_name = _parse_colbert_model_id(model_id)
+    if colbert_name:
+        return ColBERTEmbedProvider(colbert_name, {"late_interaction": True})
+
     hf_name = _parse_hf_model_id(model_id)
     if hf_name:
         model = {"provider": _HF_PROVIDER, "name": hf_name, "params": {}}
     elif model_id.startswith("custom_embedding-"):
         import os
+
         from latentscope.util import get_data_dir
         data_dir = get_data_dir()
         custom_models_path = os.path.join(data_dir, "custom_embedding_models.json")
         if os.path.exists(custom_models_path):
-            with open(custom_models_path, "r") as f:
+            with open(custom_models_path) as f:
                 custom_models = json.load(f)
             model = next((m for m in custom_models if m["id"] == model_id), None)
             if model is None:
@@ -92,6 +108,10 @@ def get_embedding_model(model_id):
         return VoyageAIEmbedProvider(model['name'], model['params'])
     if provider == "custom_embedding":
         return OpenAIEmbedProvider(model['name'], model['params'], base_url=model['url'])
+    if provider == "colbert":
+        return ColBERTEmbedProvider(model['name'], model['params'])
+    if provider == "colpali":
+        return ColPaliEmbedProvider(model['name'], model['params'])
     raise ValueError(f"Unknown embedding provider '{provider}' for model '{model_id}'")
 
 
@@ -99,7 +119,7 @@ def get_chat_model_list():
     """Return the list of available chat models."""
     from importlib.resources import files
     chat_path = files('latentscope.models').joinpath('chat_models.json')
-    with open(chat_path, "r") as f:
+    with open(chat_path) as f:
         return json.load(f)
 
 
@@ -119,11 +139,12 @@ def get_chat_model(model_id):
         model = {"provider": _HF_PROVIDER, "name": hf_name, "params": {}}
     elif model_id.startswith("custom-"):
         import os
+
         from latentscope.util import get_data_dir
         data_dir = get_data_dir()
         custom_models_path = os.path.join(data_dir, "custom_models.json")
         if os.path.exists(custom_models_path):
-            with open(custom_models_path, "r") as f:
+            with open(custom_models_path) as f:
                 custom_models = json.load(f)
             model = next((m for m in custom_models if m["id"] == model_id), None)
             if model is None:

--- a/latentscope/models/embedding_models.json
+++ b/latentscope/models/embedding_models.json
@@ -56,5 +56,35 @@
       "truncation": true,
       "max_tokens": 32000
     }
+  },
+  {
+    "provider": "colbert",
+    "name": "colbert-ir/colbertv2.0",
+    "id": "colbert-colbert-ir___colbertv2.0",
+    "group": "late_interaction",
+    "params": {
+      "late_interaction": true,
+      "max_tokens": 512
+    }
+  },
+  {
+    "provider": "colbert",
+    "name": "answerdotai/answerai-colbert-small-v1",
+    "id": "colbert-answerdotai___answerai-colbert-small-v1",
+    "group": "late_interaction",
+    "params": {
+      "late_interaction": true,
+      "max_tokens": 512
+    }
+  },
+  {
+    "provider": "colbert",
+    "name": "jinaai/jina-colbert-v2",
+    "id": "colbert-jinaai___jina-colbert-v2",
+    "group": "late_interaction",
+    "params": {
+      "late_interaction": true,
+      "max_tokens": 8192
+    }
   }
 ]

--- a/latentscope/models/providers/late_interaction.py
+++ b/latentscope/models/providers/late_interaction.py
@@ -1,0 +1,186 @@
+"""
+Late interaction embedding providers (ColBERT, ColPali-style models).
+
+These models produce per-token embeddings instead of a single vector per document.
+We store both the mean vector (for UMAP/clustering) and the per-token vectors
+(for MaxSim late interaction search).
+"""
+
+from .base import EmbedModelProvider
+
+
+class ColBERTEmbedProvider(EmbedModelProvider):
+    """Provider for ColBERT-style models via sentence-transformers.
+
+    Compatible with models like:
+    - colbert-ir/colbertv2.0
+    - answerdotai/answerai-colbert-small-v1
+    - jinaai/jina-colbert-v2
+
+    These models use the ColBERT architecture which produces per-token embeddings.
+    """
+
+    def __init__(self, name, params):
+        super().__init__(name, params)
+        self.late_interaction = True
+        import torch
+        self.torch = torch
+        self.device = torch.device(
+            "cuda" if torch.cuda.is_available()
+            else "mps" if torch.backends.mps.is_available()
+            else "cpu"
+        )
+
+    def load_model(self):
+        from sentence_transformers import SentenceTransformer
+        self.model = SentenceTransformer(self.name, trust_remote_code=True, device=self.device)
+        self.tokenizer = self.model.tokenizer
+
+    def embed(self, inputs, dimensions=None):
+        """Return mean embeddings as a list of lists (standard interface).
+
+        For the full token-level embeddings, use embed_multi().
+        """
+        mean_vectors, _ = self.embed_multi(inputs, dimensions=dimensions)
+        return mean_vectors.tolist()
+
+    def embed_multi(self, inputs, dimensions=None):
+        """Return both mean and per-token embeddings.
+
+        Returns
+        -------
+        mean_vectors : np.ndarray of shape (N, D)
+            Mean-pooled embeddings for each input.
+        token_vectors_list : list[np.ndarray]
+            Per-token embeddings for each input. Each element has shape (T_i, D)
+            where T_i is the number of tokens for that input.
+        """
+        import numpy as np
+
+        # Get the raw model output with all token embeddings
+        # sentence-transformers encode() returns pooled by default,
+        # so we need to use the underlying model for token-level output
+        features = self.tokenizer(
+            inputs,
+            padding=True,
+            truncation=True,
+            return_tensors="pt",
+            max_length=getattr(self.model, "max_seq_length", 512),
+        ).to(self.device)
+
+        with self.torch.no_grad():
+            model_output = self.model.forward(features)
+
+        # model_output typically has 'token_embeddings' and 'sentence_embedding'
+        if hasattr(model_output, "token_embeddings"):
+            all_token_embs = model_output.token_embeddings
+        elif isinstance(model_output, dict) and "token_embeddings" in model_output:
+            all_token_embs = model_output["token_embeddings"]
+        else:
+            # Fallback: use the last hidden state directly
+            all_token_embs = model_output.get(
+                "last_hidden_state", model_output[0]
+            )
+
+        attention_mask = features["attention_mask"]
+
+        # Truncate dimensions if requested (Matryoshka-style)
+        if dimensions is not None and dimensions > 0:
+            all_token_embs = all_token_embs[:, :, :dimensions]
+
+        # Normalize token embeddings
+        all_token_embs = self.torch.nn.functional.normalize(all_token_embs, p=2, dim=-1)
+
+        token_vectors_list = []
+        mean_vectors_list = []
+
+        for i in range(len(inputs)):
+            mask = attention_mask[i].bool()
+            # Skip special tokens (CLS, SEP, PAD) - keep only real tokens
+            # For most models, position 0 is CLS. We keep it for ColBERT compatibility.
+            token_embs = all_token_embs[i][mask].cpu().numpy()
+            token_vectors_list.append(token_embs)
+
+            # Mean pool for the dense vector
+            mean_vec = token_embs.mean(axis=0)
+            mean_vec = mean_vec / (np.linalg.norm(mean_vec) + 1e-10)
+            mean_vectors_list.append(mean_vec)
+
+        mean_vectors = np.array(mean_vectors_list, dtype=np.float32)
+        return mean_vectors, token_vectors_list
+
+
+class ColPaliEmbedProvider(EmbedModelProvider):
+    """Provider for ColPali-style vision-language late interaction models.
+
+    Compatible with models like:
+    - vidore/colpali-v1.2
+    - vidore/colqwen2-v1.0
+
+    These models embed both text queries and document images, producing
+    per-patch/per-token embeddings for late interaction retrieval.
+    """
+
+    def __init__(self, name, params):
+        super().__init__(name, params)
+        self.late_interaction = True
+        import torch
+        self.torch = torch
+        self.device = torch.device(
+            "cuda" if torch.cuda.is_available()
+            else "cpu"  # ColPali typically needs CUDA
+        )
+
+    def load_model(self):
+        from transformers import AutoModel, AutoProcessor
+        self.processor = AutoProcessor.from_pretrained(self.name, trust_remote_code=True)
+        self.model = AutoModel.from_pretrained(
+            self.name, trust_remote_code=True,
+            torch_dtype=self.torch.bfloat16,
+        ).to(self.device).eval()
+
+    def embed(self, inputs, dimensions=None):
+        """Return mean embeddings for text inputs."""
+        mean_vectors, _ = self.embed_multi(inputs, dimensions=dimensions)
+        return mean_vectors.tolist()
+
+    def embed_multi(self, inputs, dimensions=None):
+        """Return both mean and per-token embeddings for text inputs."""
+        import numpy as np
+
+        # Process as text queries
+        with self.torch.no_grad():
+            batch = self.processor(
+                text=inputs,
+                return_tensors="pt",
+                padding=True,
+                truncation=True,
+            ).to(self.device)
+            outputs = self.model(**batch)
+
+        # Get token embeddings from the last hidden state
+        token_embs = outputs.last_hidden_state.float()
+
+        if dimensions is not None and dimensions > 0:
+            token_embs = token_embs[:, :, :dimensions]
+
+        token_embs = self.torch.nn.functional.normalize(token_embs, p=2, dim=-1)
+
+        attention_mask = batch.get("attention_mask")
+        token_vectors_list = []
+        mean_vectors_list = []
+
+        for i in range(len(inputs)):
+            if attention_mask is not None:
+                mask = attention_mask[i].bool()
+                embs = token_embs[i][mask].cpu().numpy()
+            else:
+                embs = token_embs[i].cpu().numpy()
+
+            token_vectors_list.append(embs)
+            mean_vec = embs.mean(axis=0)
+            mean_vec = mean_vec / (np.linalg.norm(mean_vec) + 1e-10)
+            mean_vectors_list.append(mean_vec)
+
+        mean_vectors = np.array(mean_vectors_list, dtype=np.float32)
+        return mean_vectors, token_vectors_list

--- a/latentscope/scripts/embed.py
+++ b/latentscope/scripts/embed.py
@@ -1,10 +1,10 @@
 # Usage: ls-embed <dataset_id> <text_column> <model_id>
+import argparse
+import json
 import os
 import re
 import sys
-import json
 import time
-import argparse
 from datetime import datetime
 
 try:
@@ -13,18 +13,20 @@ try:
         from tqdm.notebook import tqdm
     else:
         from tqdm import tqdm
-except ImportError as e:
+except ImportError:
     # Fallback to the standard console version if import fails
     from tqdm import tqdm
 
-from latentscope.models import get_embedding_model, TransformersEmbedProvider
+from latentscope.models import TransformersEmbedProvider, get_embedding_model
 from latentscope.util import get_data_dir
+
 
 def chunked_iterable(iterable, size):
     """Yield successive chunks from an iterable."""
     for i in range(0, len(iterable), size):
         yield iterable[i:i + size]
 
+# Legacy HDF5 functions kept for backward compatibility
 def append_to_hdf5(file_path, new_data):
     import h5py
     dataset_name = "embeddings"
@@ -63,29 +65,40 @@ def main():
     embed(args.dataset_id, args.text_column, args.model_id, args.prefix, args.rerun, args.dimensions, args.batch_size, args.max_seq_length)
 
 def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_size=100, max_seq_length=None):
-    import pandas as pd
     import numpy as np
+    import pandas as pd
+
+    from latentscope.util.embedding_store import append_embeddings, get_embedding_count
     DATA_DIR = get_data_dir()
     df = pd.read_parquet(os.path.join(DATA_DIR, dataset_id, "input.parquet"))
-    
+
     embedding_dir = os.path.join(DATA_DIR, dataset_id, "embeddings")
     if not os.path.exists(embedding_dir):
         os.makedirs(embedding_dir)
     # determine the embedding id
     if rerun is not None:
         embedding_id = rerun
-        starting_batch = get_last_batch(os.path.join(embedding_dir, f"{embedding_id}.h5")) // batch_size
+        # Check LanceDB first, then fallback to HDF5
+        starting_batch = get_embedding_count(DATA_DIR, dataset_id, embedding_id) // batch_size
+        if starting_batch == 0:
+            # Fallback: check legacy HDF5
+            starting_batch = get_last_batch(os.path.join(embedding_dir, f"{embedding_id}.h5")) // batch_size
     else:
-        # determine the index of the last umap run by looking in the dataset directory
-        # for files named umap-<number>.json
+        # determine the index of the last embedding run
+        # Check both HDF5 files and LanceDB tables
         embedding_files = [f for f in os.listdir(embedding_dir) if re.match(r"embedding-\d+\.h5", f)]
-        if len(embedding_files) > 0:
-            last_umap = sorted(embedding_files)[-1]
-            last_embedding_number = int(last_umap.split("-")[1].split(".")[0])
-            next_embedding_number = last_embedding_number + 1
+        embedding_jsons = [f for f in os.listdir(embedding_dir) if re.match(r"embedding-\d+\.json", f)]
+        all_files = embedding_files + embedding_jsons
+        if len(all_files) > 0:
+            numbers = []
+            for f in all_files:
+                match = re.search(r"embedding-(\d+)", f)
+                if match:
+                    numbers.append(int(match.group(1)))
+            next_embedding_number = max(numbers) + 1 if numbers else 1
         else:
             next_embedding_number = 1
-        # make the umap name from the number, zero padded to 3 digits
+        # make the embedding name from the number, zero padded to 3 digits
         embedding_id = f"embedding-{next_embedding_number:03d}"
         starting_batch = 0
 
@@ -96,15 +109,17 @@ def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_si
     print("loading", model.name)
     model.load_model()
 
+    # Check if this is a late interaction model
+    is_late_interaction = getattr(model, 'late_interaction', False)
+    if is_late_interaction:
+        print("Late interaction model detected - will store per-token vectors")
+
     if max_seq_length is not None and isinstance(model, TransformersEmbedProvider):
         # Check if max_seq_length is a setter property
         try:
             model.model.max_seq_length = max_seq_length
         except AttributeError:
             print("Warning: This model does not support setting max_seq_length. Continuing with default length.")
-        # else:
-        #     print("Warning: max_seq_length is not a settable property, setting may not work")
-        #     model.model.max_seq_length = max_seq_length
 
     print("Checking for empty inputs")
     sentences = df[text_column].tolist()
@@ -116,7 +131,7 @@ def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_si
             print(i,s, "text is empty, adding a [space]")
             s = " "
         prefixed.append(prefix + s)
-    sentences = prefixed #[prefix + s for s in sentences]
+    sentences = prefixed
 
     total_batches = len(sentences)//batch_size
 
@@ -129,8 +144,20 @@ def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_si
             print(f"skipping batch {i}/{total_batches}", flush=True)
             continue
         try:
-            embeddings = np.array(model.embed(batch, dimensions=dimensions))
-            append_to_hdf5(os.path.join(embedding_dir, f"{embedding_id}.h5"), embeddings)
+            start_index = i * batch_size
+            if is_late_interaction:
+                mean_vectors, token_vectors_list = model.embed_multi(batch, dimensions=dimensions)
+                append_embeddings(
+                    DATA_DIR, dataset_id, embedding_id,
+                    mean_vectors, start_index=start_index,
+                    token_vectors_list=token_vectors_list,
+                )
+            else:
+                embeddings = np.array(model.embed(batch, dimensions=dimensions))
+                append_embeddings(
+                    DATA_DIR, dataset_id, embedding_id,
+                    embeddings, start_index=start_index,
+                )
         except Exception as e:
             print(batch)
             print("error embedding batch", i, e)
@@ -155,87 +182,80 @@ def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_si
         with open(history_file_path, 'w') as history_file:
             history_file.write(f"{datetime.now().isoformat()},{model_id}\n")
 
+    # Get stats from the stored embeddings
+    from latentscope.util.embedding_store import get_embedding_stats
+    stats = get_embedding_stats(DATA_DIR, dataset_id, embedding_id)
 
-    # Calculate min and max values for each index
-    min_values = np.min(embeddings, axis=0)
-    max_values = np.max(embeddings, axis=0)
+    meta = {
+        "id": embedding_id,
+        "model_id": model_id,
+        "dataset_id": dataset_id,
+        "text_column": text_column,
+        "dimensions": stats["dimensions"],
+        "max_seq_length": max_seq_length,
+        "prefix": prefix,
+        "late_interaction": is_late_interaction,
+        "min_values": stats["min_values"],
+        "max_values": stats["max_values"],
+    }
+
     with open(os.path.join(embedding_dir, f"{embedding_id}.json"), 'w') as f:
-        json.dump({
-            "id": embedding_id,
-            "model_id": model_id,
-            "dataset_id": dataset_id,
-            "text_column": text_column,
-            # "dimensions": np_embeds.shape[1],
-            "dimensions": embeddings.shape[1],
-            "max_seq_length": max_seq_length,
-            "prefix": prefix,
-            "min_values": min_values.tolist(),
-            "max_values": max_values.tolist(),
-            }, f, indent=2)
+        json.dump(meta, f, indent=2)
 
-
-    # np.save(os.path.join(embedding_dir, f"{embedding_id}.npy"), np_embeds)
     print("done with", embedding_id)
 
 def truncate():
     parser = argparse.ArgumentParser(description='Make a copy of an existing embedding truncated to a smaller number of dimensions')
     parser.add_argument('dataset_id', type=str, help='Dataset id (directory name in data/)')
-    parser.add_argument('embedding_id', type=str, help='ID of embedding to use') 
-    parser.add_argument('dimensions', type=int, help='Number of dimensions to truncate to') 
+    parser.add_argument('embedding_id', type=str, help='ID of embedding to use')
+    parser.add_argument('dimensions', type=int, help='Number of dimensions to truncate to')
     args = parser.parse_args()
     embed_truncate(args.dataset_id, args.embedding_id, args.dimensions)
 
 def embed_truncate(dataset_id, embedding_id, dimensions):
     import numpy as np
-    import h5py
+
+    from latentscope.util.embedding_store import append_embeddings
+    from latentscope.util.embedding_store import load_embeddings as lance_load
 
     DATA_DIR = get_data_dir()
     embedding_dir = os.path.join(DATA_DIR, dataset_id, "embeddings")
 
     embedding_meta_path = os.path.join(embedding_dir, f"{embedding_id}.json")
-    with open(embedding_meta_path, 'r') as f:
+    with open(embedding_meta_path) as f:
         embedding_meta = json.load(f)
-    # Load the embedding model
-    # model_id = embedding_meta["model_id"]
-    # model = get_embedding_model_dict(model_id)
-    # print("model params", model["params"])
-    # Check if the model has the attribute 'dimensions'
-    # try:
-    #     dims = model["params"]['dimensions']
-    # except KeyError:
-    #     raise KeyError(f"The model {model_id} does not have the 'dimensions' parameter meaning it cannot be truncated.")
 
-    # determine the index of the last umap run by looking in the dataset directory
-    # for files named umap-<number>.json
+    # Determine next embedding number
+    embedding_jsons = [f for f in os.listdir(embedding_dir) if re.match(r"embedding-\d+\.json", f)]
     embedding_files = [f for f in os.listdir(embedding_dir) if re.match(r"embedding-\d+\.h5", f)]
-    if len(embedding_files) > 0:
-        last_umap = sorted(embedding_files)[-1]
-        last_embedding_number = int(last_umap.split("-")[1].split(".")[0])
-        next_embedding_number = last_embedding_number + 1
+    all_files = embedding_jsons + embedding_files
+    if len(all_files) > 0:
+        numbers = []
+        for f in all_files:
+            match = re.search(r"embedding-(\d+)", f)
+            if match:
+                numbers.append(int(match.group(1)))
+        next_embedding_number = max(numbers) + 1 if numbers else 1
     else:
         next_embedding_number = 1
-    # make the umap name from the number, zero padded to 3 digits
     new_embedding_id = f"embedding-{next_embedding_number:03d}"
     print("RUNNING:", new_embedding_id)
 
-    # read in the embeddings from embedding_id
-    embedding_path = os.path.join(embedding_dir, f"{embedding_id}.h5")
-    with h5py.File(embedding_path, 'r') as f:
-        dataset = f["embeddings"]
-        embeddings = np.array(dataset)
-   
+    # Load embeddings (from LanceDB or HDF5)
+    embeddings = lance_load(DATA_DIR, dataset_id, embedding_id)
 
     print("truncating to", dimensions, "dimensions")
     matroyshka = embeddings[:, :dimensions]
     # Normalize the truncated embeddings
     matroyshka = matroyshka / np.linalg.norm(matroyshka, axis=1, keepdims=True)
-    append_to_hdf5(os.path.join(embedding_dir, f"{new_embedding_id}.h5"), matroyshka)
 
+    # Store in LanceDB
+    append_embeddings(DATA_DIR, dataset_id, new_embedding_id, matroyshka, start_index=0)
 
     # Calculate min and max values for each index
-    min_values = np.min(matroyshka, axis=0)
-    max_values = np.max(matroyshka, axis=0)
-    
+    np.min(matroyshka, axis=0)
+    np.max(matroyshka, axis=0)
+
     with open(os.path.join(embedding_dir, f"{new_embedding_id}.json"), 'w') as f:
         json.dump({
             "id": new_embedding_id,
@@ -245,34 +265,32 @@ def embed_truncate(dataset_id, embedding_id, dimensions):
             "max_seq_length": embedding_meta.get("max_seq_length"),
             "dimensions": matroyshka.shape[1],
             "prefix": embedding_meta["prefix"],
-            # "min_values": min_values.tolist(),
-            # "max_values": max_values.tolist(),
+            "late_interaction": False,
             }, f, indent=2)
 
-    print("wrote", os.path.join(embedding_dir, f"{new_embedding_id}.h5"))
+    print("wrote", new_embedding_id, "to LanceDB")
     print("done")
 
 
 def update_embedding_stats():
-    parser = argparse.ArgumentParser(description='Update embedding stats') 
+    parser = argparse.ArgumentParser(description='Update embedding stats')
     parser.add_argument('dataset_id', type=str, help='Dataset id (directory name in data/)')
-    parser.add_argument('embedding_id', type=str, help='ID of embedding to use') 
+    parser.add_argument('embedding_id', type=str, help='ID of embedding to use')
     args = parser.parse_args()
     embedding_stats(args.dataset_id, args.embedding_id)
 
 def embedding_stats(dataset_id, embedding_id):
     import os
-    import h5py
+
     import numpy as np
-    # from latentscope.utils import get_data_dir
+
+    from latentscope.util.embedding_store import load_embeddings as lance_load
 
     DATA_DIR = get_data_dir()
     embedding_dir = os.path.join(DATA_DIR, dataset_id, "embeddings")
-    embedding_path = os.path.join(embedding_dir, f"{embedding_id}.h5")
 
-    # Read the embeddings
-    with h5py.File(embedding_path, 'r') as f:
-        embeddings = np.array(f["embeddings"])
+    # Load embeddings from LanceDB or HDF5
+    embeddings = lance_load(DATA_DIR, dataset_id, embedding_id)
 
     # Calculate min and max values for each index
     min_values = np.min(embeddings, axis=0)
@@ -280,7 +298,7 @@ def embedding_stats(dataset_id, embedding_id):
 
     metadata_path = os.path.join(embedding_dir, f"{embedding_id}.json")
     # Read existing metadata
-    with open(metadata_path, 'r') as f:
+    with open(metadata_path) as f:
         metadata = json.load(f)
 
     # Add min and max values to metadata
@@ -314,16 +332,14 @@ def embed_debug(parquet_file, model_id, text_column):
         print("original index:", row[0])
         text = row[1][text_column]
         print("text:", text)
-        # print("tokens:", len(model.tokenizer.encode(text)))
-        # print("batch index:", i, "DataFrame index:", row[0], "Text:", row[1][text_column])
         embedding = model.embed([text])
         print("embedding", embedding)
-        
-def importer():
-    import pandas as pd
-    import numpy as np
 
-    parser = argparse.ArgumentParser(description='Import embeddings from an input dataset column to a standard HDF5 file')
+def importer():
+    import numpy as np
+    import pandas as pd
+
+    parser = argparse.ArgumentParser(description='Import embeddings from an input dataset column')
     parser.add_argument('dataset_id', type=str, help='Dataset id (directory name in data/)')
     parser.add_argument('embedding_column', type=str, help='Column to use as embedding input')
     parser.add_argument('model_id', type=str, help='ID of embedding to use')
@@ -333,35 +349,42 @@ def importer():
     DATA_DIR = get_data_dir()
     # read the input parquet
     df = pd.read_parquet(os.path.join(DATA_DIR, args.dataset_id, "input.parquet"))
-    # extract the column 
+    # extract the column
     embeddings = df[args.embedding_column].to_numpy()
     # Ensure embeddings is an ndarray with shape [N, M]
     if not isinstance(embeddings, np.ndarray):
         embeddings = np.array(list(embeddings))
     if embeddings.ndim == 1:
         embeddings = np.stack(embeddings)
-    
+
 
     import_embeddings(args.dataset_id, embeddings, args.model_id, args.text_column)
 
 def import_embeddings(dataset_id, embeddings, model_id="", text_column="", prefix=""):
     import numpy as np
+
+    from latentscope.util.embedding_store import append_embeddings
     DATA_DIR = get_data_dir()
     embedding_dir = os.path.join(DATA_DIR, dataset_id, "embeddings")
-    # determine the index of the last umap run by looking in the dataset directory
-    # for files named umap-<number>.json
+    os.makedirs(embedding_dir, exist_ok=True)
+
+    # Determine next embedding number
+    embedding_jsons = [f for f in os.listdir(embedding_dir) if re.match(r"embedding-\d+\.json", f)]
     embedding_files = [f for f in os.listdir(embedding_dir) if re.match(r"embedding-\d+\.h5", f)]
-    if len(embedding_files) > 0:
-        last_umap = sorted(embedding_files)[-1]
-        last_embedding_number = int(last_umap.split("-")[1].split(".")[0])
-        next_embedding_number = last_embedding_number + 1
+    all_files = embedding_jsons + embedding_files
+    if len(all_files) > 0:
+        numbers = []
+        for f in all_files:
+            match = re.search(r"embedding-(\d+)", f)
+            if match:
+                numbers.append(int(match.group(1)))
+        next_embedding_number = max(numbers) + 1 if numbers else 1
     else:
         next_embedding_number = 1
-    # make the umap name from the number, zero padded to 3 digits
     embedding_id = f"embedding-{next_embedding_number:03d}"
 
-    print("importing embeddings with shape", embeddings.shape, "to", os.path.join(embedding_dir, f"{embedding_id}.h5"))
-    append_to_hdf5(os.path.join(embedding_dir, f"{embedding_id}.h5"), embeddings)
+    print("importing embeddings with shape", embeddings.shape, "to LanceDB as", embedding_id)
+    append_embeddings(DATA_DIR, dataset_id, embedding_id, embeddings, start_index=0)
 
     # Calculate min and max values for each index
     min_values = np.min(embeddings, axis=0)
@@ -375,10 +398,11 @@ def import_embeddings(dataset_id, embeddings, model_id="", text_column="", prefi
             "dimensions": embeddings.shape[1],
             "text_column": text_column,
             "prefix": prefix,
+            "late_interaction": False,
             "min_values": min_values.tolist(),
             "max_values": max_values.tolist(),
         }, f, indent=2)
     print("done with", embedding_id)
 
 if __name__ == "__main__":
-   main() 
+   main()

--- a/latentscope/scripts/embed.py
+++ b/latentscope/scripts/embed.py
@@ -68,7 +68,9 @@ def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_si
     import numpy as np
     import pandas as pd
 
-    from latentscope.util.embedding_store import append_embeddings, get_embedding_count
+    from latentscope.util.embedding_store import (
+        append_embeddings, get_embedding_count, get_storage_format, migrate_hdf5_to_lancedb,
+    )
     DATA_DIR = get_data_dir()
     df = pd.read_parquet(os.path.join(DATA_DIR, dataset_id, "input.parquet"))
 
@@ -79,10 +81,18 @@ def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_si
     if rerun is not None:
         embedding_id = rerun
         # Check LanceDB first, then fallback to HDF5
-        starting_batch = get_embedding_count(DATA_DIR, dataset_id, embedding_id) // batch_size
-        if starting_batch == 0:
-            # Fallback: check legacy HDF5
-            starting_batch = get_last_batch(os.path.join(embedding_dir, f"{embedding_id}.h5")) // batch_size
+        fmt = get_storage_format(DATA_DIR, dataset_id, embedding_id)
+        if fmt == "lancedb":
+            starting_batch = get_embedding_count(DATA_DIR, dataset_id, embedding_id) // batch_size
+        elif fmt == "hdf5":
+            # Migrate HDF5 to LanceDB before resuming so new batches go to same store
+            print(f"Migrating {embedding_id} from HDF5 to LanceDB before resuming...")
+            result = migrate_hdf5_to_lancedb(DATA_DIR, dataset_id, embedding_id,
+                                             on_progress=lambda cur, tot: print(f"  migrated {cur}/{tot}"))
+            print(f"Migration complete: {result}")
+            starting_batch = get_embedding_count(DATA_DIR, dataset_id, embedding_id) // batch_size
+        else:
+            starting_batch = 0
     else:
         # determine the index of the last embedding run
         # Check both HDF5 files and LanceDB tables

--- a/latentscope/scripts/scope.py
+++ b/latentscope/scripts/scope.py
@@ -1,10 +1,11 @@
+import argparse
+import json
 import os
 import re
-import json
-import argparse
 from datetime import datetime
-from latentscope.util import get_data_dir
+
 from latentscope import __version__
+from latentscope.util import get_data_dir
 
 
 def main():
@@ -25,19 +26,21 @@ def main():
 
 
 def export_lance(directory, dataset, scope_id, metric="cosine", partitions=256):
-    import lancedb
-    import pandas as pd
     import h5py
+    import lancedb
     import numpy as np
+    import pandas as pd
+
+    from latentscope.util.embedding_store import load_embeddings as lance_load_embeddings
 
     dataset_path = os.path.join(directory, dataset)
     print(f"Exporting scope {scope_id} to LanceDB database in {dataset_path}")
-    
+
     # Validate directory
     if not os.path.isdir(directory):
         print(f"Error: {directory} is not a valid directory")
         return
-    
+
     # Load the scope
     scope_path = os.path.join(dataset_path, "scopes")
 
@@ -45,32 +48,35 @@ def export_lance(directory, dataset, scope_id, metric="cosine", partitions=256):
     scope_df = pd.read_parquet(os.path.join(scope_path, f"{scope_id}-input.parquet"))
     scope_meta = json.load(open(os.path.join(scope_path, f"{scope_id}.json")))
 
-    print(f"Loading embeddings from {dataset_path}/embeddings/{scope_meta['embedding_id']}.h5")
-    embeddings = h5py.File(os.path.join(dataset_path, "embeddings", f"{scope_meta['embedding_id']}.h5"), "r")
+    # Load embeddings from LanceDB store (with HDF5 fallback)
+    embedding_id = scope_meta['embedding_id']
+    print(f"Loading embeddings for {embedding_id}")
+    embeddings = lance_load_embeddings(directory, dataset, embedding_id)
 
     db_uri = os.path.join(dataset_path, "lancedb")
     db = lancedb.connect(db_uri)
 
-    print(f"Converting embeddings to numpy arrays", embeddings['embeddings'].shape)
-    scope_df["vector"] = [np.array(row) for row in embeddings['embeddings']]
+    print("Converting embeddings to numpy arrays", embeddings.shape)
+    scope_df["vector"] = [np.array(row) for row in embeddings]
 
     if "sae_id" in scope_meta and scope_meta["sae_id"]:
-        print(f"SAE scope detected, adding metadata")
+        print("SAE scope detected, adding metadata")
         # read in the sae indices
         sae_path = os.path.join(dataset_path, "saes", f"{scope_meta['sae_id']}.h5")
         with h5py.File(sae_path, 'r') as f:
             all_top_indices = np.array(f["top_indices"])
             all_top_acts = np.array(f["top_acts"])
 
-        # scope_df["sae_indices"] = all_top_indices
-        # scope_df["sae_acts"] = all_top_acts
         scope_df["sae_indices"] = [row.tolist() for row in all_top_indices]
         scope_df["sae_acts"] = [row.tolist() for row in all_top_acts]
 
     table_name = scope_id
 
     # Check if the table already exists
-    if scope_id in db.table_names():
+    table_names = db.list_tables()
+    if hasattr(table_names, 'tables'):
+        table_names = table_names.tables
+    if scope_id in table_names:
         # Remove the existing table and its index
         db.drop_table(table_name)
         print(f"Existing table '{table_name}' has been removed.")
@@ -79,10 +85,15 @@ def export_lance(directory, dataset, scope_id, metric="cosine", partitions=256):
     tbl = db.create_table(table_name, scope_df)
 
     print(f"Creating ANN index for embeddings on table '{table_name}'")
-    dim = embeddings['embeddings'].shape[1]
-    sub_vectors = dim // 16
-    print(f"Partitioning into {partitions} partitions, {sub_vectors} sub-vectors")
-    tbl.create_index(num_partitions=partitions, num_sub_vectors=sub_vectors, metric=metric)
+    dim = embeddings.shape[1]
+    num_rows = len(scope_df)
+    actual_partitions = min(partitions, max(1, num_rows // 10))
+    sub_vectors = max(1, dim // 16)
+    if num_rows >= 256:
+        print(f"Partitioning into {actual_partitions} partitions, {sub_vectors} sub-vectors")
+        tbl.create_index(num_partitions=actual_partitions, num_sub_vectors=sub_vectors, metric=metric)
+    else:
+        print(f"Dataset too small ({num_rows} rows) for IVF index, skipping ANN index")
 
     print(f"Creating index for cluster on table '{table_name}'")
     tbl.create_scalar_index("cluster", index_type="BTREE")
@@ -91,8 +102,7 @@ def export_lance(directory, dataset, scope_id, metric="cosine", partitions=256):
         print(f"Creating index for sae_indices on table '{table_name}'")
         tbl.create_scalar_index("sae_indices", index_type="LABEL_LIST")
 
-
-    print(f"Table '{table_name}' created successfully")  
+    print(f"Table '{table_name}' created successfully")
 
 def scope(dataset_id, embedding_id, umap_id, cluster_id, cluster_labels_id, label, description, scope_id=None, sae_id=None):
     DATA_DIR = get_data_dir()
@@ -158,12 +168,12 @@ def scope(dataset_id, embedding_id, umap_id, cluster_id, cluster_labels_id, labe
     with open(umap_file) as f:
         umap = json.load(f)
         scope["umap"] = umap
-    
+
     cluster_file = os.path.join(DATA_DIR, dataset_id, "clusters", cluster_id + ".json")
     with open(cluster_file) as f:
         cluster = json.load(f)
         scope["cluster"] = cluster
-    
+
     if cluster_labels_id == "default":
         cluster_labels_id = cluster_id + "-labels-default"
         scope["cluster_labels"] = {"id": cluster_labels_id, "cluster_id": cluster_id}
@@ -183,7 +193,7 @@ def scope(dataset_id, embedding_id, umap_id, cluster_id, cluster_labels_id, labe
     cluster_labels_df["hull"] = cluster_labels_df["hull"].apply(lambda x: x.tolist())
     cluster_labels_df["cluster"] = cluster_labels_df.index
     scope["cluster_labels_lookup"] = cluster_labels_df.to_dict(orient="records")
-    
+
     # create a scope parquet by combining the parquets from umap and cluster, as well as getting the labels from cluster_labels
     # then write the parquet to the scopes directory
     umap_df = pd.read_parquet(os.path.join(DATA_DIR, dataset_id, "umaps", umap_id + ".parquet"))
@@ -194,15 +204,15 @@ def scope(dataset_id, embedding_id, umap_id, cluster_id, cluster_labels_id, labe
     def make_tiles(x, y, num_tiles=64):
         import numpy as np
         tile_size = 2.0 / num_tiles  # Size of each tile (-1 to 1 = range of 2)
-        
+
         # Calculate row and column indices (0-63) for each point
         col_indices = np.floor((x + 1) / tile_size).astype(int)
         row_indices = np.floor((y + 1) / tile_size).astype(int)
-        
+
         # Clip indices to valid range in case of numerical edge cases
         col_indices = np.clip(col_indices, 0, num_tiles - 1)
         row_indices = np.clip(row_indices, 0, num_tiles - 1)
-        
+
         # Convert 2D grid indices to 1D tile index (row * num_cols + col)
         tile_indices = row_indices * num_tiles + col_indices
         return tile_indices
@@ -241,16 +251,16 @@ def scope(dataset_id, embedding_id, umap_id, cluster_id, cluster_labels_id, labe
     scope["columns"] = scope_parquet.columns.tolist()
     scope["size"] = os.path.getsize(os.path.join(directory, id + ".parquet"))
     scope["timestamp"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    
+
     file_path = os.path.join(directory, id + ".json")
     with open(file_path, 'w') as f:
         json.dump(scope, f, indent=2)
-    
+
     transactions_file_path = os.path.join(directory, id + "-transactions.json")
     if not os.path.exists(transactions_file_path):
         with open(transactions_file_path, 'w') as f:
             json.dump([], f)
-    
+
     print("creating combined scope-input parquet")
     input_df = pd.read_parquet(os.path.join(DATA_DIR, dataset_id, "input.parquet"))
     input_df.reset_index(inplace=True)

--- a/latentscope/scripts/umapper.py
+++ b/latentscope/scripts/umapper.py
@@ -48,6 +48,7 @@ def calculate_point_size(num_points, min_size=10, max_size=30, base_num_points=1
 def load_embeddings(dataset_id, embedding_id):
     import h5py
     import numpy as np
+    from latentscope.util.embedding_store import load_embeddings as lance_load_embeddings
     DATA_DIR = get_data_dir()
 
     if embedding_id[0:3] == "sae":
@@ -59,22 +60,16 @@ def load_embeddings(dataset_id, embedding_id):
         # read the meta json for sae
         with open(os.path.join(DATA_DIR, dataset_id, "saes", f"{embedding_id}.json"), 'r') as f:
             meta = json.load(f)
-        # print("SAE META", meta["id"], meta["num_features"], "features", meta["model_id"], meta["k_expansion"])
-        
+
         import scipy
-        # print("ALL ACTS SHAPE", all_acts.shape)
-        # print("ALL INDS SHAPE", all_indices.shape)
         matrix = scipy.sparse.lil_matrix((all_acts.shape[0], meta["num_features"]), dtype=np.float32)
         for i in range(all_acts.shape[0]):
             matrix.rows[i] = all_indices[i].tolist()
             matrix.data[i] = all_acts[i].tolist()
         return matrix
     else:
-        emb_path = os.path.join(DATA_DIR, dataset_id, "embeddings", f"{embedding_id}.h5")
-        with h5py.File(emb_path, 'r') as f:
-            dataset = f["embeddings"]
-            embeddings = np.array(dataset)
-            return embeddings
+        # Use LanceDB-backed store (with HDF5 fallback)
+        return lance_load_embeddings(DATA_DIR, dataset_id, embedding_id)
 
 def umapper(dataset_id, embedding_id, neighbors=25, min_dist=0.1, save=False, init=None, align=None, seed=None):
     DATA_DIR = get_data_dir()

--- a/latentscope/server/app.py
+++ b/latentscope/server/app.py
@@ -93,6 +93,9 @@ def create_app(data_dir=None, read_only=None):
     if not read_only:
         app.register_blueprint(models_write_bp, url_prefix='/api/models')
 
+    from .estimate import estimate_bp
+    app.register_blueprint(estimate_bp, url_prefix='/api/estimate')
+
     # ------------------------------------------------------------------
     # File / data routes defined directly on the app
     # ------------------------------------------------------------------
@@ -129,12 +132,12 @@ def create_app(data_dir=None, read_only=None):
         rows['index'] = valid_indices
 
         if embedding_id:
-            embedding_path = os.path.join(data_dir, dataset, "embeddings", f"{embedding_id}.h5")
-            with h5py.File(embedding_path, 'r') as f:
-                npvi = np.array(valid_indices)
-                sorted_indices = np.argsort(npvi)
-                sorted_embeddings = np.array(f["embeddings"][npvi[sorted_indices]])
-                filtered_embeddings = sorted_embeddings[np.argsort(sorted_indices)]
+            from latentscope.util.embedding_store import load_embeddings as lance_load
+            all_embeddings = lance_load(data_dir, dataset, embedding_id)
+            npvi = np.array(valid_indices)
+            sorted_indices = np.argsort(npvi)
+            sorted_embeddings = all_embeddings[npvi[sorted_indices]]
+            filtered_embeddings = sorted_embeddings[np.argsort(sorted_indices)]
             rows['ls_embedding'] = filtered_embeddings
 
         if sae_id:
@@ -216,12 +219,12 @@ def create_app(data_dir=None, read_only=None):
             rows = rows.loc[indices]
 
         if embedding_id:
-            embedding_path = os.path.join(data_dir, dataset, "embeddings", f"{embedding_id}.h5")
-            with h5py.File(embedding_path, 'r') as f:
-                npvi = np.array(rows.index)
-                sorted_indices = np.argsort(npvi)
-                sorted_embeddings = np.array(f["embeddings"][npvi[sorted_indices]])
-                filtered_embeddings = sorted_embeddings[np.argsort(sorted_indices)]
+            from latentscope.util.embedding_store import load_embeddings as lance_load
+            all_embeddings = lance_load(data_dir, dataset, embedding_id)
+            npvi = np.array(rows.index)
+            sorted_indices = np.argsort(npvi)
+            sorted_embeddings = all_embeddings[npvi[sorted_indices]]
+            filtered_embeddings = sorted_embeddings[np.argsort(sorted_indices)]
             rows['ls_embedding'] = filtered_embeddings.tolist()
 
         if sae_id:

--- a/latentscope/server/datasets.py
+++ b/latentscope/server/datasets.py
@@ -90,6 +90,25 @@ def get_dataset_embedding(dataset, embedding):
     return jsonify(json_contents)
 
 
+@datasets_bp.route('/<dataset>/embeddings/<embedding>/format', methods=['GET'])
+def get_embedding_format(dataset, embedding):
+    from latentscope.util.embedding_store import get_storage_format
+    fmt = get_storage_format(_data_dir(), dataset, embedding)
+    return jsonify({"format": fmt, "embedding_id": embedding})
+
+
+@datasets_bp.route('/<dataset>/embeddings/<embedding>/migrate', methods=['POST'])
+def migrate_embedding(dataset, embedding):
+    from latentscope.util.embedding_store import get_storage_format, migrate_hdf5_to_lancedb
+    fmt = get_storage_format(_data_dir(), dataset, embedding)
+    if fmt == "lancedb":
+        return jsonify({"status": "already_migrated", "format": "lancedb"})
+    if fmt == "none":
+        return jsonify({"error": "No embedding data found"}), 404
+    result = migrate_hdf5_to_lancedb(_data_dir(), dataset, embedding)
+    return jsonify(result)
+
+
 @datasets_bp.route('/<dataset>/saes', methods=['GET'])
 def get_dataset_saes(dataset):
     return scan_for_json_files(os.path.join(_data_dir(), dataset, "saes"))

--- a/latentscope/server/estimate.py
+++ b/latentscope/server/estimate.py
@@ -1,0 +1,301 @@
+"""
+API endpoints for estimating compute time and storage for pipeline steps.
+
+Provides both formula-based estimates and benchmark-based estimates that
+run a small sample through the actual pipeline step.
+"""
+
+import json
+import os
+import time
+
+from flask import Blueprint, current_app, jsonify, request
+
+estimate_bp = Blueprint('estimate_bp', __name__)
+
+
+def _data_dir():
+    return current_app.config['DATA_DIR']
+
+
+@estimate_bp.route('/embed', methods=['GET'])
+def estimate_embed():
+    """Estimate compute time and storage for embedding a dataset.
+
+    Query params:
+        dataset: dataset ID
+        model_id: embedding model ID
+        text_column: text column name
+        dimensions: optional dimension truncation
+    """
+    DATA_DIR = _data_dir()
+    dataset = request.args.get('dataset')
+    model_id = request.args.get('model_id')
+    text_column = request.args.get('text_column')
+    dimensions = request.args.get('dimensions')
+    dimensions = int(dimensions) if dimensions else None
+
+    if not dataset or not model_id:
+        return jsonify({"error": "Missing dataset or model_id"}), 400
+
+    import numpy as np
+    import pandas as pd
+
+    # Load dataset to get stats
+    df = pd.read_parquet(os.path.join(DATA_DIR, dataset, "input.parquet"))
+    num_rows = len(df)
+
+    # Get text stats
+    if text_column and text_column in df.columns:
+        texts = df[text_column].fillna("").astype(str)
+        avg_text_length = int(texts.str.len().mean())
+        max_text_length = int(texts.str.len().max())
+        avg_word_count = int(texts.str.split().str.len().mean())
+    else:
+        avg_text_length = 100
+        max_text_length = 1000
+        avg_word_count = 20
+
+    # Estimate dimensions from model
+    from latentscope.models import get_embedding_model_list
+    models = get_embedding_model_list()
+    model_info = next((m for m in models if m['id'] == model_id), None)
+
+    is_late_interaction = False
+    if model_info:
+        est_dimensions = dimensions or model_info.get('params', {}).get(
+            'dimensions', [768]
+        )
+        if isinstance(est_dimensions, list):
+            est_dimensions = est_dimensions[0]
+        is_late_interaction = model_info.get('params', {}).get('late_interaction', False)
+        group = model_info.get('group', model_info.get('provider', ''))
+    else:
+        est_dimensions = dimensions or 768
+        # Check if it's a colbert model by ID prefix
+        is_late_interaction = model_id.startswith('colbert-')
+        group = 'unknown'
+
+    # Estimate tokens per doc for late interaction
+    avg_tokens_per_doc = min(avg_word_count * 1.3, 512)  # rough token estimate
+
+    # Storage estimate
+    from latentscope.util.embedding_store import estimate_embedding_storage
+    storage = estimate_embedding_storage(
+        num_rows, est_dimensions,
+        has_tokens=is_late_interaction,
+        avg_tokens_per_doc=int(avg_tokens_per_doc),
+    )
+
+    # Time estimate (rough heuristics)
+    if group in ('openai', 'mistralai', 'cohereai', 'voyageai', 'togetherai'):
+        # API-based: ~500-2000 items/sec depending on provider
+        items_per_sec = 1000
+    elif is_late_interaction:
+        # Late interaction models are slower
+        items_per_sec = 50  # conservative GPU estimate
+    else:
+        # Local transformers model
+        items_per_sec = 200  # conservative GPU estimate
+
+    estimated_seconds = num_rows / items_per_sec
+
+    return jsonify({
+        "num_rows": num_rows,
+        "avg_text_length": avg_text_length,
+        "max_text_length": max_text_length,
+        "avg_word_count": avg_word_count,
+        "dimensions": est_dimensions,
+        "is_late_interaction": is_late_interaction,
+        "avg_tokens_per_doc": int(avg_tokens_per_doc),
+        "storage": storage,
+        "estimated_seconds": round(estimated_seconds, 1),
+        "estimated_time_human": _human_readable_time(estimated_seconds),
+        "note": "Rough estimate. Use 'Benchmark' for accurate timing.",
+    })
+
+
+@estimate_bp.route('/umap', methods=['GET'])
+def estimate_umap():
+    """Estimate compute time and storage for UMAP projection."""
+    DATA_DIR = _data_dir()
+    dataset = request.args.get('dataset')
+    embedding_id = request.args.get('embedding_id')
+    neighbors = request.args.get('neighbors', 25)
+    neighbors = int(neighbors)
+
+    if not dataset or not embedding_id:
+        return jsonify({"error": "Missing dataset or embedding_id"}), 400
+
+    # Get embedding dimensions and count
+    meta_path = os.path.join(DATA_DIR, dataset, "embeddings", f"{embedding_id}.json")
+    if not os.path.exists(meta_path):
+        return jsonify({"error": f"Embedding {embedding_id} not found"}), 404
+
+    with open(meta_path) as f:
+        meta = json.load(f)
+
+    dimensions = meta.get('dimensions', 768)
+
+    import pandas as pd
+    df = pd.read_parquet(os.path.join(DATA_DIR, dataset, "input.parquet"))
+    num_rows = len(df)
+
+    # UMAP output: 2 floats per row + parquet overhead
+    output_bytes = int(num_rows * 2 * 4 * 1.5)  # 2D coords, float32, 50% overhead
+
+    # UMAP time scales roughly as O(N * log(N) * D)
+    import math
+    base_time_per_1000 = 5.0  # seconds per 1000 rows at 768D
+    dim_factor = dimensions / 768
+    estimated_seconds = (num_rows / 1000) * base_time_per_1000 * dim_factor * (1 + math.log10(max(num_rows, 10)) / 4)
+
+    return jsonify({
+        "num_rows": num_rows,
+        "dimensions": dimensions,
+        "neighbors": neighbors,
+        "output_bytes": output_bytes,
+        "output_human": _human_readable_size(output_bytes),
+        "estimated_seconds": round(estimated_seconds, 1),
+        "estimated_time_human": _human_readable_time(estimated_seconds),
+        "note": "UMAP time varies significantly with data distribution.",
+    })
+
+
+@estimate_bp.route('/cluster', methods=['GET'])
+def estimate_cluster():
+    """Estimate compute time for clustering."""
+    DATA_DIR = _data_dir()
+    dataset = request.args.get('dataset')
+    umap_id = request.args.get('umap_id')
+
+    if not dataset or not umap_id:
+        return jsonify({"error": "Missing dataset or umap_id"}), 400
+
+    import pandas as pd
+    umap_path = os.path.join(DATA_DIR, dataset, "umaps", f"{umap_id}.parquet")
+    if not os.path.exists(umap_path):
+        return jsonify({"error": f"UMAP {umap_id} not found"}), 404
+
+    df = pd.read_parquet(umap_path)
+    num_rows = len(df)
+
+    # HDBSCAN on 2D data is fast - O(N log N)
+    import math
+    estimated_seconds = (num_rows / 10000) * 2 * (1 + math.log10(max(num_rows, 10)) / 5)
+
+    # Output: cluster labels parquet + PNG
+    output_bytes = int(num_rows * 4 * 2)  # cluster IDs + overhead
+
+    return jsonify({
+        "num_rows": num_rows,
+        "output_bytes": output_bytes,
+        "output_human": _human_readable_size(output_bytes),
+        "estimated_seconds": round(estimated_seconds, 1),
+        "estimated_time_human": _human_readable_time(estimated_seconds),
+    })
+
+
+@estimate_bp.route('/benchmark/embed', methods=['GET'])
+def benchmark_embed():
+    """Run embedding on a small sample to get accurate timing.
+
+    Query params:
+        dataset: dataset ID
+        model_id: embedding model ID
+        text_column: text column name
+        sample_size: number of items to benchmark (default 10)
+        dimensions: optional dimension truncation
+    """
+    DATA_DIR = _data_dir()
+    dataset = request.args.get('dataset')
+    model_id = request.args.get('model_id')
+    text_column = request.args.get('text_column')
+    sample_size = int(request.args.get('sample_size', 10))
+    dimensions = request.args.get('dimensions')
+    dimensions = int(dimensions) if dimensions else None
+
+    if not dataset or not model_id or not text_column:
+        return jsonify({"error": "Missing required parameters"}), 400
+
+    import numpy as np
+    import pandas as pd
+
+    from latentscope.models import get_embedding_model
+
+    df = pd.read_parquet(os.path.join(DATA_DIR, dataset, "input.parquet"))
+    num_rows = len(df)
+
+    # Sample texts
+    sample_size = min(sample_size, num_rows)
+    sample_df = df.sample(n=sample_size, random_state=42)
+    texts = sample_df[text_column].fillna(" ").astype(str).tolist()
+
+    # Load model
+    model = get_embedding_model(model_id)
+    model.load_model()
+
+    is_late_interaction = getattr(model, 'late_interaction', False)
+
+    # Warm up (1 item)
+    if is_late_interaction:
+        model.embed_multi([texts[0]], dimensions=dimensions)
+    else:
+        model.embed([texts[0]], dimensions=dimensions)
+
+    # Benchmark
+    start_time = time.time()
+    if is_late_interaction:
+        mean_vecs, token_vecs = model.embed_multi(texts, dimensions=dimensions)
+        sample_dim = mean_vecs.shape[1]
+        avg_tokens = int(np.mean([len(tv) for tv in token_vecs]))
+    else:
+        result = np.array(model.embed(texts, dimensions=dimensions))
+        sample_dim = result.shape[1]
+        avg_tokens = 0
+    elapsed = time.time() - start_time
+
+    time_per_item = elapsed / sample_size
+    total_estimated_seconds = time_per_item * num_rows
+
+    # Storage estimate based on actual dimensions
+    from latentscope.util.embedding_store import estimate_embedding_storage
+    storage = estimate_embedding_storage(
+        num_rows, sample_dim,
+        has_tokens=is_late_interaction,
+        avg_tokens_per_doc=avg_tokens,
+    )
+
+    return jsonify({
+        "sample_size": sample_size,
+        "num_rows": num_rows,
+        "time_per_item": round(time_per_item, 4),
+        "sample_total_time": round(elapsed, 2),
+        "estimated_total_seconds": round(total_estimated_seconds, 1),
+        "estimated_total_time_human": _human_readable_time(total_estimated_seconds),
+        "dimensions": sample_dim,
+        "is_late_interaction": is_late_interaction,
+        "avg_tokens_per_doc": avg_tokens,
+        "storage": storage,
+    })
+
+
+def _human_readable_time(seconds):
+    """Convert seconds to human-readable string."""
+    if seconds < 60:
+        return f"{seconds:.0f} seconds"
+    elif seconds < 3600:
+        minutes = seconds / 60
+        return f"{minutes:.1f} minutes"
+    else:
+        hours = seconds / 3600
+        return f"{hours:.1f} hours"
+
+
+def _human_readable_size(size_bytes):
+    """Convert bytes to human-readable string."""
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if size_bytes < 1024:
+            return f"{size_bytes:.1f} {unit}"
+        size_bytes /= 1024
+    return f"{size_bytes:.1f} PB"

--- a/latentscope/server/search.py
+++ b/latentscope/server/search.py
@@ -1,5 +1,6 @@
-import os
 import json
+import os
+
 from flask import Blueprint, current_app, jsonify, request
 
 from latentscope.models import get_embedding_model
@@ -22,9 +23,7 @@ DATAFRAMES = {}
 
 @search_bp.route('/nn', methods=['GET'])
 def nn():
-    import h5py
     import numpy as np
-    from sklearn.neighbors import NearestNeighbors
 
     DATA_DIR = _data_dir()
     dataset = request.args.get('dataset')
@@ -33,29 +32,62 @@ def nn():
     dimensions = request.args.get('dimensions')
     dimensions = int(dimensions) if dimensions else None
     query = request.args.get('query')
+    use_late_interaction = request.args.get('late_interaction', 'false').lower() == 'true'
 
-    if embedding_id not in EMBEDDINGS:
-        with open(os.path.join(DATA_DIR, dataset, "embeddings", embedding_id + ".json"), 'r') as f:
+    cache_key = dataset + "-" + embedding_id
+    if cache_key not in EMBEDDINGS:
+        with open(os.path.join(DATA_DIR, dataset, "embeddings", embedding_id + ".json")) as f:
             metadata = json.load(f)
         model_id = metadata.get('model_id')
         model = get_embedding_model(model_id)
         model.load_model()
-        EMBEDDINGS[dataset + "-" + embedding_id] = model
+        EMBEDDINGS[cache_key] = model
     else:
-        model = EMBEDDINGS[dataset + "-" + embedding_id]
+        model = EMBEDDINGS[cache_key]
 
-    # If lancedb is available, use it for search
+    # Check if late interaction search is requested and supported
+    is_late_interaction = getattr(model, 'late_interaction', False)
+    embedding_meta_path = os.path.join(DATA_DIR, dataset, "embeddings", embedding_id + ".json")
+    with open(embedding_meta_path) as f:
+        emb_meta = json.load(f)
+    has_token_vecs = emb_meta.get('late_interaction', False)
+
+    if use_late_interaction and is_late_interaction and has_token_vecs:
+        return nn_late_interaction(DATA_DIR, dataset, embedding_id, model, query, dimensions)
+
+    # If lancedb is available, use it for search (scope-level table)
     if scope_id is not None:
         lance_path = os.path.join(DATA_DIR, dataset, "lancedb", scope_id + ".lance")
         if os.path.exists(lance_path):
             return nn_lance(DATA_DIR, dataset, scope_id, model, query, dimensions)
 
-    # Otherwise use sklearn NearestNeighbors
+    # Try embedding-level LanceDB table first
+    from latentscope.util.embedding_store import get_embedding_count, search_nn
+    try:
+        count = get_embedding_count(DATA_DIR, dataset, embedding_id)
+        if count > 0:
+            embedding = np.array(model.embed([query], dimensions=dimensions))
+            query_vec = embedding[0] if embedding.ndim > 1 else embedding
+            indices, distances = search_nn(
+                DATA_DIR, dataset, embedding_id, query_vec, limit=150
+            )
+            return jsonify(
+                indices=indices,
+                distances=distances,
+                search_embedding=embedding.tolist(),
+            )
+    except Exception:
+        pass  # Fall through to sklearn
+
+    # Fallback: sklearn NearestNeighbors with HDF5 or LanceDB-loaded embeddings
+    import h5py
+    from sklearn.neighbors import NearestNeighbors
+
+    from latentscope.util.embedding_store import load_embeddings as lance_load
+
     num = 150
     if dataset not in DATASETS or embedding_id not in DATASETS[dataset]:
-        embedding_path = os.path.join(DATA_DIR, dataset, "embeddings", f"{embedding_id}.h5")
-        with h5py.File(embedding_path, 'r') as f:
-            embeddings = np.array(f["embeddings"])
+        embeddings = lance_load(DATA_DIR, dataset, embedding_id)
         nne = NearestNeighbors(n_neighbors=num, metric="cosine")
         nne.fit(embeddings)
         if dataset not in DATASETS:
@@ -84,10 +116,37 @@ def nn_lance(data_dir, dataset, scope_id, model, query, dimensions):
     return jsonify(indices=indices, distances=distances, search_embedding=embedding)
 
 
+def nn_late_interaction(data_dir, dataset, embedding_id, model, query, dimensions):
+    """Late interaction (MaxSim) search using per-token embeddings."""
+    import numpy as np
+
+    from latentscope.util.embedding_store import search_late_interaction
+
+    # Get per-token query embeddings
+    _, query_token_vectors = model.embed_multi([query], dimensions=dimensions)
+    query_tokens = query_token_vectors[0]  # (Q, D)
+
+    # Also get the mean embedding for the response
+    mean_embedding = query_tokens.mean(axis=0)
+    mean_embedding = mean_embedding / (np.linalg.norm(mean_embedding) + 1e-10)
+
+    indices, scores = search_late_interaction(
+        data_dir, dataset, embedding_id,
+        query_tokens, prefilter_limit=200, final_limit=100,
+    )
+
+    return jsonify(
+        indices=indices,
+        distances=scores,
+        search_embedding=mean_embedding.tolist(),
+        search_type="late_interaction",
+    )
+
+
 @search_bp.route('/feature_summary', methods=['POST'])
 def feature_summary():
-    dataset = request.args.get('dataset')
-    feature_id = request.args.get('feature_id')
+    request.args.get('dataset')
+    request.args.get('feature_id')
 
 
 @search_bp.route('/feature', methods=['GET'])
@@ -134,9 +193,10 @@ def feature():
 
 @search_bp.route('/features', methods=['GET'])
 def features():
-    import h5py
     import numpy as np
     from sklearn.neighbors import NearestNeighbors
+
+    from latentscope.util.embedding_store import load_embeddings as lance_load
 
     DATA_DIR = _data_dir()
     dataset = request.args.get('dataset')
@@ -146,7 +206,7 @@ def features():
 
     num = 150
     if embedding_id not in EMBEDDINGS:
-        with open(os.path.join(DATA_DIR, dataset, "embeddings", embedding_id + ".json"), 'r') as f:
+        with open(os.path.join(DATA_DIR, dataset, "embeddings", embedding_id + ".json")) as f:
             metadata = json.load(f)
         model_id = metadata.get('model_id')
         model = get_embedding_model(model_id)
@@ -156,9 +216,7 @@ def features():
         model = EMBEDDINGS[embedding_id]
 
     if dataset not in DATASETS or embedding_id not in DATASETS[dataset]:
-        embedding_path = os.path.join(DATA_DIR, dataset, "embeddings", f"{embedding_id}.h5")
-        with h5py.File(embedding_path, 'r') as f:
-            embeddings = np.array(f["embeddings"])
+        embeddings = lance_load(DATA_DIR, dataset, embedding_id)
         nne = NearestNeighbors(n_neighbors=num, metric="cosine")
         nne.fit(embeddings)
         if dataset not in DATASETS:

--- a/latentscope/util/embedding_store.py
+++ b/latentscope/util/embedding_store.py
@@ -1,0 +1,340 @@
+"""
+LanceDB-backed embedding storage.
+
+Replaces the previous HDF5-based storage with LanceDB tables that support:
+- Standard dense embeddings (single vector per row)
+- Late interaction embeddings (mean vector + per-token vectors per row)
+- Resumable batch writing
+- Backward-compatible reading of legacy HDF5 files
+"""
+
+import os
+
+import numpy as np
+
+
+def _lance_db_path(data_dir, dataset_id):
+    """Return the LanceDB directory for a dataset."""
+    return os.path.join(data_dir, dataset_id, "lancedb")
+
+
+def _embedding_table_name(embedding_id):
+    """Return the LanceDB table name for an embedding."""
+    return f"emb-{embedding_id}"
+
+
+def _connect(data_dir, dataset_id):
+    """Connect to the LanceDB database for a dataset."""
+    import lancedb
+
+    db_path = _lance_db_path(data_dir, dataset_id)
+    os.makedirs(db_path, exist_ok=True)
+    return lancedb.connect(db_path)
+
+
+def _get_table_names(db):
+    """Get list of table names from a LanceDB connection."""
+    result = db.list_tables()
+    # lancedb 0.30+ returns a ListTablesResponse object with .tables attribute
+    if hasattr(result, 'tables'):
+        return result.tables
+    return list(result)
+
+
+def append_embeddings(data_dir, dataset_id, embedding_id, vectors, start_index=0,
+                      token_vectors_list=None):
+    """Append a batch of embeddings to the LanceDB table.
+
+    Parameters
+    ----------
+    data_dir : str
+        Root data directory.
+    dataset_id : str
+        Dataset identifier.
+    embedding_id : str
+        Embedding identifier (e.g. "embedding-001").
+    vectors : np.ndarray
+        Dense embedding vectors, shape (N, D).  For late interaction models
+        this is the mean vector.
+    start_index : int
+        The row index of the first vector in this batch (for ls_index).
+    token_vectors_list : list[np.ndarray] or None
+        Per-token vectors for late interaction models.  Each element is a
+        (T_i, D) array where T_i varies per document.  None for standard
+        embeddings.
+    """
+    import pyarrow as pa
+
+    db = _connect(data_dir, dataset_id)
+    table_name = _embedding_table_name(embedding_id)
+
+    n = vectors.shape[0]
+
+    # Build list of row dicts (LanceDB requires list-of-dicts for add/create)
+    rows = []
+    for i in range(n):
+        row = {
+            "ls_index": start_index + i,
+            "vector": vectors[i].tolist(),
+        }
+        if token_vectors_list is not None:
+            row["token_vectors"] = token_vectors_list[i].tolist()
+            row["num_tokens"] = len(token_vectors_list[i])
+        rows.append(row)
+
+    if table_name in _get_table_names(db):
+        tbl = db.open_table(table_name)
+        tbl.add(rows)
+    else:
+        db.create_table(table_name, rows)
+
+
+def get_embedding_count(data_dir, dataset_id, embedding_id):
+    """Return the number of embeddings stored, or 0 if none."""
+    db = _connect(data_dir, dataset_id)
+    table_name = _embedding_table_name(embedding_id)
+    if table_name in _get_table_names(db):
+        tbl = db.open_table(table_name)
+        return tbl.count_rows()
+    return 0
+
+
+def load_embeddings(data_dir, dataset_id, embedding_id):
+    """Load all dense (mean) embeddings as a numpy array.
+
+    Falls back to HDF5 if LanceDB table doesn't exist (backward compat).
+
+    Returns
+    -------
+    np.ndarray of shape (N, D)
+    """
+    db = _connect(data_dir, dataset_id)
+    table_name = _embedding_table_name(embedding_id)
+
+    if table_name in _get_table_names(db):
+        tbl = db.open_table(table_name)
+        df = tbl.to_pandas()
+        df = df.sort_values("ls_index")
+        vectors = np.array(df["vector"].tolist(), dtype=np.float32)
+        return vectors
+
+    # Fallback: try legacy HDF5
+    return _load_hdf5_embeddings(data_dir, dataset_id, embedding_id)
+
+
+def load_token_vectors(data_dir, dataset_id, embedding_id, indices=None):
+    """Load per-token vectors for late interaction models.
+
+    Parameters
+    ----------
+    indices : list[int] or None
+        If given, load only these row indices.  Otherwise load all.
+
+    Returns
+    -------
+    list[np.ndarray]
+        Each element is (T_i, D) array of token vectors for that document.
+    """
+    db = _connect(data_dir, dataset_id)
+    table_name = _embedding_table_name(embedding_id)
+
+    if table_name not in _get_table_names(db):
+        raise ValueError(f"No LanceDB table for {embedding_id}. "
+                         "Token vectors are only available for LanceDB embeddings.")
+
+    tbl = db.open_table(table_name)
+
+    if "token_vectors" not in tbl.schema.names:
+        raise ValueError(f"Embedding {embedding_id} does not have token vectors "
+                         "(not a late interaction embedding).")
+
+    if indices is not None:
+        # Filter to specific indices
+        df = tbl.search().where(
+            f"ls_index IN ({','.join(str(i) for i in indices)})"
+        ).select(["ls_index", "token_vectors"]).to_pandas()
+    else:
+        df = tbl.to_pandas()
+
+    df = df.sort_values("ls_index")
+    result = []
+    for tv in df["token_vectors"].tolist():
+        # tv may be a numpy array of numpy arrays, or a list of lists
+        arr = np.stack(tv).astype(np.float32)
+        result.append(arr)
+    return result
+
+
+def has_token_vectors(data_dir, dataset_id, embedding_id):
+    """Check if this embedding has per-token vectors (late interaction)."""
+    db = _connect(data_dir, dataset_id)
+    table_name = _embedding_table_name(embedding_id)
+    if table_name not in _get_table_names(db):
+        return False
+    tbl = db.open_table(table_name)
+    return "token_vectors" in tbl.schema.names
+
+
+def create_vector_index(data_dir, dataset_id, embedding_id, metric="cosine"):
+    """Create an ANN index on the mean vector column."""
+    db = _connect(data_dir, dataset_id)
+    table_name = _embedding_table_name(embedding_id)
+    if table_name not in _get_table_names(db):
+        return
+    tbl = db.open_table(table_name)
+    num_rows = tbl.count_rows()
+    if num_rows < 256:
+        return  # too few rows for IVF index
+    dim = len(tbl.to_pandas().iloc[0]["vector"])
+    partitions = min(256, num_rows // 10)
+    sub_vectors = max(1, dim // 16)
+    tbl.create_index(
+        num_partitions=partitions,
+        num_sub_vectors=sub_vectors,
+        metric=metric,
+    )
+
+
+def search_nn(data_dir, dataset_id, embedding_id, query_vector, limit=150, metric="cosine"):
+    """Search for nearest neighbors using the mean vector.
+
+    Returns (indices, distances) arrays.
+    """
+    db = _connect(data_dir, dataset_id)
+    table_name = _embedding_table_name(embedding_id)
+
+    if table_name not in _get_table_names(db):
+        raise ValueError(f"No LanceDB table for {embedding_id}")
+
+    tbl = db.open_table(table_name)
+    results = (
+        tbl.search(query_vector)
+        .metric(metric)
+        .select(["ls_index"])
+        .limit(limit)
+        .to_list()
+    )
+    indices = [r["ls_index"] for r in results]
+    distances = [r["_distance"] for r in results]
+    return indices, distances
+
+
+def search_late_interaction(data_dir, dataset_id, embedding_id, query_token_vectors,
+                            prefilter_limit=200, final_limit=50, metric="cosine"):
+    """Late interaction (MaxSim) search.
+
+    1. Use the mean of query token vectors to find candidate documents via ANN.
+    2. Load per-token vectors for candidates.
+    3. Re-rank using MaxSim scoring.
+
+    Parameters
+    ----------
+    query_token_vectors : np.ndarray
+        Shape (Q, D) - per-token vectors from the query.
+    prefilter_limit : int
+        Number of candidates to retrieve via ANN before re-ranking.
+    final_limit : int
+        Number of final results to return.
+
+    Returns
+    -------
+    indices : list[int]
+    scores : list[float]
+    """
+    # Step 1: ANN search using mean of query tokens
+    query_mean = query_token_vectors.mean(axis=0).astype(np.float32)
+    candidate_indices, _ = search_nn(
+        data_dir, dataset_id, embedding_id,
+        query_mean, limit=prefilter_limit, metric=metric,
+    )
+
+    if not candidate_indices:
+        return [], []
+
+    # Step 2: Load token vectors for candidates
+    candidate_token_vecs = load_token_vectors(
+        data_dir, dataset_id, embedding_id, indices=candidate_indices,
+    )
+
+    # Step 3: MaxSim re-ranking
+    scores = []
+    for doc_tokens in candidate_token_vecs:
+        # doc_tokens shape: (T_d, D), query_token_vectors shape: (Q, D)
+        # MaxSim: for each query token, find max similarity with any doc token, then sum
+        if len(doc_tokens) == 0:
+            scores.append(0.0)
+            continue
+        # Normalize for cosine similarity
+        q_norm = query_token_vectors / (np.linalg.norm(query_token_vectors, axis=1, keepdims=True) + 1e-10)
+        d_norm = doc_tokens / (np.linalg.norm(doc_tokens, axis=1, keepdims=True) + 1e-10)
+        sim_matrix = q_norm @ d_norm.T  # (Q, T_d)
+        max_sims = sim_matrix.max(axis=1)  # (Q,)
+        scores.append(float(max_sims.sum()))
+
+    # Sort by score descending
+    ranked = sorted(zip(candidate_indices, scores), key=lambda x: -x[1])
+    ranked = ranked[:final_limit]
+    return [r[0] for r in ranked], [r[1] for r in ranked]
+
+
+def _load_hdf5_embeddings(data_dir, dataset_id, embedding_id):
+    """Load embeddings from legacy HDF5 file."""
+    import h5py
+
+    emb_path = os.path.join(data_dir, dataset_id, "embeddings", f"{embedding_id}.h5")
+    if not os.path.exists(emb_path):
+        raise FileNotFoundError(f"No embeddings found for {embedding_id} "
+                                f"(checked LanceDB and HDF5 at {emb_path})")
+    with h5py.File(emb_path, "r") as f:
+        return np.array(f["embeddings"])
+
+
+def get_embedding_stats(data_dir, dataset_id, embedding_id):
+    """Compute min/max values per dimension for the embedding."""
+    embeddings = load_embeddings(data_dir, dataset_id, embedding_id)
+    return {
+        "min_values": np.min(embeddings, axis=0).tolist(),
+        "max_values": np.max(embeddings, axis=0).tolist(),
+        "dimensions": embeddings.shape[1],
+        "count": embeddings.shape[0],
+    }
+
+
+def estimate_embedding_storage(num_rows, dimensions, has_tokens=False, avg_tokens_per_doc=50):
+    """Estimate storage requirements for embeddings.
+
+    Returns dict with estimated sizes in bytes and human-readable strings.
+    """
+    bytes_per_float = 4  # float32
+
+    # Mean vector storage
+    mean_bytes = num_rows * dimensions * bytes_per_float
+
+    # Token vector storage (if late interaction)
+    token_bytes = 0
+    if has_tokens:
+        token_bytes = num_rows * avg_tokens_per_doc * dimensions * bytes_per_float
+
+    # LanceDB overhead (~20% for metadata, indices, etc.)
+    overhead = 1.2
+    total_bytes = int((mean_bytes + token_bytes) * overhead)
+
+    return {
+        "mean_vector_bytes": mean_bytes,
+        "token_vector_bytes": token_bytes,
+        "total_bytes": total_bytes,
+        "total_human": _human_readable_size(total_bytes),
+        "num_rows": num_rows,
+        "dimensions": dimensions,
+        "has_tokens": has_tokens,
+        "avg_tokens_per_doc": avg_tokens_per_doc if has_tokens else 0,
+    }
+
+
+def _human_readable_size(size_bytes):
+    """Convert bytes to human-readable string."""
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if size_bytes < 1024:
+            return f"{size_bytes:.1f} {unit}"
+        size_bytes /= 1024
+    return f"{size_bytes:.1f} PB"

--- a/latentscope/util/embedding_store.py
+++ b/latentscope/util/embedding_store.py
@@ -359,11 +359,36 @@ def migrate_hdf5_to_lancedb(data_dir, dataset_id, embedding_id, batch_size=1000,
             if on_progress:
                 on_progress(end, total_rows)
 
+    # Verify migration: check row count and spot-check a few vectors
+    lance_count = get_embedding_count(data_dir, dataset_id, embedding_id)
+    if lance_count != total_rows:
+        raise RuntimeError(
+            f"Migration verification failed: expected {total_rows} rows, "
+            f"got {lance_count} in LanceDB"
+        )
+
+    # Spot-check first and last vectors match
+    lance_vectors = load_embeddings(data_dir, dataset_id, embedding_id)
+    with h5py.File(emb_path, "r") as f:
+        h5_first = np.array(f["embeddings"][0])
+        h5_last = np.array(f["embeddings"][-1])
+    if not np.allclose(lance_vectors[0], h5_first, atol=1e-6):
+        raise RuntimeError("Migration verification failed: first vector mismatch")
+    if not np.allclose(lance_vectors[-1], h5_last, atol=1e-6):
+        raise RuntimeError("Migration verification failed: last vector mismatch")
+
+    # Verification passed — remove the HDF5 file
+    h5_size = os.path.getsize(emb_path)
+    os.remove(emb_path)
+
     return {
         "status": "migrated",
         "rows": total_rows,
         "dimensions": dimensions,
         "source": emb_path,
+        "hdf5_removed": True,
+        "space_freed_bytes": h5_size,
+        "space_freed": _human_readable_size(h5_size),
     }
 
 

--- a/latentscope/util/embedding_store.py
+++ b/latentscope/util/embedding_store.py
@@ -300,6 +300,73 @@ def get_embedding_stats(data_dir, dataset_id, embedding_id):
     }
 
 
+def get_storage_format(data_dir, dataset_id, embedding_id):
+    """Detect the storage format for an embedding.
+
+    Returns
+    -------
+    str : "lancedb", "hdf5", or "none"
+    """
+    db = _connect(data_dir, dataset_id)
+    table_name = _embedding_table_name(embedding_id)
+    if table_name in _get_table_names(db):
+        return "lancedb"
+
+    emb_path = os.path.join(data_dir, dataset_id, "embeddings", f"{embedding_id}.h5")
+    if os.path.exists(emb_path):
+        return "hdf5"
+
+    return "none"
+
+
+def migrate_hdf5_to_lancedb(data_dir, dataset_id, embedding_id, batch_size=1000,
+                             on_progress=None):
+    """Migrate an HDF5 embedding to LanceDB format.
+
+    Parameters
+    ----------
+    on_progress : callable or None
+        Called with (current_row, total_rows) for progress reporting.
+
+    Returns
+    -------
+    dict with migration stats
+    """
+    import h5py
+
+    emb_path = os.path.join(data_dir, dataset_id, "embeddings", f"{embedding_id}.h5")
+    if not os.path.exists(emb_path):
+        raise FileNotFoundError(f"No HDF5 file at {emb_path}")
+
+    # Check if already migrated
+    db = _connect(data_dir, dataset_id)
+    table_name = _embedding_table_name(embedding_id)
+    if table_name in _get_table_names(db):
+        tbl = db.open_table(table_name)
+        return {"status": "already_migrated", "rows": tbl.count_rows()}
+
+    # Load from HDF5
+    with h5py.File(emb_path, "r") as f:
+        total_rows = f["embeddings"].shape[0]
+        dimensions = f["embeddings"].shape[1]
+
+        # Write in batches to avoid memory issues
+        for start in range(0, total_rows, batch_size):
+            end = min(start + batch_size, total_rows)
+            vectors = np.array(f["embeddings"][start:end])
+            append_embeddings(data_dir, dataset_id, embedding_id,
+                            vectors, start_index=start)
+            if on_progress:
+                on_progress(end, total_rows)
+
+    return {
+        "status": "migrated",
+        "rows": total_rows,
+        "dimensions": dimensions,
+        "source": emb_path,
+    }
+
+
 def estimate_embedding_storage(num_rows, dimensions, has_tokens=False, avg_tokens_per_doc=50):
     """Estimate storage requirements for embeddings.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,43 +14,43 @@ authors = [
 ]
 dependencies = [
     # Core scientific
-    "numpy>=1.26",
-    "scipy>=1.11",
-    "scikit-learn>=1.3",
-    "pandas>=2.0",
-    "h5py>=3.10",
-    "lancedb>=0.19",
+    "numpy==1.26.4",
+    "scipy==1.14.1",
+    "scikit-learn==1.6.1",
+    "pandas==2.2.3",
+    "h5py==3.12.1",
+    "lancedb==0.30.2",
     # ML
-    "torch>=2.1",
-    "transformers>=4.40",
-    "sentence-transformers>=3.0",
+    "torch>=2.1,<3",
+    "transformers==4.51.3",
+    "sentence-transformers==5.4.0",
     # Server
-    "Flask>=3.0",
-    "Flask-Cors>=4.0",
+    "Flask==3.1.0",
+    "Flask-Cors==5.0.1",
     # API providers
-    "openai>=1.12",
-    "tiktoken>=0.5",
-    "mistralai>=0.0.11",
-    "cohere>=4.40",
-    "together>=0.2.10",
-    "voyageai>=0.2.3",
-    "tokenizers>=0.15",
+    "openai==1.78.1",
+    "tiktoken==0.9.0",
+    "mistralai==1.7.0",
+    "cohere==5.15.0",
+    "together==1.5.7",
+    "voyageai==0.3.5",
+    "tokenizers==0.21.1",
     # Clustering & dimensionality reduction
-    "umap-learn>=0.5.5",
-    "hdbscan>=0.8",
-    "evoc>=0.3",
+    "umap-learn==0.5.7",
+    "hdbscan==0.8.40",
+    "evoc==0.3.1",
     # ML misc
-    "outlines>=0.1",
-    "nltk>=3.8",
-    "latentsae>=0.1.3",
-    "datamapplot>=0.3",
-    "matplotlib>=3.8",
+    "outlines==0.1.11",
+    "nltk==3.9.1",
+    "latentsae==0.1.3",
+    "datamapplot==0.5.2",
+    "matplotlib==3.10.1",
     # Hugging Face
-    "datasets>=2.0",
-    "huggingface-hub>=0.24",
+    "datasets==3.5.0",
+    "huggingface-hub==0.30.2",
     # Util
-    "python-dotenv>=1.0",
-    "tqdm>=4.66",
+    "python-dotenv==1.0.1",
+    "tqdm==4.67.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,43 +14,43 @@ authors = [
 ]
 dependencies = [
     # Core scientific
-    "numpy==1.26.4",
-    "scipy==1.14.1",
-    "scikit-learn==1.6.1",
-    "pandas==2.2.3",
-    "h5py==3.12.1",
-    "lancedb==0.30.2",
+    "numpy>=1.26,<3",
+    "scipy>=1.11,<2",
+    "scikit-learn>=1.3,<2",
+    "pandas>=2.0,<3",
+    "h5py>=3.10,<4",
+    "lancedb>=0.30,<1",
     # ML
     "torch>=2.1,<3",
-    "transformers==4.51.3",
-    "sentence-transformers==5.4.0",
+    "transformers>=4.40,<6",
+    "sentence-transformers>=3.0,<6",
     # Server
-    "Flask==3.1.0",
-    "Flask-Cors==5.0.1",
+    "Flask>=3.0,<4",
+    "Flask-Cors>=4.0,<7",
     # API providers
-    "openai==1.78.1",
-    "tiktoken==0.9.0",
-    "mistralai==1.7.0",
-    "cohere==5.15.0",
-    "together==1.5.7",
-    "voyageai==0.3.5",
-    "tokenizers==0.21.1",
+    "openai>=1.12,<3",
+    "tiktoken>=0.5,<1",
+    "mistralai>=1.0,<3",
+    "cohere>=5.0,<7",
+    "together>=1.0,<3",
+    "voyageai>=0.2.3,<1",
+    "tokenizers>=0.15,<1",
     # Clustering & dimensionality reduction
-    "umap-learn==0.5.7",
-    "hdbscan==0.8.40",
-    "evoc==0.3.1",
+    "umap-learn>=0.5.5,<1",
+    "hdbscan>=0.8,<1",
+    "evoc>=0.3,<1",
     # ML misc
-    "outlines==0.1.11",
-    "nltk==3.9.1",
-    "latentsae==0.1.3",
-    "datamapplot==0.5.2",
-    "matplotlib==3.10.1",
+    "outlines>=0.1,<2",
+    "nltk>=3.8,<4",
+    "latentsae>=0.1.3,<1",
+    "datamapplot>=0.5,<1",
+    "matplotlib>=3.8,<4",
     # Hugging Face
-    "datasets==3.5.0",
-    "huggingface-hub==0.30.2",
+    "datasets>=2.0,<5",
+    "huggingface-hub>=0.24,<2",
     # Util
-    "python-dotenv==1.0.1",
-    "tqdm==4.67.1",
+    "python-dotenv>=1.0,<2",
+    "tqdm>=4.66,<5",
 ]
 
 [project.urls]

--- a/tests/test_embedding_store.py
+++ b/tests/test_embedding_store.py
@@ -1,0 +1,168 @@
+"""Tests for the LanceDB-backed embedding store."""
+
+import os
+import json
+import tempfile
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def data_dir():
+    with tempfile.TemporaryDirectory() as d:
+        dataset_dir = os.path.join(d, "test-dataset")
+        os.makedirs(os.path.join(dataset_dir, "embeddings"))
+        os.makedirs(os.path.join(dataset_dir, "lancedb"))
+        yield d
+
+
+def test_append_and_load(data_dir):
+    from latentscope.util.embedding_store import append_embeddings, load_embeddings
+
+    vectors = np.random.rand(10, 128).astype(np.float32)
+    append_embeddings(data_dir, "test-dataset", "embedding-001", vectors, start_index=0)
+
+    loaded = load_embeddings(data_dir, "test-dataset", "embedding-001")
+    assert loaded.shape == (10, 128)
+    np.testing.assert_allclose(loaded, vectors, atol=1e-6)
+
+
+def test_append_batches(data_dir):
+    from latentscope.util.embedding_store import (
+        append_embeddings,
+        load_embeddings,
+        get_embedding_count,
+    )
+
+    v1 = np.random.rand(5, 64).astype(np.float32)
+    v2 = np.random.rand(5, 64).astype(np.float32)
+
+    append_embeddings(data_dir, "test-dataset", "embedding-002", v1, start_index=0)
+    assert get_embedding_count(data_dir, "test-dataset", "embedding-002") == 5
+
+    append_embeddings(data_dir, "test-dataset", "embedding-002", v2, start_index=5)
+    assert get_embedding_count(data_dir, "test-dataset", "embedding-002") == 10
+
+    loaded = load_embeddings(data_dir, "test-dataset", "embedding-002")
+    assert loaded.shape == (10, 64)
+    np.testing.assert_allclose(loaded[:5], v1, atol=1e-6)
+    np.testing.assert_allclose(loaded[5:], v2, atol=1e-6)
+
+
+def test_token_vectors(data_dir):
+    from latentscope.util.embedding_store import (
+        append_embeddings,
+        load_token_vectors,
+        has_token_vectors,
+    )
+
+    mean_vecs = np.random.rand(3, 128).astype(np.float32)
+    token_vecs = [
+        np.random.rand(5, 128).astype(np.float32),
+        np.random.rand(8, 128).astype(np.float32),
+        np.random.rand(3, 128).astype(np.float32),
+    ]
+
+    append_embeddings(
+        data_dir, "test-dataset", "embedding-003", mean_vecs,
+        start_index=0, token_vectors_list=token_vecs,
+    )
+
+    assert has_token_vectors(data_dir, "test-dataset", "embedding-003")
+    loaded_tokens = load_token_vectors(data_dir, "test-dataset", "embedding-003")
+    assert len(loaded_tokens) == 3
+    assert loaded_tokens[0].shape == (5, 128)
+    assert loaded_tokens[1].shape == (8, 128)
+    assert loaded_tokens[2].shape == (3, 128)
+
+
+def test_no_token_vectors(data_dir):
+    from latentscope.util.embedding_store import append_embeddings, has_token_vectors
+
+    vectors = np.random.rand(5, 64).astype(np.float32)
+    append_embeddings(data_dir, "test-dataset", "embedding-004", vectors, start_index=0)
+    assert not has_token_vectors(data_dir, "test-dataset", "embedding-004")
+
+
+def test_search_nn(data_dir):
+    from latentscope.util.embedding_store import append_embeddings, search_nn
+
+    # Create some distinct vectors
+    vectors = np.eye(10, 128, dtype=np.float32)  # identity-like
+    append_embeddings(data_dir, "test-dataset", "embedding-005", vectors, start_index=0)
+
+    query = vectors[3]  # search for exact match
+    indices, distances = search_nn(data_dir, "test-dataset", "embedding-005", query, limit=3)
+    assert len(indices) == 3
+    assert indices[0] == 3  # exact match should be first
+    assert distances[0] < 0.01  # very close distance
+
+
+def test_late_interaction_search(data_dir):
+    from latentscope.util.embedding_store import (
+        append_embeddings,
+        search_late_interaction,
+    )
+
+    # Create docs with token vectors
+    mean_vecs = np.random.rand(20, 64).astype(np.float32)
+    token_vecs = [np.random.rand(5, 64).astype(np.float32) for _ in range(20)]
+
+    append_embeddings(
+        data_dir, "test-dataset", "embedding-006", mean_vecs,
+        start_index=0, token_vectors_list=token_vecs,
+    )
+
+    query_tokens = np.random.rand(3, 64).astype(np.float32)
+    indices, scores = search_late_interaction(
+        data_dir, "test-dataset", "embedding-006",
+        query_tokens, prefilter_limit=10, final_limit=5,
+    )
+    assert len(indices) <= 5
+    assert len(scores) <= 5
+    # Scores should be sorted descending
+    for i in range(len(scores) - 1):
+        assert scores[i] >= scores[i + 1]
+
+
+def test_hdf5_fallback(data_dir):
+    """Test backward compatibility with HDF5 files."""
+    import h5py
+    from latentscope.util.embedding_store import load_embeddings
+
+    vectors = np.random.rand(10, 64).astype(np.float32)
+    h5_path = os.path.join(data_dir, "test-dataset", "embeddings", "embedding-099.h5")
+    with h5py.File(h5_path, "w") as f:
+        f.create_dataset("embeddings", data=vectors)
+
+    loaded = load_embeddings(data_dir, "test-dataset", "embedding-099")
+    np.testing.assert_allclose(loaded, vectors, atol=1e-6)
+
+
+def test_estimate_storage():
+    from latentscope.util.embedding_store import estimate_embedding_storage
+
+    # Standard embeddings
+    est = estimate_embedding_storage(10000, 768)
+    assert est["total_bytes"] > 0
+    assert "MB" in est["total_human"] or "KB" in est["total_human"]
+    assert not est["has_tokens"]
+
+    # Late interaction embeddings
+    est_li = estimate_embedding_storage(10000, 128, has_tokens=True, avg_tokens_per_doc=50)
+    assert est_li["token_vector_bytes"] > 0
+    assert est_li["total_bytes"] > est["total_bytes"]
+
+
+def test_get_embedding_stats(data_dir):
+    from latentscope.util.embedding_store import append_embeddings, get_embedding_stats
+
+    vectors = np.array([[1.0, 2.0, 3.0], [-1.0, 0.0, 5.0]], dtype=np.float32)
+    append_embeddings(data_dir, "test-dataset", "embedding-007", vectors, start_index=0)
+
+    stats = get_embedding_stats(data_dir, "test-dataset", "embedding-007")
+    assert stats["dimensions"] == 3
+    assert stats["count"] == 2
+    assert stats["min_values"] == [-1.0, 0.0, 3.0]
+    assert stats["max_values"] == [1.0, 2.0, 5.0]

--- a/web/src/components/Setup/Cluster.jsx
+++ b/web/src/components/Setup/Cluster.jsx
@@ -8,6 +8,7 @@ import JobProgress from '../Job/Progress';
 import { useStartJobPolling } from '../Job/Run';
 import { useSetup } from '../../contexts/SetupContext';
 import { apiService, apiUrl } from '../../lib/apiService';
+import EstimatePanel from './EstimatePanel';
 
 import Preview from './Preview';
 
@@ -126,6 +127,22 @@ function Cluster() {
     },
     [startClusterJob, umap, method]
   );
+
+  // Estimation
+  const [clusterEstimate, setClusterEstimate] = useState(null);
+  const [estimateLoading, setEstimateLoading] = useState(false);
+
+  const handleEstimateCluster = useCallback(() => {
+    if (!umap?.id || !dataset?.id) return;
+    setEstimateLoading(true);
+    apiService
+      .estimateCluster(dataset.id, umap.id)
+      .then((data) => {
+        setClusterEstimate(data);
+        setEstimateLoading(false);
+      })
+      .catch(() => setEstimateLoading(false));
+  }, [dataset, umap]);
 
   const handleNextStep = useCallback(() => {
     if (savedScope?.cluster_id == cluster?.id) {
@@ -255,6 +272,14 @@ function Cluster() {
                   </Tooltip>
                 </label>
               </>
+            )}
+            {umap && (
+              <EstimatePanel
+                estimate={clusterEstimate}
+                onEstimate={handleEstimateCluster}
+                loading={estimateLoading}
+                step="cluster"
+              />
             )}
             <Button
               type="submit"

--- a/web/src/components/Setup/Embedding.jsx
+++ b/web/src/components/Setup/Embedding.jsx
@@ -39,6 +39,9 @@ function Embedding() {
   const [clusters, setClusters] = useState([]);
   const [sae, setSae] = useState(null);
 
+  const [embeddingFormats, setEmbeddingFormats] = useState({});
+  const [migratingId, setMigratingId] = useState(null);
+
   const [modelId, setModelId] = useState(null);
   // for the models that support choosing the size of dimensions
   const [dimensions, setDimensions] = useState(null);
@@ -89,10 +92,17 @@ function Embedding() {
 
   useEffect(() => {
     if (dataset) {
-      apiService.fetchEmbeddings(dataset?.id).then((embs) => setEmbeddings(embs));
+      apiService.fetchEmbeddings(dataset?.id).then((embs) => {
+        setEmbeddings(embs);
+        // Fetch format for each embedding
+        embs.forEach((emb) => {
+          apiService.fetchEmbeddingFormat(dataset.id, emb.id).then((data) => {
+            setEmbeddingFormats((prev) => ({ ...prev, [emb.id]: data.format }));
+          });
+        });
+      });
       apiService.fetchUmaps(dataset?.id).then((ums) => setUmaps(ums));
       apiService.fetchClusters(dataset?.id).then((cls) => setClusters(cls));
-      // apiService.fetchSaes(dataset?.id).then((saes) => setSaes(saes));
       setTextColumn(dataset?.text_column);
     }
   }, [dataset, setEmbeddings, setUmaps, setClusters]);
@@ -622,7 +632,31 @@ function Embedding() {
                       ) : null}
                     </span>
                     <span>{emb.model_id?.replace('___', '/')}</span>
-                    <span>{emb.dimensions} dimensions</span>
+                    <span>
+                      {emb.dimensions} dimensions
+                      {embeddingFormats[emb.id] === 'hdf5' && (
+                        <>
+                          <span className={styles['format-badge-hdf5']}>HDF5</span>
+                          <button
+                            className={styles['migrate-button']}
+                            disabled={migratingId === emb.id}
+                            onClick={(e) => {
+                              e.preventDefault();
+                              setMigratingId(emb.id);
+                              apiService.migrateEmbedding(dataset.id, emb.id).then((result) => {
+                                setMigratingId(null);
+                                setEmbeddingFormats((prev) => ({ ...prev, [emb.id]: 'lancedb' }));
+                              });
+                            }}
+                          >
+                            {migratingId === emb.id ? 'Migrating...' : 'Migrate to LanceDB'}
+                          </button>
+                        </>
+                      )}
+                      {embeddingFormats[emb.id] === 'lancedb' && (
+                        <span className={styles['format-badge-lance']}>LanceDB</span>
+                      )}
+                    </span>
                     {umps.length || cls.length ? (
                       <div className={styles['item-deps']}>
                         {umps.length ? <span>{umps.length} umaps</span> : null}

--- a/web/src/components/Setup/Embedding.jsx
+++ b/web/src/components/Setup/Embedding.jsx
@@ -16,6 +16,7 @@ import SettingsModal from '../SettingsModal';
 
 import Sae from './Sae';
 import Preview from './Preview';
+import EstimatePanel from './EstimatePanel';
 
 import styles from './Embedding.module.scss';
 
@@ -216,6 +217,43 @@ function Embedding() {
 
   const [batchSize, setBatchSize] = useState(100);
   const [maxSeqLength, setMaxSeqLength] = useState(512);
+
+  // Estimation state
+  const [embedEstimate, setEmbedEstimate] = useState(null);
+  const [embedBenchmark, setEmbedBenchmark] = useState(null);
+  const [estimateLoading, setEstimateLoading] = useState(false);
+
+  const handleEstimate = useCallback(() => {
+    if (!modelId || !textColumn || !datasetId) return;
+    setEstimateLoading(true);
+    setEmbedEstimate(null);
+    apiService
+      .estimateEmbed(datasetId, modelId, textColumn, dimensions)
+      .then((data) => {
+        setEmbedEstimate(data);
+        setEstimateLoading(false);
+      })
+      .catch(() => setEstimateLoading(false));
+  }, [datasetId, modelId, textColumn, dimensions]);
+
+  const handleBenchmark = useCallback(() => {
+    if (!modelId || !textColumn || !datasetId) return;
+    setEstimateLoading(true);
+    setEmbedBenchmark(null);
+    apiService
+      .benchmarkEmbed(datasetId, modelId, textColumn, 10, dimensions)
+      .then((data) => {
+        setEmbedBenchmark(data);
+        setEstimateLoading(false);
+      })
+      .catch(() => setEstimateLoading(false));
+  }, [datasetId, modelId, textColumn, dimensions]);
+
+  // Reset estimates when model changes
+  useEffect(() => {
+    setEmbedEstimate(null);
+    setEmbedBenchmark(null);
+  }, [modelId]);
 
   // from the dataset, if a column is flagged as a potential embedding
   const [potentialEmbeddings, setPotentialEmbeddings] = useState([]);
@@ -508,6 +546,17 @@ function Embedding() {
                   })}
                 </select>
               : null} */}
+
+            {modelId && textColumn && (
+              <EstimatePanel
+                estimate={embedEstimate}
+                onEstimate={handleEstimate}
+                onBenchmark={handleBenchmark}
+                benchmarkResult={embedBenchmark}
+                loading={estimateLoading}
+                step="embed"
+              />
+            )}
 
             <Button
               type="submit"

--- a/web/src/components/Setup/Embedding.module.scss
+++ b/web/src/components/Setup/Embedding.module.scss
@@ -82,3 +82,37 @@
   gap: 4px;
 }
 
+.format-badge-hdf5 {
+  font-size: 0.65em;
+  padding: 1px 4px;
+  border-radius: 3px;
+  background: #fff3cd;
+  color: #856404;
+  margin-left: 6px;
+}
+.format-badge-lance {
+  font-size: 0.65em;
+  padding: 1px 4px;
+  border-radius: 3px;
+  background: #d4edda;
+  color: #155724;
+  margin-left: 6px;
+}
+.migrate-button {
+  font-size: 0.7em;
+  padding: 1px 6px;
+  border: 1px solid #856404;
+  border-radius: 3px;
+  background: #fff3cd;
+  color: #856404;
+  cursor: pointer;
+  margin-left: 4px;
+}
+.migrate-button:hover {
+  background: #ffe69c;
+}
+.migrate-button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+

--- a/web/src/components/Setup/EstimatePanel.jsx
+++ b/web/src/components/Setup/EstimatePanel.jsx
@@ -1,0 +1,162 @@
+import { useState, useCallback } from 'react';
+import { Button } from 'react-element-forge';
+import { Tooltip } from 'react-tooltip';
+import styles from './EstimatePanel.module.scss';
+
+/**
+ * EstimatePanel - shows compute/storage estimates for a pipeline step.
+ *
+ * Props:
+ *   estimate: object with estimation data (from API), or null
+ *   onEstimate: callback to trigger formula-based estimate
+ *   onBenchmark: callback to trigger benchmark on sample data (optional)
+ *   benchmarkResult: object with benchmark results, or null
+ *   loading: boolean - whether an estimate/benchmark is in progress
+ *   step: string - which pipeline step this is for ("embed", "umap", "cluster")
+ */
+function EstimatePanel({ estimate, onEstimate, onBenchmark, benchmarkResult, loading, step }) {
+  const [showDetails, setShowDetails] = useState(false);
+
+  if (!onEstimate) return null;
+
+  const hasEstimate = estimate && !estimate.error;
+  const hasBenchmark = benchmarkResult && !benchmarkResult.error;
+
+  return (
+    <div className={styles.estimatePanel}>
+      <div className={styles.estimateHeader}>
+        <div className={styles.estimateActions}>
+          <Button
+            color="secondary"
+            onClick={onEstimate}
+            disabled={loading}
+            text={loading ? 'Estimating...' : 'Estimate'}
+          />
+          {onBenchmark && (
+            <>
+              <Button
+                color="secondary"
+                onClick={onBenchmark}
+                disabled={loading}
+                text={loading ? 'Running...' : 'Benchmark'}
+              />
+              <span className="tooltip" data-tooltip-id="benchmark-tip">
+                🤔
+              </span>
+              <Tooltip className="tooltip-area" id="benchmark-tip" place="top" effect="solid">
+                Runs on a small sample to give accurate time and storage estimates.
+              </Tooltip>
+            </>
+          )}
+        </div>
+      </div>
+
+      {hasEstimate && (
+        <div className={styles.estimateResults}>
+          <div className={styles.estimateSummary}>
+            <div className={styles.estimateItem}>
+              <span className={styles.estimateLabel}>Time</span>
+              <span className={styles.estimateValue}>
+                ~{estimate.estimated_time_human || estimate.estimated_total_time_human}
+              </span>
+            </div>
+            <div className={styles.estimateItem}>
+              <span className={styles.estimateLabel}>Storage</span>
+              <span className={styles.estimateValue}>
+                {estimate.storage?.total_human || estimate.output_human || 'N/A'}
+              </span>
+            </div>
+            <div className={styles.estimateItem}>
+              <span className={styles.estimateLabel}>Rows</span>
+              <span className={styles.estimateValue}>
+                {estimate.num_rows?.toLocaleString()}
+              </span>
+            </div>
+            {estimate.is_late_interaction && (
+              <div className={styles.estimateItem}>
+                <span className={styles.lateInteractionBadge}>Late Interaction</span>
+              </div>
+            )}
+          </div>
+
+          {estimate.note && (
+            <div className={styles.estimateNote}>{estimate.note}</div>
+          )}
+
+          <button
+            className={styles.detailsToggle}
+            onClick={() => setShowDetails(!showDetails)}
+          >
+            {showDetails ? 'Hide details' : 'Show details'}
+          </button>
+
+          {showDetails && (
+            <div className={styles.estimateDetails}>
+              {estimate.dimensions && (
+                <div>Dimensions: {estimate.dimensions}</div>
+              )}
+              {estimate.avg_text_length > 0 && (
+                <div>Avg text length: {estimate.avg_text_length} chars</div>
+              )}
+              {estimate.avg_tokens_per_doc > 0 && (
+                <div>Avg tokens/doc: {estimate.avg_tokens_per_doc}</div>
+              )}
+              {estimate.storage?.mean_vector_bytes > 0 && (
+                <div>Mean vectors: {formatBytes(estimate.storage.mean_vector_bytes)}</div>
+              )}
+              {estimate.storage?.token_vector_bytes > 0 && (
+                <div>Token vectors: {formatBytes(estimate.storage.token_vector_bytes)}</div>
+              )}
+              {estimate.neighbors && (
+                <div>Neighbors: {estimate.neighbors}</div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {hasBenchmark && (
+        <div className={styles.benchmarkResults}>
+          <div className={styles.benchmarkHeader}>Benchmark Results</div>
+          <div className={styles.estimateSummary}>
+            <div className={styles.estimateItem}>
+              <span className={styles.estimateLabel}>Time/item</span>
+              <span className={styles.estimateValue}>
+                {benchmarkResult.time_per_item?.toFixed(3)}s
+              </span>
+            </div>
+            <div className={styles.estimateItem}>
+              <span className={styles.estimateLabel}>Total (projected)</span>
+              <span className={styles.estimateValue}>
+                {benchmarkResult.estimated_total_time_human}
+              </span>
+            </div>
+            <div className={styles.estimateItem}>
+              <span className={styles.estimateLabel}>Storage</span>
+              <span className={styles.estimateValue}>
+                {benchmarkResult.storage?.total_human || 'N/A'}
+              </span>
+            </div>
+          </div>
+          <div className={styles.estimateNote}>
+            Based on {benchmarkResult.sample_size} samples
+            ({benchmarkResult.sample_total_time?.toFixed(2)}s total)
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatBytes(bytes) {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let i = 0;
+  let size = bytes;
+  while (size >= 1024 && i < units.length - 1) {
+    size /= 1024;
+    i++;
+  }
+  return `${size.toFixed(1)} ${units[i]}`;
+}
+
+export default EstimatePanel;

--- a/web/src/components/Setup/EstimatePanel.module.scss
+++ b/web/src/components/Setup/EstimatePanel.module.scss
@@ -1,0 +1,92 @@
+.estimatePanel {
+  margin: 8px 0;
+  border: 1px solid var(--border-color, #ddd);
+  border-radius: 6px;
+  padding: 8px 12px;
+  background: var(--bg-secondary, #f8f9fa);
+  font-size: 0.85em;
+}
+
+.estimateHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.estimateActions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.estimateResults, .benchmarkResults {
+  margin-top: 8px;
+}
+
+.benchmarkResults {
+  border-top: 1px solid var(--border-color, #ddd);
+  padding-top: 8px;
+}
+
+.benchmarkHeader {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.estimateSummary {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.estimateItem {
+  display: flex;
+  flex-direction: column;
+}
+
+.estimateLabel {
+  font-size: 0.8em;
+  color: var(--text-secondary, #666);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.estimateValue {
+  font-weight: 600;
+  font-size: 1.1em;
+}
+
+.lateInteractionBadge {
+  background: var(--accent-color, #6366f1);
+  color: white;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.8em;
+  font-weight: 500;
+}
+
+.estimateNote {
+  margin-top: 4px;
+  font-size: 0.85em;
+  color: var(--text-secondary, #888);
+  font-style: italic;
+}
+
+.detailsToggle {
+  background: none;
+  border: none;
+  color: var(--link-color, #4a90d9);
+  cursor: pointer;
+  padding: 4px 0;
+  font-size: 0.85em;
+  text-decoration: underline;
+}
+
+.estimateDetails {
+  margin-top: 4px;
+  padding: 4px 8px;
+  background: var(--bg-tertiary, #f0f0f0);
+  border-radius: 4px;
+  font-size: 0.9em;
+  line-height: 1.6;
+}

--- a/web/src/components/Setup/Umap.jsx
+++ b/web/src/components/Setup/Umap.jsx
@@ -10,6 +10,7 @@ import { useSetup } from '../../contexts/SetupContext';
 import { apiService, apiUrl } from '../../lib/apiService';
 
 import Preview from './Preview';
+import EstimatePanel from './EstimatePanel';
 
 import styles from './Umap.module.scss';
 
@@ -131,6 +132,22 @@ function Umap({}) {
   const toggleSave = useCallback(() => {
     setSave(!save);
   }, [save, setSave]);
+
+  // Estimation
+  const [umapEstimate, setUmapEstimate] = useState(null);
+  const [estimateLoading, setEstimateLoading] = useState(false);
+
+  const handleEstimateUmap = useCallback(() => {
+    if (!embedding?.id || !dataset?.id) return;
+    setEstimateLoading(true);
+    apiService
+      .estimateUmap(dataset.id, embedding.id, 25)
+      .then((data) => {
+        setUmapEstimate(data);
+        setEstimateLoading(false);
+      })
+      .catch(() => setEstimateLoading(false));
+  }, [dataset, embedding]);
 
   const handleNextStep = useCallback(() => {
     if (savedScope?.umap_id == umap?.id) {
@@ -261,6 +278,15 @@ function Umap({}) {
                   (proportional the the data used to make it).
                 </Tooltip>
               </div>
+            )}
+
+            {embedding && (
+              <EstimatePanel
+                estimate={umapEstimate}
+                onEstimate={handleEstimateUmap}
+                loading={estimateLoading}
+                step="umap"
+              />
             )}
 
             <Button

--- a/web/src/lib/apiService.js
+++ b/web/src/lib/apiService.js
@@ -58,6 +58,16 @@ export const apiService = {
         return array;
       });
   },
+  fetchEmbeddingFormat: async (datasetId, embeddingId) => {
+    return fetch(`${apiUrl}/datasets/${datasetId}/embeddings/${embeddingId}/format`).then(
+      (response) => response.json()
+    );
+  },
+  migrateEmbedding: async (datasetId, embeddingId) => {
+    return fetch(`${apiUrl}/datasets/${datasetId}/embeddings/${embeddingId}/migrate`, {
+      method: 'POST',
+    }).then((response) => response.json());
+  },
   fetchClusterQuality: async (datasetId, clusterId) => {
     return fetch(`${apiUrl}/datasets/${datasetId}/clusters/${clusterId}/quality`).then(
       (response) => response.json()

--- a/web/src/lib/apiService.js
+++ b/web/src/lib/apiService.js
@@ -370,4 +370,42 @@ export const apiService = {
       body: JSON.stringify({ dataset: datasetId, filters: filters }),
     }).then((response) => response.json());
   },
+
+  // Estimation API
+  estimateEmbed: async (datasetId, modelId, textColumn, dimensions) => {
+    const params = new URLSearchParams({
+      dataset: datasetId,
+      model_id: modelId,
+      text_column: textColumn,
+      ...(dimensions ? { dimensions } : {}),
+    });
+    return fetch(`${apiUrl}/estimate/embed?${params}`).then((response) => response.json());
+  },
+  estimateUmap: async (datasetId, embeddingId, neighbors) => {
+    const params = new URLSearchParams({
+      dataset: datasetId,
+      embedding_id: embeddingId,
+      ...(neighbors ? { neighbors } : {}),
+    });
+    return fetch(`${apiUrl}/estimate/umap?${params}`).then((response) => response.json());
+  },
+  estimateCluster: async (datasetId, umapId) => {
+    const params = new URLSearchParams({
+      dataset: datasetId,
+      umap_id: umapId,
+    });
+    return fetch(`${apiUrl}/estimate/cluster?${params}`).then((response) => response.json());
+  },
+  benchmarkEmbed: async (datasetId, modelId, textColumn, sampleSize = 10, dimensions) => {
+    const params = new URLSearchParams({
+      dataset: datasetId,
+      model_id: modelId,
+      text_column: textColumn,
+      sample_size: sampleSize,
+      ...(dimensions ? { dimensions } : {}),
+    });
+    return fetch(`${apiUrl}/estimate/benchmark/embed?${params}`).then((response) =>
+      response.json()
+    );
+  },
 };


### PR DESCRIPTION
## Summary

Replaces HDF5-based embedding storage with LanceDB tables (Lance format v2.2), adds late interaction model support (ColBERT/ColPali), migration tooling, and compute/storage estimation endpoints.

### Embedding Storage Migration (HDF5 to LanceDB)
- New `embedding_store.py`: LanceDB-backed storage with dense and late interaction support
- Resumable batch writing, backward-compatible HDF5 fallback for reads
- Vector search with ANN index, late interaction search with MaxSim scoring
- **lancedb>=0.30** ensures Lance format v2.2 (automatic BSS + LZ4 compression, ~50% storage reduction)

### Migration Tooling
- `GET /datasets/:id/embeddings/:emb/format` returns `hdf5`/`lancedb`/`none`
- `POST /datasets/:id/embeddings/:emb/migrate` converts HDF5 to LanceDB with verification
- Migration verifies row count + spot-checks first/last vectors, then deletes HDF5 to free space
- Embedding setup page shows format badges (yellow HDF5 / green LanceDB) with migrate button
- CLI resume auto-migrates HDF5 to LanceDB before continuing
- **MIGRATIONS.md**: documents format versions, migration methods for humans and agents

### Late Interaction Model Support
- ColBERT and ColPali providers with `embed_multi()` returning mean + per-token vectors
- Updated embedding_models.json with ColBERT configurations

### Estimation API
- Time/storage estimates for embed, UMAP, cluster steps
- EstimatePanel frontend component integrated into Setup steps

### Dependency Ranges
- All Python deps use `>=min,<next_major` ranges (supply chain safety without exact-pin fragility)

## Test plan
- [ ] `python -m pytest tests/test_embedding_store.py` (requires lancedb)
- [ ] Embed a dataset: verify LanceDB table created in `lancedb/` dir
- [ ] Existing HDF5 embeddings load transparently (run UMAP on old embedding)
- [ ] Click "Migrate to LanceDB" on HDF5 embedding: verify conversion, HDF5 deleted, space reported
- [ ] Resume interrupted HDF5 embedding: auto-migrates then continues
- [ ] EstimatePanel visible in Embedding/UMAP/Cluster setup steps
- [ ] Search works on both old (HDF5 fallback) and new (LanceDB) embeddings

Supersedes #103 (closed).