### PR TITLE
Part 1: un-break the default pipeline + e2e tests

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -43,9 +43,11 @@ This file documents breaking changes to data formats and how to migrate between 
 - **CLI resume:** If you resume an interrupted HDF5 embedding via `ls-embed --rerun`, it automatically migrates the existing HDF5 data to LanceDB before continuing.
 
 **After migration:**
-- The HDF5 file is NOT deleted (safe to remove manually after verifying)
+- The migrated data is verified (row count + a random sample of vectors
+  compared against the source), then the HDF5 file is deleted to free space
+- If a migration is interrupted, re-running it detects the partial LanceDB
+  table, drops it, and migrates again from the intact HDF5 file
 - All downstream pipeline steps (UMAP, cluster, scope) work identically
-- Search uses LanceDB's native ANN index for faster queries
 
 **Agent instructions:**
 To check if a dataset needs migration, call `GET /datasets/{dataset}/embeddings/{embedding}/format`. The response includes `{"format": "hdf5"|"lancedb"|"none"}`. If `"hdf5"`, call `POST .../migrate` to convert. The metadata JSON file does not change — only the vector storage location moves.

--- a/latentscope/scripts/cluster.py
+++ b/latentscope/scripts/cluster.py
@@ -54,15 +54,11 @@ def main():
 
 
 def _load_embeddings(dataset_id, embedding_id):
-    """Load raw embedding vectors for a dataset."""
-    import h5py
-    import numpy as np
+    """Load raw embedding vectors for a dataset (LanceDB with HDF5 fallback)."""
+    from latentscope.util.embedding_store import load_embeddings
+
     DATA_DIR = get_data_dir()
-    emb_path = os.path.join(DATA_DIR, dataset_id, "embeddings", f"{embedding_id}.h5")
-    with h5py.File(emb_path, 'r') as f:
-        dataset = f["embeddings"]
-        embeddings = np.array(dataset)
-        return embeddings
+    return load_embeddings(DATA_DIR, dataset_id, embedding_id)
 
 
 def _run_evoc(embeddings, samples, n_neighbors=15, noise_level=0.5):

--- a/latentscope/scripts/embed.py
+++ b/latentscope/scripts/embed.py
@@ -72,6 +72,7 @@ def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_si
         append_embeddings,
         get_embedding_count,
         get_storage_format,
+        list_embedding_ids,
         migrate_hdf5_to_lancedb,
     )
     DATA_DIR = get_data_dir()
@@ -86,34 +87,35 @@ def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_si
         # Check LanceDB first, then fallback to HDF5
         fmt = get_storage_format(DATA_DIR, dataset_id, embedding_id)
         if fmt == "lancedb":
-            starting_batch = get_embedding_count(DATA_DIR, dataset_id, embedding_id) // batch_size
+            existing_count = get_embedding_count(DATA_DIR, dataset_id, embedding_id)
         elif fmt == "hdf5":
             # Migrate HDF5 to LanceDB before resuming so new batches go to same store
             print(f"Migrating {embedding_id} from HDF5 to LanceDB before resuming...")
             result = migrate_hdf5_to_lancedb(DATA_DIR, dataset_id, embedding_id,
                                              on_progress=lambda cur, tot: print(f"  migrated {cur}/{tot}"))
             print(f"Migration complete: {result}")
-            starting_batch = get_embedding_count(DATA_DIR, dataset_id, embedding_id) // batch_size
+            existing_count = get_embedding_count(DATA_DIR, dataset_id, embedding_id)
         else:
-            starting_batch = 0
+            existing_count = 0
     else:
-        # determine the index of the last embedding run
-        # Check both HDF5 files and LanceDB tables
+        # Determine the index of the last embedding run. Check HDF5 files,
+        # metadata JSONs, and LanceDB tables — a crashed run leaves only a
+        # LanceDB table (the .json is written at the end), and reusing its id
+        # would append a second run into the half-finished table.
         embedding_files = [f for f in os.listdir(embedding_dir) if re.match(r"embedding-\d+\.h5", f)]
         embedding_jsons = [f for f in os.listdir(embedding_dir) if re.match(r"embedding-\d+\.json", f)]
-        all_files = embedding_files + embedding_jsons
-        if len(all_files) > 0:
-            numbers = []
-            for f in all_files:
-                match = re.search(r"embedding-(\d+)", f)
-                if match:
-                    numbers.append(int(match.group(1)))
-            next_embedding_number = max(numbers) + 1 if numbers else 1
-        else:
-            next_embedding_number = 1
+        lancedb_ids = [i for i in list_embedding_ids(DATA_DIR, dataset_id)
+                       if re.match(r"embedding-\d+$", i)]
+        all_names = embedding_files + embedding_jsons + lancedb_ids
+        numbers = []
+        for f in all_names:
+            match = re.search(r"embedding-(\d+)", f)
+            if match:
+                numbers.append(int(match.group(1)))
+        next_embedding_number = max(numbers) + 1 if numbers else 1
         # make the embedding name from the number, zero padded to 3 digits
         embedding_id = f"embedding-{next_embedding_number:03d}"
-        starting_batch = 0
+        existing_count = 0
 
     print("RUNNING:", embedding_id)
     print("MODEL ID", model_id)
@@ -146,18 +148,25 @@ def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_si
         prefixed.append(prefix + s)
     sentences = prefixed
 
-    total_batches = len(sentences)//batch_size
+    total_batches = (len(sentences) + batch_size - 1) // batch_size
 
     print("embedding", len(sentences), "sentences", "in", total_batches, "batches")
-    if starting_batch > 0:
-        print("Rerunning starting at batch", starting_batch)
+    if existing_count > 0:
+        print(f"Resuming: {existing_count} rows already embedded")
 
     for i, batch in enumerate(tqdm(chunked_iterable(sentences, batch_size), total=total_batches)):
-        if i < starting_batch:
-            print(f"skipping batch {i}/{total_batches}", flush=True)
+        start_index = i * batch_size
+        end_index = start_index + len(batch)
+        if end_index <= existing_count:
+            # fully covered by a previous run — re-embedding would append
+            # duplicate ls_index rows
             continue
+        if start_index < existing_count:
+            # partial overlap (final partial batch of a completed run, or a
+            # changed batch_size): embed only the rows not yet stored
+            batch = batch[existing_count - start_index:]
+            start_index = existing_count
         try:
-            start_index = i * batch_size
             if is_late_interaction:
                 mean_vectors, token_vectors_list = model.embed_multi(batch, dimensions=dimensions)
                 append_embeddings(
@@ -176,7 +185,7 @@ def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_si
             print("error embedding batch", i, e)
             print("exiting prematurely", embedding_id)
             # extract the rows from the last batch from df
-            df_batch = df.iloc[i*batch_size:(i+1)*batch_size].copy()
+            df_batch = df.iloc[start_index:start_index + len(batch)].copy()
             df_batch["_ls_text_"] = batch
             batch_path = os.path.join(embedding_dir, f"{embedding_id}-batch-{i}.parquet")
             df_batch.to_parquet(batch_path)

--- a/latentscope/scripts/sae.py
+++ b/latentscope/scripts/sae.py
@@ -50,11 +50,10 @@ def saer(dataset_id, embedding_id, model_id, k_expansion, device):
     import torch
     from latentsae.sae import Sae
 
+    from latentscope.util.embedding_store import load_embeddings
+
     print("loading embeddings")
-    embedding_path = os.path.join(DATA_DIR, dataset_id, "embeddings", f"{embedding_id}.h5")
-    with h5py.File(embedding_path, 'r') as f:
-        dataset = f["embeddings"]
-        embeddings = np.array(dataset)
+    embeddings = load_embeddings(DATA_DIR, dataset_id, embedding_id)
 
     if device == "mps" or torch.backends.mps.is_available():
         device = torch.device("mps")

--- a/latentscope/server/bulk.py
+++ b/latentscope/server/bulk.py
@@ -110,7 +110,7 @@ def change_cluster_name():
 
     clusters = scope_meta["cluster_labels_lookup"]
     clusters[cluster]["label"] = new_label
-    df[df['cluster'] == cluster]['label'] = new_label
+    df.loc[df['cluster'] == cluster, 'label'] = new_label
     df.to_parquet(scope_file)
     update_combined(DATA_DIR, df, dataset_id, scope_id)
 

--- a/latentscope/server/jobs.py
+++ b/latentscope/server/jobs.py
@@ -6,7 +6,7 @@ import subprocess
 import threading
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask import Blueprint, current_app, jsonify, request
 
@@ -60,7 +60,7 @@ def run_job(data_dir, dataset, job_id, command):
         "job_name": job_name,
         "command": command,
         "status": "running",
-        "last_update": str(datetime.now()),
+        "last_update": datetime.now(timezone.utc).isoformat(),
         "progress": [],
         "times": [],
     }
@@ -101,8 +101,8 @@ def run_job(data_dir, dataset, job_id, command):
                 run_id = output.strip().split("RUNNING: ")[1]
                 job["run_id"] = run_id
             job["progress"].append(output.strip())
-            job["times"].append(str(datetime.now()))
-            job["last_update"] = str(datetime.now())
+            job["times"].append(datetime.now(timezone.utc).isoformat())
+            job["last_update"] = datetime.now(timezone.utc).isoformat()
             with open(progress_file, 'w') as f:
                 json.dump(job, f)
             last_output_time = current_time
@@ -653,7 +653,7 @@ def _write_completed_job(data_dir, dataset, job_id, description):
         "job_name": description,
         "command": description,
         "status": "completed",
-        "last_update": str(datetime.now()),
+        "last_update": datetime.now(timezone.utc).isoformat(),
         "progress": [],
         "times": [],
     }

--- a/latentscope/util/embedding_store.py
+++ b/latentscope/util/embedding_store.py
@@ -89,6 +89,23 @@ def append_embeddings(data_dir, dataset_id, embedding_id, vectors, start_index=0
         db.create_table(table_name, rows)
 
 
+def list_embedding_ids(data_dir, dataset_id):
+    """Return embedding ids that have a LanceDB table (e.g. ["embedding-001"]).
+
+    Includes tables from crashed runs that never wrote their .json metadata,
+    so callers allocating the next embedding id don't reuse a taken one.
+    """
+    db_path = _lance_db_path(data_dir, dataset_id)
+    if not os.path.isdir(db_path):
+        return []
+    db = _connect(data_dir, dataset_id)
+    return [
+        name[len("emb-"):]
+        for name in _get_table_names(db)
+        if name.startswith("emb-")
+    ]
+
+
 def get_embedding_count(data_dir, dataset_id, embedding_id):
     """Return the number of embeddings stored, or 0 if none."""
     db = _connect(data_dir, dataset_id)
@@ -338,44 +355,64 @@ def migrate_hdf5_to_lancedb(data_dir, dataset_id, embedding_id, batch_size=1000,
     if not os.path.exists(emb_path):
         raise FileNotFoundError(f"No HDF5 file at {emb_path}")
 
-    # Check if already migrated
     db = _connect(data_dir, dataset_id)
     table_name = _embedding_table_name(embedding_id)
-    if table_name in _get_table_names(db):
-        tbl = db.open_table(table_name)
-        return {"status": "already_migrated", "rows": tbl.count_rows()}
 
-    # Load from HDF5
     with h5py.File(emb_path, "r") as f:
         total_rows = f["embeddings"].shape[0]
         dimensions = f["embeddings"].shape[1]
 
-        # Write in batches to avoid memory issues
-        for start in range(0, total_rows, batch_size):
-            end = min(start + batch_size, total_rows)
-            vectors = np.array(f["embeddings"][start:end])
-            append_embeddings(data_dir, dataset_id, embedding_id,
-                            vectors, start_index=start)
-            if on_progress:
-                on_progress(end, total_rows)
+    # Check if already migrated. A table can also be left behind by an
+    # interrupted migration (killed process) — in that case it is shorter
+    # than the HDF5 source and must be dropped and re-migrated, otherwise it
+    # shadows the intact HDF5 in load_embeddings and silently truncates data.
+    if table_name in _get_table_names(db):
+        tbl = db.open_table(table_name)
+        existing = tbl.count_rows()
+        if existing == total_rows:
+            return {"status": "already_migrated", "rows": existing}
+        print(f"Found partial migration ({existing}/{total_rows} rows) — "
+              "dropping and re-migrating")
+        db.drop_table(table_name)
 
-    # Verify migration: check row count and spot-check a few vectors
-    lance_count = get_embedding_count(data_dir, dataset_id, embedding_id)
-    if lance_count != total_rows:
-        raise RuntimeError(
-            f"Migration verification failed: expected {total_rows} rows, "
-            f"got {lance_count} in LanceDB"
-        )
+    try:
+        # Copy from HDF5 in batches to avoid memory issues
+        with h5py.File(emb_path, "r") as f:
+            for start in range(0, total_rows, batch_size):
+                end = min(start + batch_size, total_rows)
+                vectors = np.array(f["embeddings"][start:end])
+                append_embeddings(data_dir, dataset_id, embedding_id,
+                                vectors, start_index=start)
+                if on_progress:
+                    on_progress(end, total_rows)
 
-    # Spot-check first and last vectors match
-    lance_vectors = load_embeddings(data_dir, dataset_id, embedding_id)
-    with h5py.File(emb_path, "r") as f:
-        h5_first = np.array(f["embeddings"][0])
-        h5_last = np.array(f["embeddings"][-1])
-    if not np.allclose(lance_vectors[0], h5_first, atol=1e-6):
-        raise RuntimeError("Migration verification failed: first vector mismatch")
-    if not np.allclose(lance_vectors[-1], h5_last, atol=1e-6):
-        raise RuntimeError("Migration verification failed: last vector mismatch")
+        # Verify migration: row count plus a random sample of vectors.
+        lance_count = get_embedding_count(data_dir, dataset_id, embedding_id)
+        if lance_count != total_rows:
+            raise RuntimeError(
+                f"Migration verification failed: expected {total_rows} rows, "
+                f"got {lance_count} in LanceDB"
+            )
+
+        lance_vectors = load_embeddings(data_dir, dataset_id, embedding_id)
+        rng = np.random.default_rng(0)
+        sample_size = min(16, total_rows)
+        sample = rng.choice(total_rows, size=sample_size, replace=False)
+        # Always include the endpoints
+        check_indices = sorted(set(sample.tolist()) | {0, total_rows - 1})
+        with h5py.File(emb_path, "r") as f:
+            for idx in check_indices:
+                h5_vec = np.array(f["embeddings"][idx])
+                if not np.allclose(lance_vectors[idx], h5_vec, atol=1e-6):
+                    raise RuntimeError(
+                        f"Migration verification failed: vector mismatch at row {idx}"
+                    )
+    except BaseException:
+        # Never leave a partial table behind: it would shadow the intact
+        # HDF5 file in load_embeddings.
+        if table_name in _get_table_names(db):
+            db.drop_table(table_name)
+        raise
 
     # Verification passed — remove the HDF5 file
     h5_size = os.path.getsize(emb_path)

--- a/tests/test_embedding_store.py
+++ b/tests/test_embedding_store.py
@@ -167,3 +167,102 @@ def test_get_embedding_stats(data_dir):
     assert stats["count"] == 2
     assert stats["min_values"] == [-1.0, 0.0, 3.0]
     assert stats["max_values"] == [1.0, 2.0, 5.0]
+
+
+def _write_h5(data_dir, embedding_id, vectors):
+    import h5py
+
+    h5_path = os.path.join(data_dir, "test-dataset", "embeddings", f"{embedding_id}.h5")
+    with h5py.File(h5_path, "w") as f:
+        f.create_dataset("embeddings", data=vectors)
+    return h5_path
+
+
+def test_migration_deletes_hdf5_after_verification(data_dir):
+    from latentscope.util.embedding_store import load_embeddings, migrate_hdf5_to_lancedb
+
+    vectors = np.random.rand(57, 16).astype(np.float32)
+    h5_path = _write_h5(data_dir, "embedding-001", vectors)
+
+    result = migrate_hdf5_to_lancedb(data_dir, "test-dataset", "embedding-001",
+                                     batch_size=10)
+    assert result["status"] == "migrated"
+    assert result["rows"] == 57
+    assert not os.path.exists(h5_path)
+    np.testing.assert_allclose(
+        load_embeddings(data_dir, "test-dataset", "embedding-001"), vectors, atol=1e-6)
+
+
+def test_migration_redoes_partial_table(data_dir):
+    """An interrupted migration leaves a short LanceDB table that shadows the
+    intact HDF5. Re-running the migration must detect the count mismatch,
+    drop the partial table, and migrate fully (not report already_migrated)."""
+    from latentscope.util.embedding_store import (
+        append_embeddings,
+        load_embeddings,
+        migrate_hdf5_to_lancedb,
+    )
+
+    vectors = np.random.rand(40, 16).astype(np.float32)
+    _write_h5(data_dir, "embedding-001", vectors)
+    # simulate the partial table from a killed migration
+    append_embeddings(data_dir, "test-dataset", "embedding-001", vectors[:15])
+
+    result = migrate_hdf5_to_lancedb(data_dir, "test-dataset", "embedding-001",
+                                     batch_size=10)
+    assert result["status"] == "migrated"
+    loaded = load_embeddings(data_dir, "test-dataset", "embedding-001")
+    assert loaded.shape == (40, 16)
+    np.testing.assert_allclose(loaded, vectors, atol=1e-6)
+
+
+def test_migration_complete_table_reports_already_migrated(data_dir):
+    from latentscope.util.embedding_store import append_embeddings, migrate_hdf5_to_lancedb
+
+    vectors = np.random.rand(20, 16).astype(np.float32)
+    _write_h5(data_dir, "embedding-001", vectors)
+    append_embeddings(data_dir, "test-dataset", "embedding-001", vectors)
+
+    result = migrate_hdf5_to_lancedb(data_dir, "test-dataset", "embedding-001")
+    assert result["status"] == "already_migrated"
+    assert result["rows"] == 20
+
+
+def test_failed_migration_leaves_no_partial_table(data_dir, monkeypatch):
+    """If the copy fails mid-way the partial table must be dropped so it never
+    shadows the intact HDF5 file, and the HDF5 source must survive."""
+    import latentscope.util.embedding_store as store
+
+    vectors = np.random.rand(40, 16).astype(np.float32)
+    h5_path = _write_h5(data_dir, "embedding-001", vectors)
+
+    real_append = store.append_embeddings
+    calls = {"n": 0}
+
+    def flaky_append(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] > 2:
+            raise RuntimeError("simulated write failure")
+        return real_append(*args, **kwargs)
+
+    monkeypatch.setattr(store, "append_embeddings", flaky_append)
+    with pytest.raises(RuntimeError, match="simulated write failure"):
+        store.migrate_hdf5_to_lancedb(data_dir, "test-dataset", "embedding-001",
+                                      batch_size=10)
+
+    assert os.path.exists(h5_path)
+    assert store.get_storage_format(data_dir, "test-dataset", "embedding-001") == "hdf5"
+    # and load_embeddings reads the intact HDF5, not a truncated table
+    loaded = store.load_embeddings(data_dir, "test-dataset", "embedding-001")
+    assert loaded.shape == (40, 16)
+
+
+def test_list_embedding_ids(data_dir):
+    from latentscope.util.embedding_store import append_embeddings, list_embedding_ids
+
+    assert list_embedding_ids(data_dir, "test-dataset") == []
+    vectors = np.random.rand(5, 8).astype(np.float32)
+    append_embeddings(data_dir, "test-dataset", "embedding-001", vectors)
+    append_embeddings(data_dir, "test-dataset", "embedding-003", vectors)
+    assert sorted(list_embedding_ids(data_dir, "test-dataset")) == [
+        "embedding-001", "embedding-003"]

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -1,0 +1,281 @@
+"""End-to-end pipeline tests on a small dataset with a deterministic fake
+embedding model.
+
+These tests exercise the real pipeline code (ingest -> embed -> umap ->
+cluster -> scope) against a temporary data directory. The embedding model is
+replaced with a deterministic provider so no model downloads or GPU are
+required; everything downstream of the provider is the production code path,
+including LanceDB storage.
+"""
+
+import hashlib
+import json
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+
+DIM = 32
+N_PER_TOPIC = 40
+TOPICS = ["science", "cooking", "sports"]
+
+
+class FakeEmbedProvider:
+    """Deterministic stand-in for an embedding model.
+
+    Each topic maps to a fixed random direction; individual texts get small
+    deterministic noise around their topic direction, so UMAP + clustering
+    have real structure to find.
+    """
+
+    name = "fake-test-model"
+    late_interaction = False
+
+    def __init__(self, dim=DIM):
+        self.dim = dim
+        rng = np.random.default_rng(42)
+        self.topic_dirs = {t: rng.normal(size=dim) for t in TOPICS}
+
+    def load_model(self):
+        pass
+
+    def _vector(self, text):
+        topic = next((t for t in TOPICS if t in text), TOPICS[0])
+        seed = int.from_bytes(hashlib.sha256(text.encode()).digest()[:4], "little")
+        noise = np.random.default_rng(seed).normal(scale=0.1, size=self.dim)
+        vec = self.topic_dirs[topic] + noise
+        return (vec / np.linalg.norm(vec)).astype(np.float32)
+
+    def embed(self, batch, dimensions=None):
+        return [self._vector(t) for t in batch]
+
+
+def make_input_df(n_per_topic=N_PER_TOPIC):
+    rows = []
+    for topic in TOPICS:
+        for i in range(n_per_topic):
+            rows.append({
+                "text": f"document {i} about {topic} and related {topic} matters",
+                "topic": topic,
+            })
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture
+def pipeline_env(tmp_data_dir, monkeypatch):
+    """Point the pipeline at a temp data dir and stub the embedding model."""
+    monkeypatch.setenv("LATENT_SCOPE_DATA", tmp_data_dir)
+    monkeypatch.setenv("LATENT_SCOPE_NO_DOTENV", "1")
+
+    import latentscope.scripts.embed as embed_mod
+    monkeypatch.setattr(embed_mod, "get_embedding_model",
+                        lambda model_id: FakeEmbedProvider())
+    return tmp_data_dir
+
+
+def run_ingest_and_embed(data_dir, dataset_id="e2e-test", batch_size=50):
+    from latentscope.scripts.embed import embed
+    from latentscope.scripts.ingest import ingest
+
+    df = make_input_df()
+    ingest(dataset_id, df, text_column="text")
+    embed(dataset_id, "text", "fake-test-model", prefix=None, rerun=None,
+          dimensions=None, batch_size=batch_size)
+    return df
+
+
+def test_full_pipeline_small_dataset(pipeline_env):
+    """ingest -> embed -> umap -> cluster(hdbscan) -> scope on 120 rows."""
+    data_dir = pipeline_env
+    dataset_id = "e2e-test"
+    n_total = N_PER_TOPIC * len(TOPICS)
+
+    df = run_ingest_and_embed(data_dir, dataset_id)
+
+    # --- embed wrote a LanceDB table aligned with the input ---
+    from latentscope.util.embedding_store import get_embedding_count, load_embeddings
+    assert get_embedding_count(data_dir, dataset_id, "embedding-001") == n_total
+    vectors = load_embeddings(data_dir, dataset_id, "embedding-001")
+    assert vectors.shape == (n_total, DIM)
+    # row alignment: stored vector i must equal the provider's output for text i
+    provider = FakeEmbedProvider()
+    np.testing.assert_allclose(vectors[7], provider._vector(df["text"].iloc[7]),
+                               atol=1e-6)
+    np.testing.assert_allclose(vectors[-1], provider._vector(df["text"].iloc[-1]),
+                               atol=1e-6)
+    meta_path = os.path.join(data_dir, dataset_id, "embeddings", "embedding-001.json")
+    assert os.path.exists(meta_path)
+
+    # --- umap ---
+    from latentscope.scripts.umapper import umapper
+    umapper(dataset_id, "embedding-001", neighbors=10, min_dist=0.1)
+    umap_df = pd.read_parquet(
+        os.path.join(data_dir, dataset_id, "umaps", "umap-001.parquet"))
+    assert len(umap_df) == n_total
+    assert {"x", "y"} <= set(umap_df.columns)
+    assert umap_df["x"].between(-1, 1).all()
+
+    # --- cluster (hdbscan on the 2D projection) ---
+    from latentscope.scripts.cluster import clusterer
+    clusterer(dataset_id, "umap-001", samples=5, min_samples=3,
+              cluster_selection_epsilon=0.0, column=None, method="hdbscan")
+    cluster_df = pd.read_parquet(
+        os.path.join(data_dir, dataset_id, "clusters", "cluster-001.parquet"))
+    assert len(cluster_df) == n_total
+    n_clusters = cluster_df["cluster"].nunique()
+    assert n_clusters >= 2, "expected the 3 planted topics to form >=2 clusters"
+    # noise points must all have been reassigned
+    assert (cluster_df["cluster"] >= 0).all()
+    labels_path = os.path.join(
+        data_dir, dataset_id, "clusters", "cluster-001-labels-default.parquet")
+    assert os.path.exists(labels_path)
+
+    # --- scope ---
+    from latentscope.scripts.scope import scope
+    scope(dataset_id, "embedding-001", "umap-001", "cluster-001",
+          "default", "E2E test scope", "test description")
+    scope_df = pd.read_parquet(
+        os.path.join(data_dir, dataset_id, "scopes", "scopes-001.parquet"))
+    assert len(scope_df) == n_total
+    with open(os.path.join(data_dir, dataset_id, "scopes", "scopes-001.json")) as f:
+        scope_meta = json.load(f)
+    assert scope_meta["embedding_id"] == "embedding-001"
+    assert scope_meta["cluster_id"] == "cluster-001"
+
+
+def test_cluster_evoc_reads_lancedb_embeddings(pipeline_env):
+    """Regression: EVoC (the default cluster method) must read embeddings from
+    the LanceDB store. Before the fix it read embeddings/{id}.h5 directly and
+    raised FileNotFoundError for every post-LanceDB embedding."""
+    data_dir = pipeline_env
+    dataset_id = "e2e-test"
+    run_ingest_and_embed(data_dir, dataset_id)
+
+    from latentscope.scripts.cluster import _load_embeddings
+    vectors = _load_embeddings(dataset_id, "embedding-001")
+    assert vectors.shape == (N_PER_TOPIC * len(TOPICS), DIM)
+
+
+def test_embed_rerun_completed_run_adds_no_duplicates(pipeline_env):
+    """Regression: re-running a completed embedding whose row count is not a
+    multiple of batch_size must not re-append the final partial batch."""
+    data_dir = pipeline_env
+    dataset_id = "e2e-test"
+    # 120 rows with batch_size=50 -> final batch is a partial 20
+    run_ingest_and_embed(data_dir, dataset_id, batch_size=50)
+
+    from latentscope.scripts.embed import embed
+    from latentscope.util.embedding_store import get_embedding_count
+
+    n_total = N_PER_TOPIC * len(TOPICS)
+    assert get_embedding_count(data_dir, dataset_id, "embedding-001") == n_total
+    embed(dataset_id, "text", "fake-test-model", prefix=None,
+          rerun="embedding-001", dimensions=None, batch_size=50)
+    assert get_embedding_count(data_dir, dataset_id, "embedding-001") == n_total
+
+
+def test_embed_resumes_interrupted_run_exactly(pipeline_env, monkeypatch):
+    """A run that crashes mid-way resumes from the exact stored row count and
+    produces a complete, duplicate-free table."""
+    data_dir = pipeline_env
+    dataset_id = "e2e-test"
+    n_total = N_PER_TOPIC * len(TOPICS)
+
+    from latentscope.scripts.ingest import ingest
+    ingest(dataset_id, make_input_df(), text_column="text")
+
+    import latentscope.scripts.embed as embed_mod
+
+    class CrashingProvider(FakeEmbedProvider):
+        calls = 0
+
+        def embed(self, batch, dimensions=None):
+            CrashingProvider.calls += 1
+            if CrashingProvider.calls > 1:
+                raise RuntimeError("simulated crash")
+            return super().embed(batch, dimensions)
+
+    monkeypatch.setattr(embed_mod, "get_embedding_model",
+                        lambda model_id: CrashingProvider())
+    with pytest.raises(SystemExit):
+        embed_mod.embed(dataset_id, "text", "fake-test-model", prefix=None,
+                        rerun=None, dimensions=None, batch_size=50)
+
+    from latentscope.util.embedding_store import get_embedding_count, load_embeddings
+    assert get_embedding_count(data_dir, dataset_id, "embedding-001") == 50
+
+    # resume with a healthy provider
+    monkeypatch.setattr(embed_mod, "get_embedding_model",
+                        lambda model_id: FakeEmbedProvider())
+    embed_mod.embed(dataset_id, "text", "fake-test-model", prefix=None,
+                    rerun="embedding-001", dimensions=None, batch_size=50)
+    vectors = load_embeddings(data_dir, dataset_id, "embedding-001")
+    assert vectors.shape == (n_total, DIM)
+    # the resumed rows must align with their input texts
+    provider = FakeEmbedProvider()
+    df = make_input_df()
+    np.testing.assert_allclose(vectors[60], provider._vector(df["text"].iloc[60]),
+                               atol=1e-6)
+
+
+def test_crashed_run_does_not_get_its_id_reused(pipeline_env, monkeypatch):
+    """Regression: a crashed embed run leaves a LanceDB table but no .json;
+    the next run must allocate a fresh embedding id instead of appending into
+    the half-finished table."""
+    data_dir = pipeline_env
+    dataset_id = "e2e-test"
+
+    from latentscope.scripts.ingest import ingest
+    ingest(dataset_id, make_input_df(), text_column="text")
+
+    import latentscope.scripts.embed as embed_mod
+
+    class CrashingProvider(FakeEmbedProvider):
+        calls = 0
+
+        def embed(self, batch, dimensions=None):
+            CrashingProvider.calls += 1
+            if CrashingProvider.calls > 1:
+                raise RuntimeError("simulated crash")
+            return super().embed(batch, dimensions)
+
+    monkeypatch.setattr(embed_mod, "get_embedding_model",
+                        lambda model_id: CrashingProvider())
+    with pytest.raises(SystemExit):
+        embed_mod.embed(dataset_id, "text", "fake-test-model", prefix=None,
+                        rerun=None, dimensions=None, batch_size=50)
+
+    monkeypatch.setattr(embed_mod, "get_embedding_model",
+                        lambda model_id: FakeEmbedProvider())
+    embed_mod.embed(dataset_id, "text", "fake-test-model", prefix=None,
+                    rerun=None, dimensions=None, batch_size=50)
+
+    from latentscope.util.embedding_store import get_embedding_count
+    n_total = N_PER_TOPIC * len(TOPICS)
+    # embedding-001 stays half-finished; the new run went to embedding-002
+    assert get_embedding_count(data_dir, dataset_id, "embedding-001") == 50
+    assert get_embedding_count(data_dir, dataset_id, "embedding-002") == n_total
+
+
+def test_full_pipeline_evoc_default_method(pipeline_env):
+    """The server's default cluster method is EVoC, which clusters on the raw
+    embeddings (read through the LanceDB store). This is the path that broke
+    when storage moved off HDF5."""
+    data_dir = pipeline_env
+    dataset_id = "e2e-test"
+    n_total = N_PER_TOPIC * len(TOPICS)
+
+    run_ingest_and_embed(data_dir, dataset_id)
+
+    from latentscope.scripts.umapper import umapper
+    umapper(dataset_id, "embedding-001", neighbors=10, min_dist=0.1)
+
+    from latentscope.scripts.cluster import clusterer
+    clusterer(dataset_id, "umap-001", samples=5, min_samples=3,
+              cluster_selection_epsilon=0.0, column=None, method="evoc")
+    cluster_df = pd.read_parquet(
+        os.path.join(data_dir, dataset_id, "clusters", "cluster-001.parquet"))
+    assert len(cluster_df) == n_total
+    assert cluster_df["cluster"].nunique() >= 2
+    assert (cluster_df["cluster"] >= 0).all()

--- a/web/src/components/Setup/Embedding.jsx
+++ b/web/src/components/Setup/Embedding.jsx
@@ -1,5 +1,5 @@
 // NewEmbedding.jsx
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Tooltip } from 'react-tooltip';
 import { Select, Button } from 'react-element-forge';
 
@@ -108,14 +108,15 @@ function Embedding() {
   }, [dataset, setEmbeddings, setUmaps, setClusters]);
 
   const [HFModels, setHFModels] = useState([]);
-  const searchHFModels = useCallback((query) => {
-    debounce(
-      apiService.searchHFSTModels(query).then((hfm) => {
-        setHFModels(hfm);
-      }),
-      300
-    );
-  }, []);
+  const searchHFModels = useMemo(
+    () =>
+      debounce((query) => {
+        apiService.searchHFSTModels(query).then((hfm) => {
+          setHFModels(hfm);
+        });
+      }, 300),
+    []
+  );
 
   const [presetModels, setPresetModels] = useState([]);
   useEffect(() => {

--- a/web/src/pages/Jobs.jsx
+++ b/web/src/pages/Jobs.jsx
@@ -11,6 +11,7 @@ import styles from './Jobs.module.scss';
 function Jobs() {
   const [dataset, setDataset] = useState(null);
   const { dataset: datasetId, scope: scopeId } = useParams();
+  const navigate = useNavigate();
   const [scopes, setScopes] = useState([]);
 
   useEffect(() => {


### PR DESCRIPTION
Part 1 of the review-plan series. **Stacked on #116** (base: `part0-ci`) — merge that first, then retarget this to `main`.

## The headline bug

Since the LanceDB migration (#113), **the default pipeline has been broken end-to-end for new datasets**: `cluster.py` (EVoC is the default method) and `sae.py` still read `embeddings/{id}.h5` directly, but new embeddings are LanceDB-only and migrated ones have their HDF5 deleted → `FileNotFoundError` at the cluster step. Both now read through `embedding_store.load_embeddings` (LanceDB with HDF5 fallback).

## Data-safety fixes

- **Interrupted migration could silently truncate data**: a partial Lance table shadowed the intact HDF5 in `load_embeddings` and re-running reported `already_migrated`. Now: partial tables are detected (count vs HDF5), dropped, and re-migrated; any copy/verify failure drops the table; verification checks a random sample of vectors (plus endpoints) before the HDF5 is deleted.
- **Crashed embed runs no longer get their id reused**: id allocation scans LanceDB tables too (a crashed run leaves a table but no `.json`, and the next run would append a second dataset into it).
- **`--rerun` resumes from the exact stored row count**: no duplicate `ls_index` rows when N % batch_size ≠ 0; partial overlap (changed batch size) embeds only the missing rows.

## Smaller fixes

- `bulk.py` cluster rename was a chained-assignment no-op — the new label never persisted to parquet
- Job timestamps are UTC ISO-8601 — fixes #89 (job timer wrong across timezones)
- `Jobs.jsx` crashed on scope switch (`useNavigate()` never called — it was eslint's one `no-undef`)
- HF model search debounce never debounced (invoked the fetch immediately, discarded the debounced function)
- `MIGRATIONS.md` updated to match reality (HDF5 *is* deleted after verification since fc41214; removed the not-yet-true ANN index claim)

## Tests (the e2e suite requested for small-dataset validation)

`tests/test_pipeline_e2e.py`: full **ingest → embed → umap → cluster → scope** on 120 rows with a deterministic fake embedding provider (planted topic structure, no model downloads, no GPU) — both `hdbscan` and the default `evoc` cluster paths — plus regression tests for crash-resume, id reuse, and duplicate-free rerun. Runs in ~17s. `tests/test_embedding_store.py` gains 6 migration-hardening tests.

**Local verification:** 68 passed (was 57), ruff clean, vitest 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)