### PR TITLE
Compare page interactions, EVoC fixes, filtered point highlighting

### DIFF
--- a/latentscope/scripts/cluster.py
+++ b/latentscope/scripts/cluster.py
@@ -172,16 +172,26 @@ def clusterer(dataset_id, umap_id, samples, min_samples, cluster_selection_epsil
     point_size = calculate_point_size(umap_embeddings.shape[0])
     print("POINT SIZE", point_size, "for", umap_embeddings.shape[0], "points")
     plt.scatter(umap_embeddings[:, 0], umap_embeddings[:, 1], s=point_size, alpha=0.5, c=cluster_labels, cmap='Spectral')
-    # plot a convex hull around each cluster
-    hulls = []
+    # Compute convex hulls around each cluster on the UMAP 2D coordinates.
+    # For HDBSCAN (which clusters on UMAP coords), hulls are spatially coherent.
+    # For EVoC (which clusters on raw embeddings), clusters may be scattered
+    # across the 2D projection, so convex hulls are not meaningful — skip them.
+    hulls_by_label = {}
+    compute_hulls = (method != 'evoc')
     for label in non_noise_labels:
         indices = np.where(cluster_labels == label)[0]
         points = umap_embeddings[indices]
-        hull = ConvexHull(points)
-        hull_list = [indices[s] for s in hull.vertices.tolist()]
-        hulls.append(hull_list)
-        for simplex in hull.simplices:
-            plt.plot(points[simplex, 0], points[simplex, 1], 'k-')
+        if not compute_hulls or len(points) < 3:
+            hulls_by_label[label] = []
+            continue
+        try:
+            hull = ConvexHull(points)
+            hull_list = [indices[s] for s in hull.vertices.tolist()]
+            hulls_by_label[label] = hull_list
+            for simplex in hull.simplices:
+                plt.plot(points[simplex, 0], points[simplex, 1], 'k-')
+        except Exception:
+            hulls_by_label[label] = []
 
     plt.axis('off')  # remove axis
     plt.gca().set_position([0, 0, 1, 1])  # remove margins
@@ -211,10 +221,11 @@ def clusterer(dataset_id, umap_id, samples, min_samples, cluster_selection_epsil
 
     # iterate over the clusters and create a row for each in a new dataframe with a label, description and array of indicies
     slides_df = pd.DataFrame(columns=['label', 'description', 'indices'])
-    for cluster, indices in tqdm(cluster_indices.items()):
-        label = f"Cluster {cluster}"
-        description = f"This is cluster {cluster} with {len(indices)} items."
-        new_row = pd.DataFrame({'label': [label], 'description': [description], 'indices': [list(indices)], 'hull': [hulls[cluster]]})
+    for cluster_label, indices in tqdm(cluster_indices.items()):
+        label = f"Cluster {cluster_label}"
+        description = f"This is cluster {cluster_label} with {len(indices)} items."
+        hull = hulls_by_label.get(cluster_label, [])
+        new_row = pd.DataFrame({'label': [label], 'description': [description], 'indices': [list(indices)], 'hull': [hull]})
         slides_df = pd.concat([slides_df, new_row], ignore_index=True)
 
     # write the df to parquet

--- a/latentscope/server/bulk.py
+++ b/latentscope/server/bulk.py
@@ -57,14 +57,28 @@ def change_cluster():
     df.to_parquet(scope_file)
     update_combined(DATA_DIR, df, dataset_id, scope_id)
 
+    # Only recompute hulls for methods that cluster on UMAP coordinates (not EVoC)
+    cluster_meta_file = os.path.join(DATA_DIR, dataset_id, "clusters",
+                                     scope_meta.get("cluster_id", "") + ".json")
+    skip_hulls = False
+    if os.path.exists(cluster_meta_file):
+        with open(cluster_meta_file) as cmf:
+            skip_hulls = json.load(cmf).get("method") == "evoc"
+
     for c in clusters:
-        indices = df[df['cluster'] == c["cluster"]]["ls_index"].tolist()
-        label_points = df[df['cluster'] == c["cluster"]][['x', 'y']].values
-        if len(label_points) > 0:
-            hull = ConvexHull(label_points)
-            c["hull"] = [indices[s] for s in hull.vertices.tolist()]
-        else:
+        if skip_hulls:
             c["hull"] = []
+        else:
+            indices = df[df['cluster'] == c["cluster"]]["ls_index"].tolist()
+            label_points = df[df['cluster'] == c["cluster"]][['x', 'y']].values
+            if len(label_points) > 0:
+                try:
+                    hull = ConvexHull(label_points)
+                    c["hull"] = [indices[s] for s in hull.vertices.tolist()]
+                except Exception:
+                    c["hull"] = []
+            else:
+                c["hull"] = []
 
     with open(scope_meta_file, "w") as f:
         json.dump(scope_meta, f, indent=2)
@@ -131,14 +145,25 @@ def delete_rows():
     with open(scope_meta_file) as f:
         scope_meta = json.load(f)
     clusters = scope_meta["cluster_labels_lookup"]
+
+    cluster_meta_file = os.path.join(DATA_DIR, dataset_id, "clusters",
+                                     scope_meta.get("cluster_id", "") + ".json")
+    skip_hulls = False
+    if os.path.exists(cluster_meta_file):
+        with open(cluster_meta_file) as cmf:
+            skip_hulls = json.load(cmf).get("method") == "evoc"
+
     for c in clusters:
-        indices = df[df['cluster'] == c["cluster"]]["ls_index"].tolist()
-        label_points = df[df['cluster'] == c["cluster"]][['x', 'y']].values
-        try:
-            hull = ConvexHull(label_points)
-            c["hull"] = [indices[s] for s in hull.vertices.tolist()]
-        except Exception:
+        if skip_hulls:
             c["hull"] = []
+        else:
+            indices = df[df['cluster'] == c["cluster"]]["ls_index"].tolist()
+            label_points = df[df['cluster'] == c["cluster"]][['x', 'y']].values
+            try:
+                hull = ConvexHull(label_points)
+                c["hull"] = [indices[s] for s in hull.vertices.tolist()]
+            except Exception:
+                c["hull"] = []
 
     scope_meta["rows"] = len(df)
     with open(scope_meta_file, "w") as f:

--- a/latentscope/server/jobs.py
+++ b/latentscope/server/jobs.py
@@ -471,19 +471,25 @@ def run_cluster():
     n_neighbors = request.args.get('n_neighbors')
     noise_level = request.args.get('noise_level')
 
-    err = _require_params(dataset=dataset, umap_id=umap_id, samples=samples,
-                          min_samples=min_samples,
-                          cluster_selection_epsilon=cluster_selection_epsilon)
+    err = _require_params(dataset=dataset, umap_id=umap_id, samples=samples)
     if err:
         return err
+
+    # min_samples and cluster_selection_epsilon are positional in the CLI
+    # Default them when not provided (EVoC doesn't use them)
+    if not min_samples or min_samples == 'null':
+        min_samples = '5'
+    if not cluster_selection_epsilon or cluster_selection_epsilon == 'null':
+        cluster_selection_epsilon = '0'
 
     job_id = str(uuid.uuid4())
     command = ['ls-cluster', dataset, umap_id, samples, min_samples,
                cluster_selection_epsilon, f'--method={method}']
-    if n_neighbors is not None:
-        command.append(f'--n_neighbors={n_neighbors}')
-    if noise_level is not None:
-        command.append(f'--noise_level={noise_level}')
+    if method == 'evoc':
+        if n_neighbors is not None:
+            command.append(f'--n_neighbors={n_neighbors}')
+        if noise_level is not None:
+            command.append(f'--noise_level={noise_level}')
     threading.Thread(target=run_job, args=(data_dir, dataset, job_id, command)).start()
     return jsonify({"job_id": job_id})
 

--- a/latentscope/server/search.py
+++ b/latentscope/server/search.py
@@ -233,6 +233,38 @@ def compare():
     return jsonify(result.tolist())
 
 
+@search_bp.route('/compare/neighbors', methods=['GET'])
+def compare_neighbors():
+    import numpy as np
+    import pandas as pd
+    from sklearn.neighbors import NearestNeighbors
+
+    DATA_DIR = _data_dir()
+    dataset = request.args.get('dataset')
+    umap_left = request.args.get('umap_left')
+    umap_right = request.args.get('umap_right')
+    point_index = int(request.args.get('point_index'))
+    side = request.args.get('side', 'left')
+    k = int(request.args.get('k', 10))
+
+    umap_dir = os.path.join(DATA_DIR, dataset, "umaps")
+    left = pd.read_parquet(os.path.join(umap_dir, f"{umap_left}.parquet")).to_numpy()
+    right = pd.read_parquet(os.path.join(umap_dir, f"{umap_right}.parquet")).to_numpy()
+
+    # Find k-NN based on which side was clicked
+    source = left if side == 'left' else right
+    nn = NearestNeighbors(n_neighbors=k + 1, algorithm='auto').fit(source)
+    _, indices = nn.kneighbors([source[point_index]])
+    # Remove the point itself from neighbors
+    neighbor_indices = [int(i) for i in indices[0] if i != point_index][:k]
+
+    return jsonify({
+        "point_index": point_index,
+        "side": side,
+        "neighbor_indices": neighbor_indices,
+    })
+
+
 @search_bp.route('/compare-clusters', methods=['GET'])
 def compare_clusters():
     import numpy as np

--- a/latentscope/server/search.py
+++ b/latentscope/server/search.py
@@ -253,6 +253,8 @@ def compare_neighbors():
 
     # Find k-NN based on which side was clicked
     source = left if side == 'left' else right
+    # Clamp k to dataset size to avoid sklearn error
+    k = min(k, len(source) - 1)
     nn = NearestNeighbors(n_neighbors=k + 1, algorithm='auto').fit(source)
     _, indices = nn.kneighbors([source[point_index]])
     # Remove the point itself from neighbors

--- a/web/src/components/Compare/Compare.module.css
+++ b/web/src/components/Compare/Compare.module.css
@@ -59,6 +59,13 @@
   color: #666;
 }
 
+.metric-description {
+  font-size: 0.75em;
+  color: #888;
+  line-height: 1.3;
+  max-width: 300px;
+}
+
 .metric-k {
   display: flex;
   flex-direction: column;
@@ -166,6 +173,57 @@
   font-weight: 600;
 }
 
+.neighbor-info {
+  font-size: 0.8em;
+  color: #4488ff;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.clear-neighbors {
+  padding: 1px 8px;
+  border: 1px solid #4488ff;
+  border-radius: 3px;
+  background: transparent;
+  color: #4488ff;
+  cursor: pointer;
+  font-size: 0.85em;
+}
+
+.clear-neighbors:hover {
+  background: #4488ff22;
+}
+
+/* Hover tooltip */
+.hover-tooltip {
+  max-width: 400px;
+  z-index: 1000;
+}
+
+.tooltip-loading {
+  font-size: 0.8em;
+  color: #aaa;
+  font-style: italic;
+}
+
+.tooltip-text {
+  font-size: 0.85em;
+  line-height: 1.3;
+  margin-bottom: 4px;
+}
+
+.tooltip-metric {
+  font-size: 0.75em;
+  color: #aaa;
+  font-family: monospace;
+}
+
+.tooltip-index {
+  font-size: 0.7em;
+  color: #888;
+}
+
 /* Shared scatter styles */
 .scatter-container {
   position: relative;
@@ -243,6 +301,64 @@
 
 .deselect:hover {
   background: #e0e0e0;
+}
+
+/* Neighbor list in data panel */
+.neighbor-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.neighbor-list-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid #ddd;
+  margin-bottom: 4px;
+  font-size: 0.9em;
+}
+
+.neighbor-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 4px 6px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 0.85em;
+  line-height: 1.4;
+}
+
+.neighbor-row:hover {
+  background: #f0f0f0;
+}
+
+.neighbor-badge {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  color: #fff;
+  font-size: 0.75em;
+  font-weight: bold;
+}
+
+.neighbor-index {
+  flex-shrink: 0;
+  color: #888;
+  font-family: monospace;
+  font-size: 0.8em;
+  min-width: 50px;
+}
+
+.neighbor-text {
+  color: #333;
+  overflow: hidden;
 }
 
 .search-box input[type='text'] {

--- a/web/src/components/Compare/CompareControls.jsx
+++ b/web/src/components/Compare/CompareControls.jsx
@@ -1,5 +1,20 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import styles from './Compare.module.css';
+
+const METRIC_INFO = {
+  displacement: {
+    label: 'Displacement (L2)',
+    description: 'Euclidean distance each point moved between the two UMAPs. High values mean the point landed in a very different position.',
+  },
+  neighborhood: {
+    label: 'Neighborhood Change',
+    description: 'Jaccard distance of each point\'s k nearest neighbors between the two UMAPs. High values mean the point\'s local neighborhood changed, regardless of global position.',
+  },
+  relative: {
+    label: 'Relative Displacement',
+    description: 'How much a point moved relative to its neighbors. High values mean the point moved away from its neighbors (not just with them).',
+  },
+};
 
 function CompareControls({
   dataset,
@@ -63,10 +78,13 @@ function CompareControls({
         <div className={styles['metric-selector']}>
           <label>Metric</label>
           <select value={metric} onChange={(e) => onMetricChange(e.target.value)}>
-            <option value="displacement">Displacement (L2)</option>
-            <option value="neighborhood">Neighborhood Change</option>
-            <option value="relative">Relative Displacement</option>
+            {Object.entries(METRIC_INFO).map(([key, info]) => (
+              <option key={key} value={key}>{info.label}</option>
+            ))}
           </select>
+          <span className={styles['metric-description']}>
+            {METRIC_INFO[metric]?.description}
+          </span>
         </div>
         {metric !== 'displacement' && (
           <div className={styles['metric-k']}>

--- a/web/src/components/Compare/CompareDataPanel.jsx
+++ b/web/src/components/Compare/CompareDataPanel.jsx
@@ -1,4 +1,6 @@
-import { useState, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import { scaleOrdinal } from 'd3-scale';
+import { schemeTableau10 } from 'd3-scale-chromatic';
 import IndexDataTable from '../IndexDataTable';
 import styles from './Compare.module.css';
 
@@ -9,11 +11,15 @@ const tabs = [
   { id: 1, name: 'Search' },
 ];
 
+const neighborColorScale = scaleOrdinal(schemeTableau10);
+
 function CompareDataPanel({
   dataset,
   datasetId,
   embeddings,
   selectedIndices,
+  neighborSelectedIndex,
+  neighborIndices,
   onClearSelection,
   searchIndices,
   distances,
@@ -26,6 +32,13 @@ function CompareDataPanel({
 }) {
   const [activeTab, setActiveTab] = useState(0);
 
+  // Auto-switch to Selected tab when neighbors are selected
+  useEffect(() => {
+    if (neighborSelectedIndex != null) {
+      setActiveTab(0);
+    }
+  }, [neighborSelectedIndex]);
+
   const handleSearchSubmit = useCallback(
     (e) => {
       e.preventDefault();
@@ -35,6 +48,8 @@ function CompareDataPanel({
     },
     [onSearch]
   );
+
+  const isNeighborMode = neighborSelectedIndex != null && neighborIndices?.length > 0;
 
   return (
     <div className={styles['data-panel']}>
@@ -46,28 +61,66 @@ function CompareDataPanel({
             className={tab.id === activeTab ? styles['tab-active'] : styles['tab-inactive']}
           >
             {tab.name}
+            {tab.id === 0 && isNeighborMode && ` (${1 + neighborIndices.length})`}
           </button>
         ))}
       </div>
 
       {activeTab === 0 && (
         <div className={styles['tab-content']}>
-          <span>
-            Selected: {selectedIndices?.length || 0}
-            {selectedIndices?.length > 0 && (
-              <button className={styles['deselect']} onClick={onClearSelection}>
-                X
-              </button>
-            )}
-          </span>
-          {selectedIndices?.length > 0 && (
-            <IndexDataTable
-              indices={selectedIndices}
-              dataset={dataset}
-              maxRows={150}
-              onHover={onHover}
-              onClick={onClick}
-            />
+          {isNeighborMode ? (
+            <div className={styles['neighbor-list']}>
+              <div className={styles['neighbor-list-header']}>
+                <span>
+                  Selected point + {neighborIndices.length} neighbors
+                </span>
+                <button className={styles['deselect']} onClick={onClearSelection}>
+                  X
+                </button>
+              </div>
+              {/* Selected point */}
+              <NeighborRow
+                index={neighborSelectedIndex}
+                rank={null}
+                dataset={dataset}
+                datasetId={datasetId}
+                onHover={onHover}
+                onClick={onClick}
+                isSelected
+              />
+              {/* Neighbor rows */}
+              {neighborIndices.map((idx, rank) => (
+                <NeighborRow
+                  key={idx}
+                  index={idx}
+                  rank={rank}
+                  dataset={dataset}
+                  datasetId={datasetId}
+                  onHover={onHover}
+                  onClick={onClick}
+                />
+              ))}
+            </div>
+          ) : (
+            <>
+              <span>
+                Selected: {selectedIndices?.length || 0}
+                {selectedIndices?.length > 0 && (
+                  <button className={styles['deselect']} onClick={onClearSelection}>
+                    X
+                  </button>
+                )}
+              </span>
+              {selectedIndices?.length > 0 && (
+                <IndexDataTable
+                  indices={selectedIndices}
+                  dataset={dataset}
+                  maxRows={150}
+                  onHover={onHover}
+                  onClick={onClick}
+                />
+              )}
+            </>
           )}
         </div>
       )}
@@ -119,6 +172,50 @@ function CompareDataPanel({
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * A single row showing a neighbor (or selected point) with rank badge and text preview.
+ */
+function NeighborRow({ index, rank, dataset, datasetId, onHover, onClick, isSelected }) {
+  const [text, setText] = useState(null);
+
+  useEffect(() => {
+    if (index == null || !datasetId) return;
+    fetch(`${apiUrl}/query`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dataset: datasetId, indices: [index], page: 0 }),
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        const t = data.rows?.[0]?.[dataset?.text_column];
+        setText(t);
+      })
+      .catch(() => setText(null));
+  }, [index, datasetId, dataset]);
+
+  const color = isSelected ? '#4488ff' : neighborColorScale(rank);
+
+  return (
+    <div
+      className={styles['neighbor-row']}
+      onMouseEnter={() => onHover && onHover(index)}
+      onMouseLeave={() => onHover && onHover(null)}
+      onClick={() => onClick && onClick(index)}
+    >
+      <span
+        className={styles['neighbor-badge']}
+        style={{ backgroundColor: color }}
+      >
+        {isSelected ? '★' : rank + 1}
+      </span>
+      <span className={styles['neighbor-index']}>#{index}</span>
+      <span className={styles['neighbor-text']}>
+        {text ? (text.length > 150 ? text.slice(0, 150) + '...' : text) : '...'}
+      </span>
     </div>
   );
 }

--- a/web/src/components/Compare/CrosshairPlot.jsx
+++ b/web/src/components/Compare/CrosshairPlot.jsx
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from 'react';
+import { scaleLinear } from 'd3-scale';
+import '../AnnotationPlot.css';
+
+/**
+ * Canvas overlay that draws a blue dotted crosshair (full-width horizontal
+ * and vertical lines) with a small blue circle at the intersection.
+ * Used for hover/click indication on the Compare scatter views.
+ */
+function CrosshairPlot({ point, xDomain, yDomain, width, height }) {
+  const canvasRef = useRef();
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, width, height);
+
+    if (!point || !xDomain || !yDomain) return;
+
+    const xScale = scaleLinear().domain(xDomain).range([0, width]);
+    const yScale = scaleLinear().domain(yDomain).range([height, 0]);
+
+    const px = xScale(point[0]);
+    const py = yScale(point[1]);
+
+    // Dotted crosshair lines
+    ctx.setLineDash([4, 4]);
+    ctx.strokeStyle = '#4488ff';
+    ctx.lineWidth = 1;
+    ctx.globalAlpha = 0.7;
+
+    // Vertical line
+    ctx.beginPath();
+    ctx.moveTo(px, 0);
+    ctx.lineTo(px, height);
+    ctx.stroke();
+
+    // Horizontal line
+    ctx.beginPath();
+    ctx.moveTo(0, py);
+    ctx.lineTo(width, py);
+    ctx.stroke();
+
+    // Blue circle at intersection
+    ctx.setLineDash([]);
+    ctx.globalAlpha = 0.9;
+    ctx.strokeStyle = '#4488ff';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(px, py, 6, 0, 2 * Math.PI);
+    ctx.stroke();
+
+    ctx.globalAlpha = 0.3;
+    ctx.fillStyle = '#4488ff';
+    ctx.fill();
+  }, [point, xDomain, yDomain, width, height]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="annotation-plot"
+      width={width}
+      height={height}
+    />
+  );
+}
+
+export default CrosshairPlot;

--- a/web/src/components/Compare/NeighborPlot.jsx
+++ b/web/src/components/Compare/NeighborPlot.jsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef } from 'react';
+import { scaleLinear, scaleOrdinal } from 'd3-scale';
+import { schemeTableau10 } from 'd3-scale-chromatic';
+import '../AnnotationPlot.css';
+
+/**
+ * Canvas overlay that draws k nearest neighbors as colored circles,
+ * each with a unique color from a d3 categorical scale.
+ * Also draws the selected point as a larger blue circle.
+ */
+function NeighborPlot({
+  points,
+  selectedIndex,
+  neighborIndices,
+  xDomain,
+  yDomain,
+  width,
+  height,
+}) {
+  const canvasRef = useRef();
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, width, height);
+
+    if (!points?.length || !xDomain || !yDomain) return;
+    if (selectedIndex == null && (!neighborIndices || !neighborIndices.length)) return;
+
+    const xScale = scaleLinear().domain(xDomain).range([0, width]);
+    const yScale = scaleLinear().domain(yDomain).range([height, 0]);
+
+    const colorScale = scaleOrdinal(schemeTableau10);
+
+    // Draw neighbor circles with unique colors
+    if (neighborIndices) {
+      neighborIndices.forEach((idx, rank) => {
+        const pt = points[idx];
+        if (!pt) return;
+        const px = xScale(pt[0]);
+        const py = yScale(pt[1]);
+        const color = colorScale(rank);
+
+        // Filled circle
+        ctx.globalAlpha = 0.85;
+        ctx.fillStyle = color;
+        ctx.beginPath();
+        ctx.arc(px, py, 5, 0, 2 * Math.PI);
+        ctx.fill();
+
+        // Border
+        ctx.globalAlpha = 1;
+        ctx.strokeStyle = '#fff';
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+
+        // Rank label
+        ctx.globalAlpha = 1;
+        ctx.fillStyle = '#fff';
+        ctx.font = '9px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(rank + 1, px, py);
+      });
+    }
+
+    // Draw selected point
+    if (selectedIndex != null) {
+      const pt = points[selectedIndex];
+      if (pt) {
+        const px = xScale(pt[0]);
+        const py = yScale(pt[1]);
+
+        // Crosshair
+        ctx.setLineDash([4, 4]);
+        ctx.strokeStyle = '#4488ff';
+        ctx.lineWidth = 1;
+        ctx.globalAlpha = 0.5;
+        ctx.beginPath();
+        ctx.moveTo(px, 0);
+        ctx.lineTo(px, height);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.moveTo(0, py);
+        ctx.lineTo(width, py);
+        ctx.stroke();
+
+        // Circle
+        ctx.setLineDash([]);
+        ctx.globalAlpha = 1;
+        ctx.strokeStyle = '#4488ff';
+        ctx.lineWidth = 2.5;
+        ctx.beginPath();
+        ctx.arc(px, py, 8, 0, 2 * Math.PI);
+        ctx.stroke();
+        ctx.globalAlpha = 0.3;
+        ctx.fillStyle = '#4488ff';
+        ctx.fill();
+      }
+    }
+  }, [points, selectedIndex, neighborIndices, xDomain, yDomain, width, height]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="annotation-plot"
+      width={width}
+      height={height}
+    />
+  );
+}
+
+export default NeighborPlot;

--- a/web/src/components/Compare/SideBySideView.jsx
+++ b/web/src/components/Compare/SideBySideView.jsx
@@ -1,28 +1,38 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { interpolateReds } from 'd3-scale-chromatic';
+import { Tooltip } from 'react-tooltip';
 import Scatter from '../Scatter';
 import AnnotationPlot from '../AnnotationPlot';
+import CrosshairPlot from './CrosshairPlot';
+import NeighborPlot from './NeighborPlot';
 import styles from './Compare.module.css';
 
 const isIOS = () => /iPhone|iPad|iPod/i.test(navigator.userAgent);
 
+const apiUrl = import.meta.env.VITE_API_URL;
+
 function SideBySideView({
+  datasetId,
+  dataset,
+  left,
+  right,
   leftPoints,
   rightPoints,
   drawPoints,
+  displacementData,
   width,
   height,
   onScatter,
   onSelect,
   onHover,
-  searchAnnotations,
-  hoverAnnotations,
+  onNeighborSelect,
   pointSizeRange,
   opacityRange,
   hoveredIndex,
+  metricK,
 }) {
-  const [leftScatter, setLeftScatter] = useState(null);
-  const [rightScatter, setRightScatter] = useState(null);
+  const leftScatterRef = useRef(null);
+  const rightScatterRef = useRef(null);
   const [linkZoom, setLinkZoom] = useState(true);
 
   const [leftXDomain, setLeftXDomain] = useState([-1, 1]);
@@ -30,39 +40,53 @@ function SideBySideView({
   const [rightXDomain, setRightXDomain] = useState([-1, 1]);
   const [rightYDomain, setRightYDomain] = useState([-1, 1]);
 
-  // Track which side initiated zoom to avoid infinite loops
   const zoomSourceRef = useRef(null);
 
+  // Click/neighbor state
+  const [clickedIndex, setClickedIndex] = useState(null);
+  const [clickedSide, setClickedSide] = useState(null);
+  const [neighborIndices, setNeighborIndices] = useState([]);
+
+  // Hover tooltip state
+  const [hoverText, setHoverText] = useState(null);
+  const [hoverLoading, setHoverLoading] = useState(false);
+  const hoverFetchRef = useRef(0);
+
   // Build display points for each side
-  const [leftDisplayPoints, setLeftDisplayPoints] = useState([]);
-  const [rightDisplayPoints, setRightDisplayPoints] = useState([]);
-
-  useEffect(() => {
-    if (!drawPoints?.length || !leftPoints?.length) return;
-    setLeftDisplayPoints(
-      leftPoints.map((p, i) => {
-        const dp = drawPoints[i];
-        return [p[0], p[1], dp ? dp[2] : 0, dp ? dp[3] : 0];
-      })
-    );
-  }, [leftPoints, drawPoints]);
-
-  useEffect(() => {
-    if (!drawPoints?.length || !rightPoints?.length) return;
-    setRightDisplayPoints(
-      rightPoints.map((p, i) => {
-        const dp = drawPoints[i];
-        return [p[0], p[1], dp ? dp[2] : 0, dp ? dp[3] : 0];
-      })
-    );
-  }, [rightPoints, drawPoints]);
-
-  // Expose the left scatter as the primary scatter for selection/zoom-to-points
-  useEffect(() => {
-    if (leftScatter) {
-      onScatter && onScatter(leftScatter);
+  const leftDisplayPoints = useMemo(() => {
+    if (!drawPoints?.length || !leftPoints?.length) return [];
+    // When in neighbor mode, dim all metric points
+    if (clickedIndex != null) {
+      return leftPoints.map((p) => [p[0], p[1], 0, 0]);
     }
-  }, [leftScatter, onScatter]);
+    return leftPoints.map((p, i) => {
+      const dp = drawPoints[i];
+      return [p[0], p[1], dp ? dp[2] : 0, dp ? dp[3] : 0];
+    });
+  }, [leftPoints, drawPoints, clickedIndex]);
+
+  const rightDisplayPoints = useMemo(() => {
+    if (!drawPoints?.length || !rightPoints?.length) return [];
+    if (clickedIndex != null) {
+      return rightPoints.map((p) => [p[0], p[1], 0, 0]);
+    }
+    return rightPoints.map((p, i) => {
+      const dp = drawPoints[i];
+      return [p[0], p[1], dp ? dp[2] : 0, dp ? dp[3] : 0];
+    });
+  }, [rightPoints, drawPoints, clickedIndex]);
+
+  const handleLeftScatter = useCallback(
+    (s) => {
+      leftScatterRef.current = s;
+      onScatter && onScatter(s);
+    },
+    [onScatter]
+  );
+
+  const handleRightScatter = useCallback((s) => {
+    rightScatterRef.current = s;
+  }, []);
 
   const handleLeftView = useCallback(
     (xd, yd) => {
@@ -72,21 +96,20 @@ function SideBySideView({
         zoomSourceRef.current = 'left';
         setRightXDomain(xd);
         setRightYDomain(yd);
-        if (rightScatter) {
-          const padding = 0.0;
-          rightScatter.zoomToArea({
-            x: xd[0] - padding,
-            y: yd[0] - padding,
-            width: xd[1] - xd[0] + padding * 2,
-            height: yd[1] - yd[0] + padding * 2,
-          });
-        }
+        try {
+          rightScatterRef.current?.zoomToArea({
+            x: xd[0],
+            y: yd[0],
+            width: xd[1] - xd[0],
+            height: yd[1] - yd[0],
+          })?.catch?.(() => {});
+        } catch (e) { /* scatter not ready yet */ }
         setTimeout(() => {
           zoomSourceRef.current = null;
         }, 50);
       }
     },
-    [linkZoom, rightScatter]
+    [linkZoom]
   );
 
   const handleRightView = useCallback(
@@ -97,40 +120,125 @@ function SideBySideView({
         zoomSourceRef.current = 'right';
         setLeftXDomain(xd);
         setLeftYDomain(yd);
-        if (leftScatter) {
-          const padding = 0.0;
-          leftScatter.zoomToArea({
-            x: xd[0] - padding,
-            y: yd[0] - padding,
-            width: xd[1] - xd[0] + padding * 2,
-            height: yd[1] - yd[0] + padding * 2,
-          });
-        }
+        try {
+          leftScatterRef.current?.zoomToArea({
+            x: xd[0],
+            y: yd[0],
+            width: xd[1] - xd[0],
+            height: yd[1] - yd[0],
+          })?.catch?.(() => {});
+        } catch (e) { /* scatter not ready yet */ }
         setTimeout(() => {
           zoomSourceRef.current = null;
         }, 50);
       }
     },
-    [linkZoom, leftScatter]
+    [linkZoom]
   );
 
-  // Compute hover annotations for each side using their own points
-  const leftHoverAnnotations =
-    hoveredIndex != null && leftPoints[hoveredIndex]
-      ? [leftPoints[hoveredIndex]]
-      : [];
-  const rightHoverAnnotations =
-    hoveredIndex != null && rightPoints[hoveredIndex]
-      ? [rightPoints[hoveredIndex]]
-      : [];
+  // Fetch hover text for tooltip
+  useEffect(() => {
+    if (hoveredIndex == null || !dataset) {
+      setHoverText(null);
+      setHoverLoading(false);
+      return;
+    }
+    setHoverLoading(true);
+    const fetchId = ++hoverFetchRef.current;
+    fetch(`${apiUrl}/query`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dataset: datasetId, indices: [hoveredIndex], page: 0 }),
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        if (fetchId !== hoverFetchRef.current) return;
+        const text = data.rows?.[0]?.[dataset.text_column];
+        setHoverText(text);
+        setHoverLoading(false);
+      })
+      .catch(() => {
+        setHoverText(null);
+        setHoverLoading(false);
+      });
+  }, [hoveredIndex, datasetId, dataset]);
 
-  // Search annotations mapped to each side's coordinates
-  const leftSearchAnnotations = searchAnnotations
-    .map((_, i) => leftPoints[i])
-    .filter(Boolean);
-  const rightSearchAnnotations = searchAnnotations
-    .map((_, i) => rightPoints[i])
-    .filter(Boolean);
+  const clearNeighbors = useCallback(() => {
+    setClickedIndex(null);
+    setClickedSide(null);
+    setNeighborIndices([]);
+    onNeighborSelect && onNeighborSelect(null, []);
+  }, [onNeighborSelect]);
+
+  // Handle click on a scatter — toggle neighbor mode
+  const handleLeftClick = useCallback(
+    (indices) => {
+      if (!indices?.length) return;
+      const idx = indices[0];
+      if (clickedIndex === idx && clickedSide === 'left') {
+        clearNeighbors();
+        return;
+      }
+      setClickedIndex(idx);
+      setClickedSide('left');
+      fetch(
+        `${apiUrl}/search/compare/neighbors?dataset=${datasetId}&umap_left=${left.id}&umap_right=${right.id}&point_index=${idx}&side=left&k=${metricK}`
+      )
+        .then((r) => r.json())
+        .then((data) => {
+          setNeighborIndices(data.neighbor_indices);
+          onNeighborSelect && onNeighborSelect(idx, data.neighbor_indices);
+        });
+    },
+    [clickedIndex, clickedSide, datasetId, left, right, metricK, clearNeighbors, onNeighborSelect]
+  );
+
+  const handleRightClick = useCallback(
+    (indices) => {
+      if (!indices?.length) return;
+      const idx = indices[0];
+      if (clickedIndex === idx && clickedSide === 'right') {
+        clearNeighbors();
+        return;
+      }
+      setClickedIndex(idx);
+      setClickedSide('right');
+      fetch(
+        `${apiUrl}/search/compare/neighbors?dataset=${datasetId}&umap_left=${left.id}&umap_right=${right.id}&point_index=${idx}&side=right&k=${metricK}`
+      )
+        .then((r) => r.json())
+        .then((data) => {
+          setNeighborIndices(data.neighbor_indices);
+          onNeighborSelect && onNeighborSelect(idx, data.neighbor_indices);
+        });
+    },
+    [clickedIndex, clickedSide, datasetId, left, right, metricK, clearNeighbors, onNeighborSelect]
+  );
+
+  // Clear neighbor mode when UMAPs change
+  useEffect(() => {
+    setClickedIndex(null);
+    setClickedSide(null);
+    setNeighborIndices([]);
+  }, [left, right]);
+
+  // Hover crosshair points
+  const leftHoverPoint =
+    hoveredIndex != null && leftPoints[hoveredIndex] ? leftPoints[hoveredIndex] : null;
+  const rightHoverPoint =
+    hoveredIndex != null && rightPoints[hoveredIndex] ? rightPoints[hoveredIndex] : null;
+
+  // Clicked crosshair points
+  const leftClickedPoint =
+    clickedIndex != null && leftPoints[clickedIndex] ? leftPoints[clickedIndex] : null;
+  const rightClickedPoint =
+    clickedIndex != null && rightPoints[clickedIndex] ? rightPoints[clickedIndex] : null;
+
+  // Displacement value for hovered point
+  const hoveredDisplacement =
+    hoveredIndex != null && displacementData?.[hoveredIndex] != null
+      ? displacementData[hoveredIndex].toFixed(3)
+      : null;
 
   const halfWidth = Math.floor((width - 12) / 2);
 
@@ -145,12 +253,28 @@ function SideBySideView({
           />
           Link zoom
         </label>
+        {clickedIndex != null && (
+          <span className={styles['neighbor-info']}>
+            Showing k={metricK} neighbors from {clickedSide} map (point {clickedIndex})
+            <button
+              className={styles['clear-neighbors']}
+              onClick={clearNeighbors}
+            >
+              Clear
+            </button>
+          </span>
+        )}
         <span className={styles['side-label']}>← Left</span>
         <span className={styles['side-label']}>Right →</span>
       </div>
       <div className={styles['side-by-side-container']}>
+        {/* Left scatter */}
         <div className={styles['scatter-panel']}>
-          <div className={styles['scatter-container']} style={{ width: halfWidth, height }}>
+          <div
+            className={styles['scatter-container']}
+            style={{ width: halfWidth, height }}
+            data-tooltip-id="compare-hover-tooltip"
+          >
             {leftDisplayPoints.length > 0 && (
               <>
                 <div className={styles['scatter']}>
@@ -160,15 +284,15 @@ function SideBySideView({
                       duration={0}
                       pointScale={1}
                       pointSizeRange={pointSizeRange}
-                      opacityRange={opacityRange}
+                      opacityRange={clickedIndex != null ? [0.15, 0.15] : opacityRange}
                       width={halfWidth}
                       height={height}
                       colorScaleType="continuous"
                       colorInterpolator={interpolateReds}
                       opacityBy="valueA"
-                      onScatter={setLeftScatter}
+                      onScatter={handleLeftScatter}
                       onView={handleLeftView}
-                      onSelect={onSelect}
+                      onSelect={handleLeftClick}
                       onHover={onHover}
                     />
                   ) : (
@@ -183,22 +307,37 @@ function SideBySideView({
                     />
                   )}
                 </div>
-                <AnnotationPlot
-                  points={leftHoverAnnotations}
-                  stroke="black"
-                  fill="orange"
-                  size="16"
-                  xDomain={leftXDomain}
-                  yDomain={leftYDomain}
-                  width={halfWidth}
-                  height={height}
-                />
+                {clickedIndex != null ? (
+                  <NeighborPlot
+                    points={leftPoints}
+                    selectedIndex={clickedIndex}
+                    neighborIndices={neighborIndices}
+                    xDomain={leftXDomain}
+                    yDomain={leftYDomain}
+                    width={halfWidth}
+                    height={height}
+                  />
+                ) : (
+                  <CrosshairPlot
+                    point={leftHoverPoint}
+                    xDomain={leftXDomain}
+                    yDomain={leftYDomain}
+                    width={halfWidth}
+                    height={height}
+                  />
+                )}
               </>
             )}
           </div>
         </div>
+
+        {/* Right scatter */}
         <div className={styles['scatter-panel']}>
-          <div className={styles['scatter-container']} style={{ width: halfWidth, height }}>
+          <div
+            className={styles['scatter-container']}
+            style={{ width: halfWidth, height }}
+            data-tooltip-id="compare-hover-tooltip"
+          >
             {rightDisplayPoints.length > 0 && (
               <>
                 <div className={styles['scatter']}>
@@ -208,15 +347,15 @@ function SideBySideView({
                       duration={0}
                       pointScale={1}
                       pointSizeRange={pointSizeRange}
-                      opacityRange={opacityRange}
+                      opacityRange={clickedIndex != null ? [0.15, 0.15] : opacityRange}
                       width={halfWidth}
                       height={height}
                       colorScaleType="continuous"
                       colorInterpolator={interpolateReds}
                       opacityBy="valueA"
-                      onScatter={setRightScatter}
+                      onScatter={handleRightScatter}
                       onView={handleRightView}
-                      onSelect={onSelect}
+                      onSelect={handleRightClick}
                       onHover={onHover}
                     />
                   ) : (
@@ -231,21 +370,58 @@ function SideBySideView({
                     />
                   )}
                 </div>
-                <AnnotationPlot
-                  points={rightHoverAnnotations}
-                  stroke="black"
-                  fill="orange"
-                  size="16"
-                  xDomain={rightXDomain}
-                  yDomain={rightYDomain}
-                  width={halfWidth}
-                  height={height}
-                />
+                {clickedIndex != null ? (
+                  <NeighborPlot
+                    points={rightPoints}
+                    selectedIndex={clickedIndex}
+                    neighborIndices={neighborIndices}
+                    xDomain={rightXDomain}
+                    yDomain={rightYDomain}
+                    width={halfWidth}
+                    height={height}
+                  />
+                ) : (
+                  <CrosshairPlot
+                    point={rightHoverPoint}
+                    xDomain={rightXDomain}
+                    yDomain={rightYDomain}
+                    width={halfWidth}
+                    height={height}
+                  />
+                )}
               </>
             )}
           </div>
         </div>
       </div>
+
+      <Tooltip
+        id="compare-hover-tooltip"
+        isOpen={hoveredIndex != null && clickedIndex == null}
+        float={true}
+        offset={15}
+        className={styles['hover-tooltip']}
+        noArrow
+      >
+        {hoverLoading && !hoverText && (
+          <div className={styles['tooltip-loading']}>Loading...</div>
+        )}
+        {hoverText && (
+          <div className={styles['tooltip-text']}>
+            {hoverText.length > 200 ? hoverText.slice(0, 200) + '...' : hoverText}
+          </div>
+        )}
+        {hoveredDisplacement != null && (
+          <div className={styles['tooltip-metric']}>
+            Metric: {hoveredDisplacement}
+          </div>
+        )}
+        {hoveredIndex != null && (
+          <div className={styles['tooltip-index']}>
+            Point {hoveredIndex}
+          </div>
+        )}
+      </Tooltip>
     </div>
   );
 }

--- a/web/src/components/Explore/FilteredPointsOverlay.jsx
+++ b/web/src/components/Explore/FilteredPointsOverlay.jsx
@@ -1,0 +1,70 @@
+import { useEffect, useRef, useMemo } from 'react';
+import { scaleLinear } from 'd3-scale';
+import '../AnnotationPlot.css';
+
+/**
+ * Canvas overlay that draws slightly larger green dots for all filtered points
+ * (the full set, not just the paginated table rows).
+ * Only renders when a filter is active and there are more filtered points
+ * than the shown (table) subset.
+ */
+function FilteredPointsOverlay({
+  scopeRows,
+  filteredIndices,
+  shownIndices,
+  xDomain,
+  yDomain,
+  width,
+  height,
+}) {
+  const canvasRef = useRef();
+
+  // Build the set of indices to highlight: filteredIndices minus shownIndices
+  // (shownIndices already have numbered labels, so we skip those)
+  const highlightIndices = useMemo(() => {
+    if (!filteredIndices?.length) return [];
+    const shownSet = new Set(shownIndices || []);
+    return filteredIndices.filter((i) => !shownSet.has(i));
+  }, [filteredIndices, shownIndices]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, width, height);
+
+    if (!highlightIndices.length || !xDomain || !yDomain || !scopeRows?.length) return;
+
+    const xScale = scaleLinear().domain(xDomain).range([0, width]);
+    const yScale = scaleLinear().domain(yDomain).range([height, 0]);
+
+    ctx.fillStyle = '#5cb85c';
+    ctx.globalAlpha = 0.6;
+
+    const r = 3;
+    for (let j = 0; j < highlightIndices.length; j++) {
+      const row = scopeRows[highlightIndices[j]];
+      if (!row || row.deleted) continue;
+      const px = xScale(row.x);
+      const py = yScale(row.y);
+      // Skip points outside viewport
+      if (px < -r || px > width + r || py < -r || py > height + r) continue;
+      ctx.beginPath();
+      ctx.arc(px, py, r, 0, 2 * Math.PI);
+      ctx.fill();
+    }
+  }, [highlightIndices, scopeRows, xDomain, yDomain, width, height]);
+
+  if (!highlightIndices.length) return null;
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="annotation-plot"
+      width={width}
+      height={height}
+    />
+  );
+}
+
+export default FilteredPointsOverlay;

--- a/web/src/components/Explore/VisualizationPane.jsx
+++ b/web/src/components/Explore/VisualizationPane.jsx
@@ -54,7 +54,8 @@ function VisualizationPane({
 }) {
   const { scopeRows, clusterLabels, clusterMap, deletedIndices, scope, features } = useScope();
 
-  const { featureFilter, clusterFilter, shownIndices, filteredIndices, filterConfig } = useFilter();
+  const { featureFilter, clusterFilter, shownIndices, filteredIndices, filterConfig, filterActive } =
+    useFilter();
 
   // only show the hull if we are filtering by cluster
   const showHull = filterConfig?.type === filterConstants.CLUSTER;
@@ -301,15 +302,17 @@ function VisualizationPane({
           />
         )}
         {/* green dots for all filtered points beyond the table page */}
-        <FilteredPointsOverlay
-          scopeRows={scopeRows}
-          filteredIndices={filteredIndices}
-          shownIndices={shownIndices}
-          xDomain={xDomain}
-          yDomain={yDomain}
-          width={width}
-          height={height}
-        />
+        {filterActive && (
+          <FilteredPointsOverlay
+            scopeRows={scopeRows}
+            filteredIndices={filteredIndices}
+            shownIndices={shownIndices}
+            xDomain={xDomain}
+            yDomain={yDomain}
+            width={width}
+            height={height}
+          />
+        )}
         {/* show all the hulls */}
         {vizConfig.showClusterOutlines && hulls.length && (
           <HullPlot

--- a/web/src/components/Explore/VisualizationPane.jsx
+++ b/web/src/components/Explore/VisualizationPane.jsx
@@ -10,6 +10,7 @@ import TilePlot from '../TilePlot';
 import { Tooltip } from 'react-tooltip';
 import CrossHair from './Crosshair';
 import { processHulls } from './util';
+import FilteredPointsOverlay from './FilteredPointsOverlay';
 import PointLabel from './PointLabel';
 import { filterConstants } from './Search/utils';
 
@@ -53,7 +54,7 @@ function VisualizationPane({
 }) {
   const { scopeRows, clusterLabels, clusterMap, deletedIndices, scope, features } = useScope();
 
-  const { featureFilter, clusterFilter, shownIndices, filterConfig } = useFilter();
+  const { featureFilter, clusterFilter, shownIndices, filteredIndices, filterConfig } = useFilter();
 
   // only show the hull if we are filtering by cluster
   const showHull = filterConfig?.type === filterConstants.CLUSTER;
@@ -299,6 +300,16 @@ function VisualizationPane({
             isSmallScreen={isSmallScreen}
           />
         )}
+        {/* green dots for all filtered points beyond the table page */}
+        <FilteredPointsOverlay
+          scopeRows={scopeRows}
+          filteredIndices={filteredIndices}
+          shownIndices={shownIndices}
+          xDomain={xDomain}
+          yDomain={yDomain}
+          width={width}
+          height={height}
+        />
         {/* show all the hulls */}
         {vizConfig.showClusterOutlines && hulls.length && (
           <HullPlot
@@ -317,7 +328,7 @@ function VisualizationPane({
             height={height}
           />
         )}
-        {hoveredCluster && hoveredHulls && scope.cluster_labels_lookup && (
+        {hoveredCluster && hoveredHulls?.length > 0 && scope.cluster_labels_lookup && (
           <HullPlot
             hulls={hoveredHulls}
             fill="#8bcf66"
@@ -339,7 +350,7 @@ function VisualizationPane({
         {/* Cluster is selected via filter */}
         {showHull &&
           clusterFilter.cluster &&
-          clusterFilter.cluster.hull &&
+          clusterFilter.cluster.hull?.length > 0 &&
           !scope.ignore_hulls &&
           scope.cluster_labels_lookup && (
             <HullPlot

--- a/web/src/components/Explore/util.js
+++ b/web/src/components/Explore/util.js
@@ -1,8 +1,11 @@
 export function processHulls(labels, points, pointSelector = (d) => d) {
   if (!labels) return [];
-  return labels.map((d) => {
-    return d.hull.map((i) => pointSelector(points[i])).filter((d) => !!d);
-  });
+  return labels
+    .filter((d) => d.hull && d.hull.length > 0)
+    .map((d) => {
+      return d.hull.map((i) => pointSelector(points[i])).filter((d) => !!d);
+    })
+    .filter((d) => d.length > 0);
 }
 
 // let's warn mobile users (on demo in read-only) that desktop is better experience

--- a/web/src/components/HullPlot.jsx
+++ b/web/src/components/HullPlot.jsx
@@ -91,7 +91,8 @@ const HullPlot = ({
   };
 
   useEffect(() => {
-    if (!xDomain || !yDomain || !hulls.length) return;
+    const validHulls = hulls.filter((h) => h && h.length > 0);
+    if (!xDomain || !yDomain || !validHulls.length) return;
 
     // console.log("NO PRE HULLS CURRENT", !prevHulls.current)
     const hullsChanged =
@@ -266,7 +267,7 @@ const HullPlot = ({
 
   // This effect will rerender instantly when the fill, stroke, strokeWidth, or domain changes
   useEffect(() => {
-    if (!xDomain || !yDomain || !hulls.length) return;
+    if (!xDomain || !yDomain || !hulls.filter((h) => h && h.length > 0).length) return;
     const svg = select(svgRef.current);
 
     // Calculate scale factors

--- a/web/src/components/Scatter.jsx
+++ b/web/src/components/Scatter.jsx
@@ -10,7 +10,6 @@ import {
   interpolateReds,
   interpolateOranges,
 } from 'd3-scale-chromatic';
-// import { SELECT } from '../pages/FullScreenExplore';
 
 import styles from './Scatter.module.css';
 
@@ -34,15 +33,15 @@ ScatterPlot.propTypes = {
 };
 
 const calculatePointSize = (numPoints) => {
-  const minPoints = 100; // Minimum number of points to start scaling
+  const minPoints = 100;
   const maxPoints = 1000000;
-  const minSize = 6; // Minimum size of points
-  const maxSize = 1; // Maximum size of points when number of points is very large
+  const minSize = 6;
+  const maxSize = 1;
   const scale = scaleLog().domain([minPoints, maxPoints]).range([minSize, maxSize]).clamp(true);
   return scale(numPoints);
 };
 const calculatePointOpacity = (numPoints) => {
-  const minPoints = 100; // Minimum number of points to start scaling
+  const minPoints = 100;
   const maxPoints = 1000000;
   const minOpacity = 0.2;
   const maxOpacity = 0.7;
@@ -60,7 +59,6 @@ function ScatterPlot({
   duration = 0,
   pointScale = 1,
   colorScaleType = null,
-  // colorInterpolator = interpolateCool,
   colorInterpolator = interpolateOranges,
   colorDomain = null,
   colorRange = null,
@@ -79,35 +77,39 @@ function ScatterPlot({
   const yDomain = useRef([-1, 1]);
   const scatterplotRef = useRef(null);
 
-  const handleMouseLeave = useCallback(() => {
-    onHover && onHover(null);
-  }, [onHover]);
+  // Store callbacks in refs so they never trigger effect re-runs.
+  // Recreating the scatterplot destroys the WebGL context and causes
+  // "double destroy texture" errors when the draw effect races cleanup.
+  const onScatterRef = useRef(onScatter);
+  const onViewRef = useRef(onView);
+  const onSelectRef = useRef(onSelect);
+  const onHoverRef = useRef(onHover);
+  onScatterRef.current = onScatter;
+  onViewRef.current = onView;
+  onSelectRef.current = onSelect;
+  onHoverRef.current = onHover;
 
-  // setup the scatterplot on first render
+  const handleMouseLeave = useCallback(() => {
+    onHoverRef.current && onHoverRef.current(null);
+  }, []);
+
+  // Setup the scatterplot — only recreate on true structural changes
   useEffect(() => {
-    // console.log('===setting up scatterplot===');
-    const xScale = scaleLinear()
-      // .domain(xDomain.current)
-      .domain([-1, 1]);
-    const yScale = scaleLinear()
-      // .domain(yDomain.current)
-      .domain([-1, 1]);
-    const scatterSettings = {
+    if (!container.current || !width || !height) return;
+
+    const xScale = scaleLinear().domain([-1, 1]);
+    const yScale = scaleLinear().domain([-1, 1]);
+    const scatterplot = createScatterplot({
       canvas: container.current,
       width,
       height,
       pointColorHover: [0.1, 0.1, 0.1, 0.5],
       xScale,
       yScale,
-    };
-    // console.log("creating scatterplot", xDomain.current)
-    const scatterplot = createScatterplot(scatterSettings);
+    });
     scatterplotRef.current = scatterplot;
 
-    // padding around the points and the border of the canvas
     const padding = 0.05;
-
-    // center the view on the canvas
     scatterplot.zoomToArea({
       x: -1 - padding,
       y: -1 - padding,
@@ -115,36 +117,32 @@ function ScatterPlot({
       height: 2 + padding * 2,
     });
 
-    onView && onView(xDomain.current, yDomain.current);
-    scatterplot.subscribe('view', ({ camera, view, xScale: xs, yScale: ys }) => {
+    onViewRef.current && onViewRef.current(xDomain.current, yDomain.current);
+    scatterplot.subscribe('view', ({ xScale: xs, yScale: ys }) => {
       xDomain.current = xs.domain();
       yDomain.current = ys.domain();
-      onView && onView(xDomain.current, yDomain.current);
+      onViewRef.current && onViewRef.current(xDomain.current, yDomain.current);
     });
     scatterplot.subscribe('select', ({ points }) => {
-      onSelect && onSelect(points);
+      onSelectRef.current && onSelectRef.current(points);
     });
     scatterplot.subscribe('deselect', () => {
-      onSelect && onSelect([]);
+      onSelectRef.current && onSelectRef.current([]);
     });
     scatterplot.subscribe('pointOver', (pointIndex) => {
-      onHover && onHover(pointIndex);
+      onHoverRef.current && onHoverRef.current(pointIndex);
     });
     scatterplot.subscribe('pointOut', () => {
-      onHover && onHover(null);
+      onHoverRef.current && onHoverRef.current(null);
     });
 
-    // const canvas = container.current;
-    // canvas.addEventListener('mouseleave', handleMouseLeave);
-
-    onScatter && onScatter(scatterplot);
+    onScatterRef.current && onScatterRef.current(scatterplot);
 
     return () => {
       scatterplotRef.current = null;
       scatterplot.destroy();
-      // canvas.removeEventListener('mouseleave', handleMouseLeave);
     };
-  }, [onScatter, onView, onSelect, onHover, width, height, activeFilterTab]);
+  }, [width, height, activeFilterTab]);
 
   const prevPointsRef = useRef();
   useEffect(() => {
@@ -153,16 +151,7 @@ function ScatterPlot({
     if (scatterplot && points && points.length) {
       const pointSize = calculatePointSize(points.length) * pointScale;
       const opacity = calculatePointOpacity(points.length);
-      // console.log("point size", pointSize, opacity)
-      // let pointColor = [250/255, 128/255, 114/255, 1] //salmon
-      let pointColor = [122 / 255, 217 / 255, 255 / 255, 1]; //salmon
-      // let pointColor = '#7AD9FF';
-
-      // 224, 239, 255
-
-      // let drawPoints = points
-      // let categories = points[0].length === 3 ? true : false
-      // console.log({ colorScaleType, colorDomain, colorRange });
+      let pointColor = [122 / 255, 217 / 255, 255 / 255, 1];
 
       if (colorScaleType === 'categorical') {
         let uniques = colorDomain;
@@ -177,7 +166,7 @@ function ScatterPlot({
         let domain = extent(uniques).reverse();
         if (!colorRange) {
           const colorScale = scaleSequential(colorInterpolator).domain(domain);
-          pointColor = range(uniques).map((u) => rgb(colorScale(u)).hex());
+          pointColor = uniques.map((u) => rgb(colorScale(u)).hex());
         } else {
           pointColor = colorRange;
         }
@@ -186,13 +175,10 @@ function ScatterPlot({
         let r = range(0, 50);
         const colorScale = scaleSequential(colorInterpolator).domain([0, 50]);
         pointColor = r.map((i) => rgb(colorScale(i)).hex());
-        // console.log('COLOR');
         scatterplot.set({ colorBy: 'valueB' });
-        // scatterplot.set({ colorBy: 'valueA' });
       }
 
       if (opacityBy) {
-        // console.log('OPACITY', opacityBy);
         scatterplot.set({
           opacityBy,
           sizeBy: opacityBy,
@@ -207,7 +193,6 @@ function ScatterPlot({
       }
       if (prevPoints && prevPoints.length === points.length) {
         scatterplot.draw(points, { transition: true, transitionDuration: duration }).then(() => {
-          // don't color till after
           scatterplot.set({
             pointColor: pointColor,
           });

--- a/web/src/components/Setup/Cluster.jsx
+++ b/web/src/components/Setup/Cluster.jsx
@@ -113,13 +113,14 @@ function Cluster() {
       const params = {
         umap_id: umap.id,
         samples: data.get('samples'),
-        min_samples: data.get('min_samples'),
-        cluster_selection_epsilon: data.get('cluster_selection_epsilon'),
         method,
       };
       if (method === 'evoc') {
         params.n_neighbors = data.get('n_neighbors');
         params.noise_level = data.get('noise_level');
+      } else {
+        params.min_samples = data.get('min_samples');
+        params.cluster_selection_epsilon = data.get('cluster_selection_epsilon');
       }
       startClusterJob(params);
     },

--- a/web/src/components/Setup/Preview.jsx
+++ b/web/src/components/Setup/Preview.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback, useMemo } from 'react';
 import { range } from 'd3-array';
-import { interpolatePurples } from 'd3-scale-chromatic';
+import { interpolatePurples, interpolateSpectral } from 'd3-scale-chromatic';
 
 import { Input, Button } from 'react-element-forge';
 import { Tooltip } from 'react-tooltip';
@@ -273,12 +273,14 @@ function Preview({ embedding, umap, cluster, labelId } = {}) {
   const [clusterLabels, setClusterLabels] = useState([]);
   const [clusterIndices, setClusterIndices] = useState([]);
   const [hulls, setHulls] = useState([]);
+  const [hasHulls, setHasHulls] = useState(false);
   useEffect(() => {
     if (cluster && drawPoints.length) {
       apiService.fetchClusterLabels(datasetId, cluster.id, labelId).then((data) => {
-        // console.log("cluster labels", data)
         setClusterLabelData(data);
-        setHulls(processHulls(data, drawPoints));
+        const processedHulls = processHulls(data, drawPoints);
+        setHulls(processedHulls);
+        setHasHulls(processedHulls.length > 0);
         let ci = [];
         let cl = [];
         let cm = {};
@@ -292,9 +294,15 @@ function Preview({ embedding, umap, cluster, labelId } = {}) {
         setClusterIndices(ci);
         setClusterLabels(cl);
         setClusterMap(cm);
+
+        // When there are no hulls (EVoC), color points by cluster ID
+        if (processedHulls.length === 0) {
+          const clusterPoints = drawPoints.map((d, i) => [d[0], d[1], ci[i] ?? 0]);
+          setDrawPoints(clusterPoints);
+        }
       });
     }
-  }, [datasetId, cluster, drawPoints, labelId]);
+  }, [datasetId, cluster, drawPoints.length, labelId]);
 
   const [pointSize, setPointSize] = useState(0.25);
   useEffect(() => {
@@ -365,11 +373,12 @@ function Preview({ embedding, umap, cluster, labelId } = {}) {
             height={umapHeight}
             duration={1000}
             colorScaleType="categorical"
-            colorRange={mapSelectionColorsLight}
-            colorDomain={mapSelectionDomain}
-            opacityRange={mapSelectionOpacity}
-            pointSizeRange={pointSizeRange}
-            opacityBy="valueA"
+            colorInterpolator={cluster && !hasHulls ? interpolateSpectral : undefined}
+            colorRange={cluster && !hasHulls ? undefined : mapSelectionColorsLight}
+            colorDomain={cluster && !hasHulls ? undefined : mapSelectionDomain}
+            opacityRange={cluster && !hasHulls ? undefined : mapSelectionOpacity}
+            pointSizeRange={cluster && !hasHulls ? undefined : pointSizeRange}
+            opacityBy={cluster && !hasHulls ? undefined : 'valueA'}
             onScatter={setScatter}
             onView={handleView}
             onSelect={handleSelected}

--- a/web/src/components/Setup/Umap.jsx
+++ b/web/src/components/Setup/Umap.jsx
@@ -274,6 +274,13 @@ function Umap({}) {
           </form>
         </div>
         {/* The list of available UMAPS */}
+        {umaps.filter((d) => d.embedding_id == embedding?.id).length >= 2 && (
+          <div style={{ padding: '4px 0', textAlign: 'center' }}>
+            <Link to={`/datasets/${dataset?.id}/compare`} style={{ color: 'seagreen', fontWeight: 600, textDecoration: 'none' }}>
+              ↗ Compare UMAPs
+            </Link>
+          </div>
+        )}
         <div className={styles['umap-list']}>
           {umaps
             .filter((d) => d.embedding_id == embedding?.id)
@@ -313,21 +320,12 @@ function Umap({}) {
                 <img src={um.url} alt={um.id} />
 
                 {um.align ? (
-                  <div>
-                    <Link to={`/datasets/${dataset?.id}/compare`}>↗ Compare Aligned UMAPs </Link>
-                    <span className="tooltip" data-tooltip-id="compare-umaps">
-                      🤔
-                    </span>
-                    <div className={styles['umap-align-list']}>
-                      {umaps
-                        .filter((d) => d.align_id == um.id && d.id != um.id)
-                        .map((d) => {
-                          return <img key={d.id} src={d.url} alt={d.id} />;
-                        })}
-                    </div>
-                    <Tooltip id="compare-umaps" place="top" effect="solid">
-                      An interface for comparing Aligned UMAPS.
-                    </Tooltip>
+                  <div className={styles['umap-align-list']}>
+                    {umaps
+                      .filter((d) => d.align_id == um.id && d.id != um.id)
+                      .map((d) => {
+                        return <img key={d.id} src={d.url} alt={d.id} />;
+                      })}
                   </div>
                 ) : null}
 

--- a/web/src/lib/colors.js
+++ b/web/src/lib/colors.js
@@ -13,8 +13,8 @@ export const baseColor = '#b87333';
 export const baseColorDark = '#E0EFFF';
 
 export const mapSelectionColorsLight = [
-  baseColor, // normaimage.pngl
-  baseColor, // selected
+  baseColor, // normal
+  '#5cb85c', // selected (green to stand out from base)
   baseColor, // not selected
   '#8bcf66', // hovered
   '#fcfbfd', // hidden
@@ -22,10 +22,10 @@ export const mapSelectionColorsLight = [
 
 export const mapSelectionColorsDark = [
   baseColorDark,
+  '#5cb85c', // selected (green)
   baseColorDark,
   baseColorDark,
-  baseColorDark,
-  '#fcfbfd', // 99, hidden
+  '#fcfbfd', // hidden
 ];
 
 export const mapSelectionOpacity = [

--- a/web/src/pages/Compare.jsx
+++ b/web/src/pages/Compare.jsx
@@ -39,11 +39,14 @@ function Compare() {
   const [aboveThresholdCount, setAboveThresholdCount] = useState(0);
 
   // Metric controls
-  const [metric, setMetric] = useState('displacement');
+  const [metric, setMetric] = useState('relative');
   const [metricK, setMetricK] = useState(10);
 
+  // Raw displacement data (before threshold) for tooltip display
+  const [rawDisplacementData, setRawDisplacementData] = useState([]);
+
   // View mode
-  const [viewMode, setViewMode] = useState('transition');
+  const [viewMode, setViewMode] = useState('side-by-side');
   const [direction, setDirection] = useState('left');
 
   // Scatterplot state
@@ -54,6 +57,10 @@ function Compare() {
   // Selection state
   const [selectedIndices, setSelectedIndices] = useState([]);
   const [hoveredIndex, setHoveredIndex] = useState(null);
+
+  // Neighbor selection state (from SideBySideView clicks)
+  const [neighborSelectedIndex, setNeighborSelectedIndex] = useState(null);
+  const [neighborIndices, setNeighborIndices] = useState([]);
 
   // Search state
   const [searchModel, setSearchModel] = useState(null);
@@ -141,6 +148,7 @@ function Compare() {
     )
       .then((r) => r.json())
       .then((displacementData) => {
+        setRawDisplacementData(displacementData);
         const log = scaleSymlog(extent(displacementData), [0, 1]);
         const dpts = leftPoints.map((d, i) => {
           const displacement = log(displacementData[i]);
@@ -191,6 +199,8 @@ function Compare() {
 
   const handleClearSelection = useCallback(() => {
     setSelectedIndices([]);
+    setNeighborSelectedIndex(null);
+    setNeighborIndices([]);
     scatter?.select([]);
     scatter?.zoomToOrigin({ transition: true, transitionDuration: 1500 });
   }, [scatter]);
@@ -242,6 +252,16 @@ function Compare() {
     setDistances([]);
   }, []);
 
+  const handleNeighborSelect = useCallback((pointIndex, neighbors) => {
+    setNeighborSelectedIndex(pointIndex);
+    setNeighborIndices(neighbors || []);
+    if (pointIndex != null) {
+      setSelectedIndices([pointIndex, ...(neighbors || [])]);
+    } else {
+      setSelectedIndices([]);
+    }
+  }, []);
+
   // Annotations
   const activePoints = direction === 'left' ? leftPoints : rightPoints;
   const searchAnnotations = searchIndices.map((i) => activePoints[i]).filter(Boolean);
@@ -250,6 +270,35 @@ function Compare() {
 
   const pointSizeRange = [5, 1];
   const opacityRange = [1, 0.2];
+
+  // Resizable bottom panel
+  const [panelHeight, setPanelHeight] = useState(200);
+  const isDraggingRef = useRef(false);
+  const dragStartYRef = useRef(0);
+  const dragStartHeightRef = useRef(0);
+
+  const handleDragStart = useCallback((e) => {
+    e.preventDefault();
+    isDraggingRef.current = true;
+    dragStartYRef.current = e.clientY;
+    dragStartHeightRef.current = panelHeight;
+
+    const handleDragMove = (e) => {
+      if (!isDraggingRef.current) return;
+      const delta = dragStartYRef.current - e.clientY;
+      const newHeight = Math.max(40, Math.min(600, dragStartHeightRef.current + delta));
+      setPanelHeight(newHeight);
+    };
+
+    const handleDragEnd = () => {
+      isDraggingRef.current = false;
+      document.removeEventListener('mousemove', handleDragMove);
+      document.removeEventListener('mouseup', handleDragEnd);
+    };
+
+    document.addEventListener('mousemove', handleDragMove);
+    document.addEventListener('mouseup', handleDragEnd);
+  }, [panelHeight]);
 
   if (!dataset) return <div>Loading...</div>;
 
@@ -314,39 +363,51 @@ function Compare() {
 
           {viewMode === 'side-by-side' && (
             <SideBySideView
+              datasetId={datasetId}
+              dataset={dataset}
+              left={left}
+              right={right}
               leftPoints={leftPoints}
               rightPoints={rightPoints}
               drawPoints={drawPoints}
+              displacementData={rawDisplacementData}
               width={scopeWidth}
               height={scopeHeight}
               onScatter={setScatter}
               onSelect={handleSelected}
               onHover={handleHover}
-              searchAnnotations={searchAnnotations}
-              hoverAnnotations={hoverAnnotations}
+              onNeighborSelect={handleNeighborSelect}
               pointSizeRange={pointSizeRange}
               opacityRange={opacityRange}
               hoveredIndex={hoveredIndex}
+              metricK={metricK}
             />
           )}
         </div>
       </div>
 
-      <CompareDataPanel
-        dataset={dataset}
-        datasetId={datasetId}
-        embeddings={embeddings}
-        selectedIndices={selectedIndices}
-        onClearSelection={handleClearSelection}
-        searchIndices={searchIndices}
-        distances={distances}
-        onClearSearch={handleClearSearch}
-        onSearch={handleSearch}
-        searchModel={searchModel}
-        onSearchModelChange={handleSearchModelChange}
-        onHover={handleHover}
-        onClick={handleClicked}
-      />
+      <div className={styles['drag-handle']} onMouseDown={handleDragStart}>
+        <div className={styles['drag-grip']} />
+      </div>
+      <div style={{ height: panelHeight, minHeight: 40 }}>
+        <CompareDataPanel
+          dataset={dataset}
+          datasetId={datasetId}
+          embeddings={embeddings}
+          selectedIndices={selectedIndices}
+          neighborSelectedIndex={neighborSelectedIndex}
+          neighborIndices={neighborIndices}
+          onClearSelection={handleClearSelection}
+          searchIndices={searchIndices}
+          distances={distances}
+          onClearSearch={handleClearSearch}
+          onSearch={handleSearch}
+          searchModel={searchModel}
+          onSearchModelChange={handleSearchModelChange}
+          onHover={handleHover}
+          onClick={handleClicked}
+        />
+      </div>
     </div>
   );
 }

--- a/web/src/pages/Compare.module.css
+++ b/web/src/pages/Compare.module.css
@@ -1,7 +1,7 @@
 .container {
-  display: grid;
-  grid-template-rows: auto 1fr auto;
-  gap: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
   height: 100%;
   overflow: hidden;
   padding: 6px;
@@ -13,6 +13,7 @@
   flex-direction: column;
   overflow: hidden;
   min-height: 0;
+  flex: 1;
 }
 
 .view-tabs {
@@ -49,11 +50,33 @@
   overflow: hidden;
 }
 
+/* Drag handle between visualization and data panel */
+.drag-handle {
+  height: 8px;
+  cursor: ns-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.drag-handle:hover .drag-grip,
+.drag-handle:active .drag-grip {
+  background: #aaa;
+}
+
+.drag-grip {
+  width: 40px;
+  height: 3px;
+  border-radius: 2px;
+  background: #ccc;
+  transition: background 0.15s;
+}
+
 /* Responsive */
 @media screen and (max-width: 1024px) {
   .container {
-    display: flex;
-    flex-direction: column;
     overflow-y: auto;
   }
 }
@@ -65,5 +88,14 @@
 
   .view-tab-inactive:hover {
     background: #333;
+  }
+
+  .drag-grip {
+    background: #555;
+  }
+
+  .drag-handle:hover .drag-grip,
+  .drag-handle:active .drag-grip {
+    background: #888;
   }
 }

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -1,8 +1,11 @@
 export function processHulls(labels, points, pointSelector = (d) => d) {
   if (!labels) return [];
-  return labels.map((d) => {
-    return d.hull.map((i) => pointSelector(points[i])).filter((d) => !!d);
-  });
+  return labels
+    .filter((d) => d.hull && d.hull.length > 0)
+    .map((d) => {
+      return d.hull.map((i) => pointSelector(points[i])).filter((d) => !!d);
+    })
+    .filter((d) => d.length > 0);
 }
 
 // let's warn mobile users (on demo in read-only) that desktop is better experience


### PR DESCRIPTION
## Summary

A collection of improvements spanning the Compare page, EVoC clustering, and the Explore page filtering UX.

### Compare Page (Side-by-Side view)
- **Defaults**: Side-by-side view with relative displacement metric
- **Crosshair hover**: Blue dotted crosshair follows the mouse (replaces orange circle), with floating tooltip showing text content + metric value
- **Click-to-explore neighbors**: Click a point to enter neighbor mode — dims the metric coloring and shows k-NN as numbered colored circles on both maps. Which map you click determines the neighbor definitions. Data panel shows ranked neighbor list with text previews.
- **Resizable bottom panel**: Drag handle to resize data panel height
- **Metric descriptions**: Inline explanation below dropdown for each metric mode
- **Backend**: New `GET /search/compare/neighbors` endpoint for k-NN queries
- **Scatter.jsx**: Callback refs prevent unnecessary WebGL destroy/recreate cycles

### EVoC Clustering Fixes
- **Skip convex hulls for EVoC**: EVoC clusters on high-dimensional embeddings, not 2D UMAP coords — convex hulls are meaningless (span entire plot). Hulls now skipped for EVoC, still computed for HDBSCAN.
- **Hull index bug**: Fixed positional array lookup that broke with non-contiguous cluster labels
- **Empty hull handling**: `processHulls()`, `HullPlot`, `VisualizationPane`, and `bulk.py` all gracefully handle empty hull arrays
- **Job dispatch**: Frontend no longer sends null HDBSCAN params for EVoC jobs
- **Preview cluster coloring**: When no hulls (EVoC), points colored by cluster ID using Spectral scale
- **Scatter categorical color fix**: `range(uniques)` → `uniques.map()` (was producing empty color array = black dots)

### Explore Page
- **Green filtered points**: Selected/filtered points now render green (`#5cb85c`) instead of same copper as base
- **FilteredPointsOverlay**: New canvas overlay draws green dots for ALL points matching the active filter (not just the ~20 in the table). Performant `arc()` loop with viewport culling.

### Setup Page
- Single "Compare UMAPs" link above the UMAP list (not repeated per item)
- Cluster page "Compare Clusters" link when ≥2 clusters exist

## Test plan
- [ ] Compare page: hover shows blue crosshair + tooltip with text
- [ ] Compare page: click a point → neighbors appear numbered on both maps, data panel shows list
- [ ] Compare page: click same point again to deselect, or click "Clear"
- [ ] Compare page: drag bottom panel handle to resize
- [ ] Compare page: metric dropdown shows descriptions
- [ ] EVoC clustering: re-run EVoC cluster → no hull outlines shown, points colored by cluster
- [ ] HDBSCAN clustering: hull outlines still render correctly
- [ ] Explore page: filter to a cluster → all cluster points show as green dots
- [ ] Explore page: green dots visible beyond the ~20 numbered labels
- [ ] Setup > UMAP: single "Compare UMAPs" link above list

🤖 Generated with [Claude Code](https://claude.com/claude-code)