### PR TITLE
Part 3: job system / terminal passthru overhaul

### DIFF
--- a/latentscope/server/app.py
+++ b/latentscope/server/app.py
@@ -85,11 +85,13 @@ def create_app(data_dir=None, read_only=None):
         app.register_blueprint(jobs_write_bp, url_prefix='/api/jobs')
 
     # Mark jobs left "running" by a previous server process as dead.  A bad
-    # job file must never prevent the server from starting.
-    try:
-        reconcile_stale_jobs(data_dir)
-    except Exception:
-        app.logger.exception("Failed to reconcile stale jobs on startup")
+    # job file must never prevent the server from starting.  Read-only
+    # deployments must not mutate the data directory at all.
+    if not read_only:
+        try:
+            reconcile_stale_jobs(data_dir)
+        except Exception:
+            app.logger.exception("Failed to reconcile stale jobs on startup")
 
     from .search import search_bp
     app.register_blueprint(search_bp, url_prefix='/api/search')

--- a/latentscope/server/app.py
+++ b/latentscope/server/app.py
@@ -8,6 +8,7 @@ from importlib.resources import files
 from dotenv import dotenv_values, set_key
 from flask import Flask, jsonify, request, send_from_directory
 from flask_cors import CORS
+from werkzeug.exceptions import HTTPException
 
 from latentscope.__version__ import __version__
 from latentscope.util import get_data_dir, get_supported_api_keys
@@ -59,12 +60,36 @@ def create_app(data_dir=None, read_only=None):
     app.config['DATAFRAMES'] = {}
 
     # ------------------------------------------------------------------
+    # JSON error handlers
+    # ------------------------------------------------------------------
+
+    @app.errorhandler(HTTPException)
+    def handle_http_exception(e):
+        return jsonify({"error": e.description, "code": e.code}), e.code
+
+    @app.errorhandler(Exception)
+    def handle_unexpected_exception(e):
+        # Preserve normal exception propagation while testing/debugging so
+        # failures surface directly in test output and the debugger.
+        if app.testing or app.debug:
+            raise e
+        app.logger.exception("Unhandled exception")
+        return jsonify({"error": str(e), "code": 500}), 500
+
+    # ------------------------------------------------------------------
     # Blueprint registration
     # ------------------------------------------------------------------
-    from .jobs import jobs_bp, jobs_write_bp
+    from .jobs import jobs_bp, jobs_write_bp, reconcile_stale_jobs
     app.register_blueprint(jobs_bp, url_prefix='/api/jobs')
     if not read_only:
         app.register_blueprint(jobs_write_bp, url_prefix='/api/jobs')
+
+    # Mark jobs left "running" by a previous server process as dead.  A bad
+    # job file must never prevent the server from starting.
+    try:
+        reconcile_stale_jobs(data_dir)
+    except Exception:
+        app.logger.exception("Failed to reconcile stale jobs on startup")
 
     from .search import search_bp
     app.register_blueprint(search_bp, url_prefix='/api/search')
@@ -291,7 +316,27 @@ def create_app(data_dir=None, read_only=None):
     return app
 
 
-def serve(host="0.0.0.0", port=5001, debug=True, data_dir=None, read_only=None):
-    """Create the app and start the development server."""
+def serve(host="0.0.0.0", port=5001, debug=False, data_dir=None, read_only=None):
+    """Create the app and start a server.
+
+    Uses waitress (production WSGI server) when it is installed and debug mode
+    is off; otherwise falls back to the Flask development server.  Set
+    ``LATENT_SCOPE_DEBUG=1`` to force the development server.
+    """
     application = create_app(data_dir=data_dir, read_only=read_only)
+    if _parse_bool_env(os.getenv("LATENT_SCOPE_DEBUG")):
+        debug = True
+    if not debug:
+        try:
+            from waitress import serve as waitress_serve
+        except ImportError:
+            waitress_serve = None
+        if waitress_serve is not None:
+            application.logger.info("Serving with waitress on %s:%s", host, port)
+            waitress_serve(application, listen=f"{host}:{port}", threads=8)
+            return
+        application.logger.warning(
+            "waitress not installed (pip install waitress); "
+            "falling back to the Flask development server"
+        )
     application.run(host=host, port=port, debug=debug)

--- a/latentscope/server/bulk.py
+++ b/latentscope/server/bulk.py
@@ -4,6 +4,8 @@ from datetime import datetime
 
 from flask import Blueprint, current_app, jsonify, request
 
+from latentscope.server.job_utils import _safe_dataset
+
 # Create a Blueprint
 bulk_bp = Blueprint('bulk_bp', __name__)
 bulk_write_bp = Blueprint('bulk_write_bp', __name__)
@@ -39,7 +41,7 @@ def change_cluster():
 
     DATA_DIR = _data_dir()
     data = request.get_json()
-    dataset_id = data["dataset_id"]
+    dataset_id = _safe_dataset(data.get("dataset_id"), param="dataset_id")
     scope_id = data["scope_id"]
     row_ids = data["row_ids"]
     new_cluster = int(data["new_cluster"])
@@ -96,7 +98,7 @@ def change_cluster_name():
     import pandas as pd
 
     DATA_DIR = _data_dir()
-    dataset_id = request.args["dataset_id"]
+    dataset_id = _safe_dataset(request.args.get("dataset_id"), param="dataset_id")
     scope_id = request.args["scope_id"]
     cluster = int(request.args["cluster"])
     new_label = request.args["new_label"]
@@ -131,7 +133,7 @@ def delete_rows():
 
     DATA_DIR = _data_dir()
     data = request.get_json()
-    dataset_id = data["dataset_id"]
+    dataset_id = _safe_dataset(data.get("dataset_id"), param="dataset_id")
     scope_id = data["scope_id"]
     row_ids = data["row_ids"]
 

--- a/latentscope/server/datasets.py
+++ b/latentscope/server/datasets.py
@@ -4,9 +4,18 @@ import re
 
 from flask import Blueprint, current_app, jsonify, request
 
+from latentscope.server.job_utils import _safe_dataset
+
 # Create a Blueprint
 datasets_bp = Blueprint('datasets_bp', __name__)
 datasets_write_bp = Blueprint('datasets_write_bp', __name__)
+
+
+@datasets_bp.url_value_preprocessor
+@datasets_write_bp.url_value_preprocessor
+def _validate_dataset_path_param(endpoint, values):
+    if values and 'dataset' in values:
+        _safe_dataset(values['dataset'])
 
 
 def _data_dir():

--- a/latentscope/server/job_utils.py
+++ b/latentscope/server/job_utils.py
@@ -1,0 +1,19 @@
+"""Shared helpers for server blueprints: parameter validation utilities."""
+import os
+
+from flask import abort
+
+
+def _safe_dataset(value, param="dataset"):
+    """Validate an identifier (dataset id, job id, tag name, ...) that will be
+    joined into a filesystem path.
+
+    Rejects values that are empty/missing, contain path separators or "..",
+    or are absolute paths.  Aborts the request with a 400 when invalid and
+    returns the value unchanged when valid.
+    """
+    if not value or not isinstance(value, str):
+        abort(400, description=f"Missing or invalid '{param}' parameter")
+    if "/" in value or "\\" in value or ".." in value or os.path.isabs(value):
+        abort(400, description=f"Invalid '{param}' parameter")
+    return value

--- a/latentscope/server/jobs.py
+++ b/latentscope/server/jobs.py
@@ -1,3 +1,4 @@
+import glob
 import json
 import os
 import shlex
@@ -6,17 +7,30 @@ import subprocess
 import threading
 import time
 import uuid
+from collections import deque
 from datetime import datetime, timezone
 
-from flask import Blueprint, current_app, jsonify, request
+from flask import Blueprint, abort, current_app, jsonify, request
+from werkzeug.utils import secure_filename
+
+from latentscope.server.job_utils import _safe_dataset
 
 # Create a Blueprint
 jobs_bp = Blueprint('jobs_bp', __name__)
 jobs_write_bp = Blueprint('jobs_write_bp', __name__)
 
-TIMEOUT = 60 * 5  # 5 minute timeout
+TIMEOUT = 60 * 5  # 5 minute no-output timeout
+MAX_PROGRESS_LINES = 500  # lines of output retained in the job JSON
+WRITE_INTERVAL = 0.5  # seconds between JSON rewrites while streaming output
 
 PROCESSES = {}
+# job ids that were explicitly killed via the kill endpoint, so run_job can
+# preserve the "dead" status instead of overwriting it with "error"
+KILLED = set()
+
+
+def _now():
+    return datetime.now(timezone.utc).isoformat()
 
 
 def _data_dir():
@@ -46,6 +60,11 @@ def run_job(data_dir, dataset, job_id, command):
     injection when dataset names, file paths or user-supplied parameters are
     included in the command.
 
+    Every output line is appended to a plain-text sidecar log
+    ``<jobs_dir>/<job_id>.log``.  The job JSON keeps only the last
+    ``MAX_PROGRESS_LINES`` lines and is rewritten at most every
+    ``WRITE_INTERVAL`` seconds (plus always on status changes / exit).
+
     This function runs in a background thread, so it receives *data_dir* as an
     explicit parameter rather than relying on the Flask application context.
     """
@@ -53,19 +72,28 @@ def run_job(data_dir, dataset, job_id, command):
     os.makedirs(job_dir, exist_ok=True)
 
     progress_file = os.path.join(job_dir, f"{job_id}.json")
+    log_path = os.path.join(job_dir, f"{job_id}.log")
     job_name = command[0].replace("ls-", "")
+    progress = deque(maxlen=MAX_PROGRESS_LINES)
+    times = deque(maxlen=MAX_PROGRESS_LINES)
     job = {
         "id": job_id,
         "dataset": dataset,
         "job_name": job_name,
         "command": command,
         "status": "running",
-        "last_update": datetime.now(timezone.utc).isoformat(),
+        "last_update": _now(),
         "progress": [],
         "times": [],
     }
-    with open(progress_file, 'w') as f:
-        json.dump(job, f)
+
+    def write_job():
+        job["progress"] = list(progress)
+        job["times"] = list(times)
+        with open(progress_file, 'w') as f:
+            json.dump(job, f)
+
+    write_job()
 
     env = os.environ.copy()
     env['PYTHONUNBUFFERED'] = '1'
@@ -81,39 +109,106 @@ def run_job(data_dir, dataset, job_id, command):
         )
     except (FileNotFoundError, OSError) as exc:
         job["status"] = "error"
-        job["progress"].append(f"Failed to start process: {exc}")
-        with open(progress_file, 'w') as f:
-            json.dump(job, f)
+        progress.append(f"Failed to start process: {exc}")
+        times.append(_now())
+        job["last_update"] = _now()
+        write_job()
         return
 
     PROCESSES[job_id] = process
+    job["pid"] = process.pid
+    write_job()
 
     last_output_time = time.time()
+    last_write_time = time.time()
+    timed_out = False
 
-    while True:
-        output = process.stdout.readline()
-        current_time = time.time()
+    try:
+        with open(log_path, 'a', buffering=1) as log:
+            while True:
+                output = process.stdout.readline()
+                current_time = time.time()
 
-        if output == '' and process.poll() is not None:
-            break
-        if output:
-            if "RUNNING:" in output:
-                run_id = output.strip().split("RUNNING: ")[1]
-                job["run_id"] = run_id
-            job["progress"].append(output.strip())
-            job["times"].append(datetime.now(timezone.utc).isoformat())
-            job["last_update"] = datetime.now(timezone.utc).isoformat()
-            with open(progress_file, 'w') as f:
-                json.dump(job, f)
-            last_output_time = current_time
-        elif current_time - last_output_time > TIMEOUT:
-            job["progress"].append(f"Timeout: No output for more than {TIMEOUT} seconds.")
+                if output == '' and process.poll() is not None:
+                    break
+                if output:
+                    log.write(output if output.endswith("\n") else output + "\n")
+                    if "RUNNING:" in output:
+                        run_id = output.strip().split("RUNNING: ")[1]
+                        job["run_id"] = run_id
+                    progress.append(output.strip())
+                    times.append(_now())
+                    job["last_update"] = _now()
+                    last_output_time = current_time
+                    if current_time - last_write_time >= WRITE_INTERVAL:
+                        write_job()
+                        last_write_time = current_time
+                elif current_time - last_output_time > TIMEOUT:
+                    message = f"Timeout: No output for more than {TIMEOUT} seconds."
+                    log.write(message + "\n")
+                    progress.append(message)
+                    times.append(_now())
+                    timed_out = True
+                    process.kill()
+                    break
+
+        process.wait()
+        if job_id in KILLED:
+            job["status"] = "dead"
+            job["cause_of_death"] = "killed"
+        elif timed_out or process.returncode != 0:
             job["status"] = "error"
-            break
+        else:
+            job["status"] = "completed"
+        job["last_update"] = _now()
+        write_job()
+    finally:
+        PROCESSES.pop(job_id, None)
+        KILLED.discard(job_id)
 
-    job["status"] = "error" if process.returncode != 0 else "completed"
-    with open(progress_file, 'w') as f:
-        json.dump(job, f)
+
+def reconcile_stale_jobs(data_dir):
+    """Mark 'running' jobs whose recorded process is no longer alive as errored.
+
+    Called once on server startup: any job file left in status "running" from
+    a previous server process is checked against its recorded pid; if the pid
+    is missing or dead the job is rewritten as an error.
+    """
+    for path in glob.glob(os.path.join(data_dir, "*", "jobs", "*.json")):
+        try:
+            with open(path) as f:
+                job = json.load(f)
+        except Exception:
+            continue
+        if not isinstance(job, dict) or job.get("status") != "running":
+            continue
+        pid = job.get("pid")
+        alive = False
+        if pid is not None:
+            try:
+                os.kill(int(pid), 0)
+                alive = True
+            except ProcessLookupError:
+                alive = False
+            except PermissionError:
+                alive = True  # exists but owned by someone else
+            except (OSError, ValueError, TypeError):
+                alive = False
+        if alive:
+            continue
+        job["status"] = "error"
+        progress = job.get("progress") or []
+        progress.append("server restarted while job was running; marked as dead")
+        job["progress"] = progress
+        times = job.get("times") or []
+        times.append(_now())
+        job["times"] = times
+        job["last_update"] = _now()
+        try:
+            with open(path, 'w') as f:
+                json.dump(job, f)
+        except Exception:
+            continue
 
 
 def _delete_glob(data_dir, dataset, subdirectory, id_prefix):
@@ -136,8 +231,8 @@ def _delete_glob(data_dir, dataset, subdirectory, id_prefix):
 
 @jobs_bp.route('/job')
 def get_job():
-    dataset = request.args.get('dataset')
-    job_id = request.args.get('job_id')
+    dataset = _safe_dataset(request.args.get('dataset'))
+    job_id = _safe_dataset(request.args.get('job_id'), param='job_id')
     progress_file = os.path.join(_data_dir(), dataset, "jobs", f"{job_id}.json")
     if os.path.exists(progress_file):
         try:
@@ -153,7 +248,7 @@ def get_job():
 
 @jobs_bp.route('/all')
 def get_jobs():
-    dataset = request.args.get('dataset')
+    dataset = _safe_dataset(request.args.get('dataset'))
     job_dir = os.path.join(_data_dir(), dataset, "jobs")
     jobs = []
     if os.path.exists(job_dir):
@@ -172,12 +267,17 @@ def get_jobs():
 @jobs_write_bp.route('/ingest', methods=['POST'])
 def run_ingest():
     data_dir = _data_dir()
-    dataset = request.form.get('dataset')
+    dataset = _safe_dataset(request.form.get('dataset'))
     file = request.files.get('file')
     text_column = request.form.get('text_column')
+    if file is None or not file.filename:
+        return jsonify({"error": "Missing required file upload"}), 400
+    filename = secure_filename(file.filename)
+    if not filename:
+        return jsonify({"error": "Invalid file name"}), 400
     dataset_dir = os.path.join(data_dir, dataset)
     os.makedirs(dataset_dir, exist_ok=True)
-    file_path = os.path.join(dataset_dir, file.filename)
+    file_path = os.path.join(dataset_dir, filename)
     file.save(file_path)
 
     job_id = str(uuid.uuid4())
@@ -188,11 +288,11 @@ def run_ingest():
     return jsonify({"job_id": job_id})
 
 
-@jobs_write_bp.route('/reingest', methods=['GET'])
+@jobs_write_bp.route('/reingest', methods=['GET', 'POST'])
 def run_reingest():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    text_column = request.args.get('text_column')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    text_column = request.values.get('text_column')
     file_path = os.path.join(data_dir, dataset, "input.parquet")
 
     job_id = str(uuid.uuid4())
@@ -203,16 +303,16 @@ def run_reingest():
     return jsonify({"job_id": job_id})
 
 
-@jobs_write_bp.route('/embed')
+@jobs_write_bp.route('/embed', methods=['GET', 'POST'])
 def run_embed():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    text_column = request.args.get('text_column')
-    model_id = request.args.get('model_id')
-    prefix = request.args.get('prefix')
-    dimensions = request.args.get('dimensions')
-    batch_size = request.args.get('batch_size')
-    max_seq_length = request.args.get('max_seq_length')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    text_column = request.values.get('text_column')
+    model_id = request.values.get('model_id')
+    prefix = request.values.get('prefix')
+    dimensions = request.values.get('dimensions')
+    batch_size = request.values.get('batch_size')
+    max_seq_length = request.values.get('max_seq_length')
 
     err = _require_params(dataset=dataset, text_column=text_column, model_id=model_id,
                           prefix=prefix, batch_size=batch_size)
@@ -230,12 +330,12 @@ def run_embed():
     return jsonify({"job_id": job_id})
 
 
-@jobs_write_bp.route('/embed_truncate')
+@jobs_write_bp.route('/embed_truncate', methods=['GET', 'POST'])
 def run_embed_truncate():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    embedding_id = request.args.get('embedding_id')
-    dimensions = request.args.get('dimensions')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    embedding_id = request.values.get('embedding_id')
+    dimensions = request.values.get('dimensions')
 
     err = _require_params(dataset=dataset, embedding_id=embedding_id, dimensions=dimensions)
     if err:
@@ -247,13 +347,13 @@ def run_embed_truncate():
     return jsonify({"job_id": job_id})
 
 
-@jobs_write_bp.route('/embed_importer')
+@jobs_write_bp.route('/embed_importer', methods=['GET', 'POST'])
 def run_embed_importer():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    model_id = request.args.get('model_id')
-    embedding_column = request.args.get('embedding_column')
-    text_column = request.args.get('text_column')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    model_id = request.values.get('model_id')
+    embedding_column = request.values.get('embedding_column')
+    text_column = request.values.get('text_column')
 
     err = _require_params(dataset=dataset, model_id=model_id,
                           embedding_column=embedding_column, text_column=text_column)
@@ -266,12 +366,14 @@ def run_embed_importer():
     return jsonify({"job_id": job_id})
 
 
-@jobs_write_bp.route('/rerun')
+@jobs_write_bp.route('/rerun', methods=['GET', 'POST'])
 def rerun_job():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    job_id = request.args.get('job_id')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    job_id = _safe_dataset(request.values.get('job_id'), param='job_id')
     progress_file = os.path.join(data_dir, dataset, "jobs", f"{job_id}.json")
+    if not os.path.exists(progress_file):
+        abort(404, description="job not found")
     with open(progress_file) as f:
         job = json.load(f)
     command = job.get('command')
@@ -286,31 +388,40 @@ def rerun_job():
     return jsonify({"job_id": new_job_id})
 
 
-@jobs_write_bp.route('/kill')
+@jobs_write_bp.route('/kill', methods=['GET', 'POST'])
 def kill_job():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    job_id = request.args.get('job_id')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    job_id = _safe_dataset(request.values.get('job_id'), param='job_id')
     progress_file = os.path.join(data_dir, dataset, "jobs", f"{job_id}.json")
+    if not os.path.exists(progress_file):
+        abort(404, description="job not found")
     with open(progress_file) as f:
         job = json.load(f)
-    if job_id in PROCESSES:
-        PROCESSES[job_id].kill()
+    process = PROCESSES.pop(job_id, None)
+    if process is not None:
+        KILLED.add(job_id)
+        process.kill()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            pass
         job["status"] = "dead"
         job["cause_of_death"] = "killed"
     else:
         job["status"] = "dead"
         job["cause_of_death"] = "process not found, presumed dead"
+    job["last_update"] = _now()
     with open(progress_file, 'w') as f:
         json.dump(job, f)
     return jsonify(job)
 
 
-@jobs_write_bp.route('/delete/embedding')
+@jobs_write_bp.route('/delete/embedding', methods=['GET', 'POST'])
 def delete_embedding():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    embedding_id = request.args.get('embedding_id')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    embedding_id = request.values.get('embedding_id')
 
     # Find all umaps that reference this embedding
     umap_dir = os.path.join(data_dir, dataset, 'umaps')
@@ -345,18 +456,18 @@ def delete_embedding():
     return jsonify({"job_id": job_id})
 
 
-@jobs_write_bp.route('/umap')
+@jobs_write_bp.route('/umap', methods=['GET', 'POST'])
 def run_umap():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    embedding_id = request.args.get('embedding_id')
-    sae_id = request.args.get('sae_id')
-    neighbors = request.args.get('neighbors')
-    min_dist = request.args.get('min_dist')
-    init = request.args.get('init')
-    align = request.args.get('align')
-    save = request.args.get('save')
-    seed = request.args.get('seed')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    embedding_id = request.values.get('embedding_id')
+    sae_id = request.values.get('sae_id')
+    neighbors = request.values.get('neighbors')
+    min_dist = request.values.get('min_dist')
+    init = request.values.get('init')
+    align = request.values.get('align')
+    save = request.values.get('save')
+    seed = request.values.get('seed')
 
     err = _require_params(dataset=dataset, embedding_id=embedding_id,
                           neighbors=neighbors, min_dist=min_dist)
@@ -379,11 +490,11 @@ def run_umap():
     return jsonify({"job_id": job_id})
 
 
-@jobs_write_bp.route('/delete/umap')
+@jobs_write_bp.route('/delete/umap', methods=['GET', 'POST'])
 def delete_umap_request():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    umap_id = request.args.get('umap_id')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    umap_id = request.values.get('umap_id')
     return _delete_umap(data_dir, dataset, umap_id)
 
 
@@ -411,13 +522,13 @@ def _delete_umap(data_dir, dataset, umap_id):
     return jsonify({"job_id": job_id})
 
 
-@jobs_write_bp.route('/sae')
+@jobs_write_bp.route('/sae', methods=['GET', 'POST'])
 def run_sae():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    embedding_id = request.args.get('embedding_id')
-    model_id = request.args.get('model_id')
-    k_expansion = request.args.get('k_expansion')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    embedding_id = request.values.get('embedding_id')
+    model_id = request.values.get('model_id')
+    k_expansion = request.values.get('k_expansion')
 
     err = _require_params(dataset=dataset, embedding_id=embedding_id,
                           model_id=model_id, k_expansion=k_expansion)
@@ -430,11 +541,11 @@ def run_sae():
     return jsonify({"job_id": job_id})
 
 
-@jobs_write_bp.route('/delete/sae')
+@jobs_write_bp.route('/delete/sae', methods=['GET', 'POST'])
 def delete_sae_request():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    sae_id = request.args.get('sae_id')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    sae_id = request.values.get('sae_id')
     return _delete_sae(data_dir, dataset, sae_id)
 
 
@@ -459,17 +570,17 @@ def _delete_sae(data_dir, dataset, sae_id):
     return jsonify({"job_id": job_id})
 
 
-@jobs_write_bp.route('/cluster')
+@jobs_write_bp.route('/cluster', methods=['GET', 'POST'])
 def run_cluster():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    umap_id = request.args.get('umap_id')
-    samples = request.args.get('samples')
-    min_samples = request.args.get('min_samples')
-    cluster_selection_epsilon = request.args.get('cluster_selection_epsilon')
-    method = request.args.get('method', 'evoc')
-    n_neighbors = request.args.get('n_neighbors')
-    noise_level = request.args.get('noise_level')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    umap_id = request.values.get('umap_id')
+    samples = request.values.get('samples')
+    min_samples = request.values.get('min_samples')
+    cluster_selection_epsilon = request.values.get('cluster_selection_epsilon')
+    method = request.values.get('method', 'evoc')
+    n_neighbors = request.values.get('n_neighbors')
+    noise_level = request.values.get('noise_level')
 
     err = _require_params(dataset=dataset, umap_id=umap_id, samples=samples)
     if err:
@@ -494,28 +605,28 @@ def run_cluster():
     return jsonify({"job_id": job_id})
 
 
-@jobs_write_bp.route('/delete/cluster')
+@jobs_write_bp.route('/delete/cluster', methods=['GET', 'POST'])
 def delete_cluster():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    cluster_id = request.args.get('cluster_id')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    cluster_id = request.values.get('cluster_id')
     _delete_glob(data_dir, dataset, "clusters", cluster_id)
     job_id = str(uuid.uuid4())
     _write_completed_job(data_dir, dataset, job_id, f"delete cluster {cluster_id}")
     return jsonify({"job_id": job_id})
 
 
-@jobs_write_bp.route('/cluster_label')
+@jobs_write_bp.route('/cluster_label', methods=['GET', 'POST'])
 def run_cluster_label():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    chat_id = request.args.get('chat_id')
-    text_column = request.args.get('text_column')
-    cluster_id = request.args.get('cluster_id')
-    context = request.args.get('context') or ''
-    samples = request.args.get('samples')
-    max_tokens_per_sample = request.args.get('max_tokens_per_sample')
-    max_tokens_total = request.args.get('max_tokens_total')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    chat_id = request.values.get('chat_id')
+    text_column = request.values.get('text_column')
+    cluster_id = request.values.get('cluster_id')
+    context = request.values.get('context') or ''
+    samples = request.values.get('samples')
+    max_tokens_per_sample = request.values.get('max_tokens_per_sample')
+    max_tokens_total = request.values.get('max_tokens_total')
 
     err = _require_params(dataset=dataset, text_column=text_column,
                           cluster_id=cluster_id, chat_id=chat_id, samples=samples)
@@ -532,29 +643,29 @@ def run_cluster_label():
     return jsonify({"job_id": job_id})
 
 
-@jobs_write_bp.route('/delete/cluster_label')
+@jobs_write_bp.route('/delete/cluster_label', methods=['GET', 'POST'])
 def delete_cluster_label():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    cluster_labels_id = request.args.get('cluster_labels_id')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    cluster_labels_id = request.values.get('cluster_labels_id')
     _delete_glob(data_dir, dataset, "clusters", cluster_labels_id)
     job_id = str(uuid.uuid4())
     _write_completed_job(data_dir, dataset, job_id, f"delete cluster labels {cluster_labels_id}")
     return jsonify({"job_id": job_id})
 
 
-@jobs_write_bp.route('/scope')
+@jobs_write_bp.route('/scope', methods=['GET', 'POST'])
 def run_scope():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    embedding_id = request.args.get('embedding_id')
-    sae_id = request.args.get('sae_id')
-    umap_id = request.args.get('umap_id')
-    cluster_id = request.args.get('cluster_id')
-    cluster_labels_id = request.args.get('cluster_labels_id')
-    label = request.args.get('label')
-    description = request.args.get('description')
-    scope_id = request.args.get('scope_id')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    embedding_id = request.values.get('embedding_id')
+    sae_id = request.values.get('sae_id')
+    umap_id = request.values.get('umap_id')
+    cluster_id = request.values.get('cluster_id')
+    cluster_labels_id = request.values.get('cluster_labels_id')
+    label = request.values.get('label')
+    description = request.values.get('description')
+    scope_id = request.values.get('scope_id')
 
     err = _require_params(dataset=dataset, embedding_id=embedding_id,
                           umap_id=umap_id, cluster_id=cluster_id,
@@ -574,23 +685,23 @@ def run_scope():
     return jsonify({"job_id": job_id})
 
 
-@jobs_write_bp.route('/delete/scope')
+@jobs_write_bp.route('/delete/scope', methods=['GET', 'POST'])
 def delete_scope():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    scope_id = request.args.get('scope_id')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    scope_id = request.values.get('scope_id')
     _delete_glob(data_dir, dataset, "scopes", scope_id)
     job_id = str(uuid.uuid4())
     _write_completed_job(data_dir, dataset, job_id, f"delete scope {scope_id}")
     return jsonify({"job_id": job_id})
 
 
-@jobs_write_bp.route('/plot')
+@jobs_write_bp.route('/plot', methods=['GET', 'POST'])
 def run_plot():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    scope_id = request.args.get('scope_id')
-    config = request.args.get('config')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    scope_id = request.values.get('scope_id')
+    config = request.values.get('config')
 
     err = _require_params(dataset=dataset, scope_id=scope_id, config=config)
     if err:
@@ -602,15 +713,16 @@ def run_plot():
     return jsonify({"job_id": job_id})
 
 
-@jobs_write_bp.route('/download_dataset')
+@jobs_write_bp.route('/download_dataset', methods=['GET', 'POST'])
 def download_dataset():
     data_dir = _data_dir()
-    dataset_repo = request.args.get('dataset_repo')
-    dataset_name = request.args.get('dataset_name')
+    dataset_repo = request.values.get('dataset_repo')
+    dataset_name = request.values.get('dataset_name')
 
     err = _require_params(dataset_repo=dataset_repo, dataset_name=dataset_name)
     if err:
         return err
+    dataset_name = _safe_dataset(dataset_name, param='dataset_name')
 
     job_id = str(uuid.uuid4())
     command = ['ls-download-dataset', dataset_repo, dataset_name, data_dir]
@@ -618,13 +730,13 @@ def download_dataset():
     return jsonify({"job_id": job_id})
 
 
-@jobs_write_bp.route('/upload_dataset')
+@jobs_write_bp.route('/upload_dataset', methods=['GET', 'POST'])
 def upload_dataset():
     data_dir = _data_dir()
-    dataset = request.args.get('dataset')
-    hf_dataset = request.args.get('hf_dataset')
-    main_parquet = request.args.get('main_parquet')
-    private = request.args.get('private')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    hf_dataset = request.values.get('hf_dataset')
+    main_parquet = request.values.get('main_parquet')
+    private = request.values.get('private')
 
     err = _require_params(dataset=dataset, hf_dataset=hf_dataset,
                           main_parquet=main_parquet, private=private)
@@ -653,7 +765,7 @@ def _write_completed_job(data_dir, dataset, job_id, description):
         "job_name": description,
         "command": description,
         "status": "completed",
-        "last_update": datetime.now(timezone.utc).isoformat(),
+        "last_update": _now(),
         "progress": [],
         "times": [],
     }

--- a/latentscope/server/search.py
+++ b/latentscope/server/search.py
@@ -4,6 +4,7 @@ import os
 from flask import Blueprint, current_app, jsonify, request
 
 from latentscope.models import get_embedding_model
+from latentscope.server.job_utils import _safe_dataset
 
 # Create a Blueprint
 search_bp = Blueprint('search_bp', __name__)
@@ -26,7 +27,7 @@ def nn():
     import numpy as np
 
     DATA_DIR = _data_dir()
-    dataset = request.args.get('dataset')
+    dataset = _safe_dataset(request.args.get('dataset'))
     scope_id = request.args.get('scope_id')
     embedding_id = request.args.get('embedding_id')
     dimensions = request.args.get('dimensions')
@@ -155,7 +156,7 @@ def feature():
     import numpy as np
 
     DATA_DIR = _data_dir()
-    dataset = request.args.get('dataset')
+    dataset = _safe_dataset(request.args.get('dataset'))
     sae_id = request.args.get('sae_id')
     feature_id = request.args.get('feature_id')
     threshold = request.args.get('threshold')
@@ -199,7 +200,7 @@ def features():
     from latentscope.util.embedding_store import load_embeddings as lance_load
 
     DATA_DIR = _data_dir()
-    dataset = request.args.get('dataset')
+    dataset = _safe_dataset(request.args.get('dataset'))
     embedding_id = request.args.get('embedding_id')
     dimensions = request.args.get('dimensions')
     dimensions = int(dimensions) if dimensions else None
@@ -241,7 +242,7 @@ def compare():
     import pandas as pd
 
     DATA_DIR = _data_dir()
-    dataset = request.args.get('dataset')
+    dataset = _safe_dataset(request.args.get('dataset'))
     umap_left = request.args.get('umap_left')
     umap_right = request.args.get('umap_right')
     metric = request.args.get('metric', 'displacement')
@@ -298,7 +299,7 @@ def compare_neighbors():
     from sklearn.neighbors import NearestNeighbors
 
     DATA_DIR = _data_dir()
-    dataset = request.args.get('dataset')
+    dataset = _safe_dataset(request.args.get('dataset'))
     umap_left = request.args.get('umap_left')
     umap_right = request.args.get('umap_right')
     point_index = int(request.args.get('point_index'))
@@ -331,7 +332,7 @@ def compare_clusters():
     import pandas as pd
 
     DATA_DIR = _data_dir()
-    dataset = request.args.get('dataset')
+    dataset = _safe_dataset(request.args.get('dataset'))
     cluster_left = request.args.get('cluster_left')
     cluster_right = request.args.get('cluster_right')
 

--- a/latentscope/server/tags.py
+++ b/latentscope/server/tags.py
@@ -3,6 +3,8 @@ import os
 import numpy as np
 from flask import Blueprint, current_app, jsonify, request
 
+from latentscope.server.job_utils import _safe_dataset
+
 # Create a Blueprint
 tags_bp = Blueprint('tags_bp', __name__)
 tags_write_bp = Blueprint('tags_write_bp', __name__)
@@ -22,7 +24,7 @@ tagsets = {}
 
 @tags_bp.route("/", methods=['GET'])
 def tags():
-    dataset = request.args.get('dataset')
+    dataset = _safe_dataset(request.args.get('dataset'))
     DATA_DIR = _data_dir()
     tagdir = os.path.join(DATA_DIR, dataset, "tags")
     if not os.path.exists(tagdir):
@@ -39,10 +41,10 @@ def tags():
     return jsonify(tagsets[dataset])
 
 
-@tags_write_bp.route("/new", methods=['GET'])
+@tags_write_bp.route("/new", methods=['GET', 'POST'])
 def new_tag():
-    dataset = request.args.get('dataset')
-    tag = request.args.get('tag')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    tag = _safe_dataset(request.values.get('tag'), param='tag')
     DATA_DIR = _data_dir()
     if dataset not in tagsets:
         tagsets[dataset] = {}
@@ -65,8 +67,8 @@ def new_tag():
 
 @tags_write_bp.route("/add", methods=['GET'])
 def add_tag():
-    dataset = request.args.get('dataset')
-    tag = request.args.get('tag')
+    dataset = _safe_dataset(request.args.get('dataset'))
+    tag = _safe_dataset(request.args.get('tag'), param='tag')
     index = request.args.get('index')
     DATA_DIR = _data_dir()
     if dataset not in tagsets:
@@ -93,8 +95,8 @@ def add_tag():
 @tags_write_bp.route("/add", methods=['POST'])
 def add_tags():
     data = request.get_json()
-    dataset = data.get('dataset')
-    tag = data.get('tag')
+    dataset = _safe_dataset(data.get('dataset'))
+    tag = _safe_dataset(data.get('tag'), param='tag')
     new_indices = data.get('indices')
     DATA_DIR = _data_dir()
 
@@ -124,8 +126,8 @@ def add_tags():
 
 @tags_write_bp.route("/remove", methods=['GET'])
 def remove_tag():
-    dataset = request.args.get('dataset')
-    tag = request.args.get('tag')
+    dataset = _safe_dataset(request.args.get('dataset'))
+    tag = _safe_dataset(request.args.get('tag'), param='tag')
     index = int(request.args.get('index'))
     DATA_DIR = _data_dir()
     if dataset not in tagsets:
@@ -149,8 +151,8 @@ def remove_tag():
 @tags_write_bp.route("/remove", methods=['POST'])
 def remove_tags():
     data = request.get_json()
-    dataset = data.get('dataset')
-    tag = data.get('tag')
+    dataset = _safe_dataset(data.get('dataset'))
+    tag = _safe_dataset(data.get('tag'), param='tag')
     remove_indices = data.get('indices')
     DATA_DIR = _data_dir()
 
@@ -178,10 +180,10 @@ def remove_tags():
     return jsonify(tagsets[dataset])
 
 
-@tags_write_bp.route("/delete", methods=['GET'])
+@tags_write_bp.route("/delete", methods=['GET', 'POST'])
 def delete_tag():
-    dataset = request.args.get('dataset')
-    tag = request.args.get('tag')
+    dataset = _safe_dataset(request.values.get('dataset'))
+    tag = _safe_dataset(request.values.get('tag'), param='tag')
     DATA_DIR = _data_dir()
     if dataset not in tagsets:
         ts = tagsets[dataset] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,9 @@ dev = [
     "pytest-cov>=5.0",
     "ruff>=0.4",
 ]
+serve = [
+    "waitress>=3",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,269 @@
+"""Tests for the subprocess job runner and job routes."""
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+
+from latentscope.server.jobs import PROCESSES, reconcile_stale_jobs, run_job
+
+DATASET = "ds1"
+JOB_ID = "job-test-1"
+
+
+def _job_path(data_dir, job_id=JOB_ID, dataset=DATASET, ext="json"):
+    return os.path.join(data_dir, dataset, "jobs", f"{job_id}.{ext}")
+
+
+def _read_job(data_dir, job_id=JOB_ID, dataset=DATASET):
+    with open(_job_path(data_dir, job_id, dataset)) as f:
+        return json.load(f)
+
+
+def _pid_alive(pid):
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# run_job (called synchronously — the endpoints wrap it in a thread)
+# ---------------------------------------------------------------------------
+
+class TestRunJob:
+    def test_streams_output_and_completes(self, tmp_data_dir):
+        command = [sys.executable, "-c", "print('hello'); print('RUNNING: foo-001')"]
+        run_job(tmp_data_dir, DATASET, JOB_ID, command)
+
+        job = _read_job(tmp_data_dir)
+        assert job["status"] == "completed"
+        assert "hello" in job["progress"]
+        assert job["run_id"] == "foo-001"
+        assert isinstance(job["pid"], int)
+        assert job["job_name"] == sys.executable.replace("ls-", "")
+        assert len(job["times"]) == len(job["progress"])
+        assert JOB_ID not in PROCESSES
+
+    def test_failing_command_sets_error(self, tmp_data_dir):
+        command = [sys.executable, "-c", "import sys; print('boom'); sys.exit(3)"]
+        run_job(tmp_data_dir, DATASET, JOB_ID, command)
+
+        job = _read_job(tmp_data_dir)
+        assert job["status"] == "error"
+        assert "boom" in job["progress"]
+        assert JOB_ID not in PROCESSES
+
+    def test_nonexistent_command_sets_error(self, tmp_data_dir):
+        run_job(tmp_data_dir, DATASET, JOB_ID, ["definitely-not-a-real-binary-xyz"])
+        job = _read_job(tmp_data_dir)
+        assert job["status"] == "error"
+        assert any("Failed to start process" in line for line in job["progress"])
+        assert JOB_ID not in PROCESSES
+
+    def test_log_sidecar_has_all_lines_when_progress_capped(self, tmp_data_dir):
+        n_lines = 600
+        command = [sys.executable, "-c", f"for i in range({n_lines}): print(f'line {{i}}')"]
+        run_job(tmp_data_dir, DATASET, JOB_ID, command)
+
+        job = _read_job(tmp_data_dir)
+        assert job["status"] == "completed"
+        assert len(job["progress"]) <= 500
+        assert len(job["times"]) == len(job["progress"])
+        # last line emitted must be retained
+        assert f"line {n_lines - 1}" in job["progress"]
+
+        log_path = _job_path(tmp_data_dir, ext="log")
+        assert os.path.exists(log_path)
+        with open(log_path) as f:
+            log_lines = [line.strip() for line in f if line.strip()]
+        assert log_lines == [f"line {i}" for i in range(n_lines)]
+
+
+# ---------------------------------------------------------------------------
+# kill endpoint
+# ---------------------------------------------------------------------------
+
+class TestKillJob:
+    def test_kill_running_job(self, client, tmp_data_dir):
+        command = [sys.executable, "-c", "import time; print('started'); time.sleep(60)"]
+        thread = threading.Thread(
+            target=run_job, args=(tmp_data_dir, DATASET, JOB_ID, command)
+        )
+        thread.start()
+
+        # wait for the subprocess to be registered
+        deadline = time.time() + 10
+        while JOB_ID not in PROCESSES and time.time() < deadline:
+            time.sleep(0.05)
+        assert JOB_ID in PROCESSES
+        pid = PROCESSES[JOB_ID].pid
+
+        response = client.get(f'/api/jobs/kill?dataset={DATASET}&job_id={JOB_ID}')
+        assert response.status_code == 200
+        assert response.get_json()["status"] == "dead"
+
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+
+        job = _read_job(tmp_data_dir)
+        assert job["status"] == "dead"
+        assert job["cause_of_death"] == "killed"
+        assert JOB_ID not in PROCESSES
+        assert not _pid_alive(pid)
+
+    def test_kill_unknown_process_marks_dead(self, client, tmp_data_dir):
+        job_dir = os.path.join(tmp_data_dir, DATASET, "jobs")
+        os.makedirs(job_dir)
+        job = {"id": JOB_ID, "status": "running", "progress": [], "times": []}
+        with open(os.path.join(job_dir, f"{JOB_ID}.json"), "w") as f:
+            json.dump(job, f)
+
+        response = client.get(f'/api/jobs/kill?dataset={DATASET}&job_id={JOB_ID}')
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "dead"
+        assert data["cause_of_death"] == "process not found, presumed dead"
+        assert _read_job(tmp_data_dir)["status"] == "dead"
+
+    def test_kill_missing_job_file_404(self, client, tmp_data_dir):
+        response = client.get(f'/api/jobs/kill?dataset={DATASET}&job_id=nope')
+        assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# reconcile_stale_jobs
+# ---------------------------------------------------------------------------
+
+class TestReconcileStaleJobs:
+    def _write_job(self, data_dir, job, job_id=JOB_ID):
+        job_dir = os.path.join(data_dir, DATASET, "jobs")
+        os.makedirs(job_dir, exist_ok=True)
+        with open(os.path.join(job_dir, f"{job_id}.json"), "w") as f:
+            json.dump(job, f)
+
+    def test_dead_pid_marked_error(self, tmp_data_dir):
+        # spawn a process and let it exit so the pid is definitely dead
+        proc = subprocess.Popen([sys.executable, "-c", "pass"])
+        proc.wait()
+        self._write_job(tmp_data_dir, {
+            "id": JOB_ID, "status": "running", "pid": proc.pid,
+            "progress": [], "times": [],
+        })
+
+        reconcile_stale_jobs(tmp_data_dir)
+
+        job = _read_job(tmp_data_dir)
+        assert job["status"] == "error"
+        assert "server restarted while job was running; marked as dead" in job["progress"]
+
+    def test_missing_pid_treated_as_dead(self, tmp_data_dir):
+        self._write_job(tmp_data_dir, {
+            "id": JOB_ID, "status": "running", "progress": [], "times": [],
+        })
+        reconcile_stale_jobs(tmp_data_dir)
+        assert _read_job(tmp_data_dir)["status"] == "error"
+
+    def test_alive_pid_left_running(self, tmp_data_dir):
+        self._write_job(tmp_data_dir, {
+            "id": JOB_ID, "status": "running", "pid": os.getpid(),
+            "progress": [], "times": [],
+        })
+        reconcile_stale_jobs(tmp_data_dir)
+        assert _read_job(tmp_data_dir)["status"] == "running"
+
+    def test_non_running_jobs_untouched(self, tmp_data_dir):
+        self._write_job(tmp_data_dir, {
+            "id": JOB_ID, "status": "completed", "progress": ["done"], "times": [],
+        })
+        reconcile_stale_jobs(tmp_data_dir)
+        job = _read_job(tmp_data_dir)
+        assert job["status"] == "completed"
+        assert job["progress"] == ["done"]
+
+    def test_bad_job_file_does_not_break_startup(self, tmp_data_dir):
+        job_dir = os.path.join(tmp_data_dir, DATASET, "jobs")
+        os.makedirs(job_dir, exist_ok=True)
+        with open(os.path.join(job_dir, "bad.json"), "w") as f:
+            f.write("{not json")
+        reconcile_stale_jobs(tmp_data_dir)  # must not raise
+
+    def test_called_on_create_app(self, tmp_data_dir):
+        self._write_job(tmp_data_dir, {
+            "id": JOB_ID, "status": "running", "progress": [], "times": [],
+        })
+        from latentscope.server.app import create_app
+        create_app(data_dir=tmp_data_dir, read_only=False)
+        assert _read_job(tmp_data_dir)["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# path traversal / input validation
+# ---------------------------------------------------------------------------
+
+class TestValidation:
+    def test_job_endpoint_rejects_traversal(self, client):
+        response = client.get('/api/jobs/job?dataset=../../etc&job_id=x')
+        assert response.status_code == 400
+        assert "error" in response.get_json()
+
+    def test_all_endpoint_rejects_traversal(self, client):
+        response = client.get('/api/jobs/all?dataset=../../etc')
+        assert response.status_code == 400
+        assert "error" in response.get_json()
+
+    def test_job_endpoint_rejects_traversal_job_id(self, client):
+        response = client.get('/api/jobs/job?dataset=ds1&job_id=../../../x')
+        assert response.status_code == 400
+
+    def test_rejects_absolute_path(self, client):
+        response = client.get('/api/jobs/all?dataset=/etc')
+        assert response.status_code == 400
+
+    def test_rejects_missing_dataset(self, client):
+        response = client.get('/api/jobs/all')
+        assert response.status_code == 400
+
+    def test_kill_rejects_traversal(self, client):
+        response = client.get('/api/jobs/kill?dataset=..%5C..%5Cetc&job_id=x')
+        assert response.status_code == 400
+
+    def test_rerun_rejects_traversal(self, client):
+        response = client.get('/api/jobs/rerun?dataset=a/b&job_id=x')
+        assert response.status_code == 400
+
+    def test_ingest_without_file_returns_400_json(self, client):
+        response = client.post('/api/jobs/ingest', data={"dataset": "ds1"})
+        assert response.status_code == 400
+        assert "error" in response.get_json()
+
+    def test_ingest_without_dataset_returns_400_json(self, client):
+        response = client.post('/api/jobs/ingest', data={})
+        assert response.status_code == 400
+        assert "error" in response.get_json()
+
+    def test_tags_rejects_traversal(self, client):
+        response = client.get('/api/tags/?dataset=../../etc')
+        assert response.status_code == 400
+
+    def test_datasets_meta_rejects_traversal(self, client):
+        response = client.get('/api/datasets/..%5C..%5Cetc/meta')
+        assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# mutations accept POST as well as GET
+# ---------------------------------------------------------------------------
+
+class TestPostCompat:
+    def test_kill_via_post_form(self, client, tmp_data_dir):
+        job_dir = os.path.join(tmp_data_dir, DATASET, "jobs")
+        os.makedirs(job_dir)
+        with open(os.path.join(job_dir, f"{JOB_ID}.json"), "w") as f:
+            json.dump({"id": JOB_ID, "status": "running"}, f)
+
+        response = client.post('/api/jobs/kill', data={"dataset": DATASET, "job_id": JOB_ID})
+        assert response.status_code == 200
+        assert response.get_json()["status"] == "dead"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -267,3 +267,29 @@ class TestPostCompat:
         response = client.post('/api/jobs/kill', data={"dataset": DATASET, "job_id": JOB_ID})
         assert response.status_code == 200
         assert response.get_json()["status"] == "dead"
+
+
+def test_readonly_app_does_not_reconcile_jobs(tmp_data_dir):
+    """Codex review on #119: read-only deployments must not mutate the data
+    dir — starting the app in read_only mode must leave stale 'running' job
+    files untouched."""
+    import json
+    import os
+
+    from latentscope.server.app import create_app
+
+    jobs_dir = os.path.join(tmp_data_dir, "some-dataset", "jobs")
+    os.makedirs(jobs_dir)
+    job = {"id": "stale-job", "status": "running", "pid": 99999999,
+           "progress": [], "times": [], "last_update": ""}
+    job_path = os.path.join(jobs_dir, "stale-job.json")
+    with open(job_path, "w") as f:
+        json.dump(job, f)
+
+    create_app(data_dir=tmp_data_dir, read_only=True)
+    with open(job_path) as f:
+        assert json.load(f)["status"] == "running"
+
+    create_app(data_dir=tmp_data_dir, read_only=False)
+    with open(job_path) as f:
+        assert json.load(f)["status"] == "error"

--- a/uv.lock
+++ b/uv.lock
@@ -2463,6 +2463,9 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+serve = [
+    { name = "waitress" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2506,6 +2509,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "ruff", specifier = ">=0.4" },
 ]
+serve = [{ name = "waitress", specifier = ">=3" }]
 
 [[package]]
 name = "lazy-loader"
@@ -6457,6 +6461,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/94/16/1b46b3cd401e1717a68197c1fe336d7bb4e0a1833f8105e1738f5b1add05/voyageai-0.3.7.tar.gz", hash = "sha256:826cd97f97223f42b5babc5c459c9c80f3a8215ce5c0e007b0b276550f790d24", size = 26485, upload-time = "2025-12-16T18:43:05.26Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/64/89f6325666d6836979f94ac88b96fefc7527e02e61abc81359843585e088/voyageai-0.3.7-py3-none-any.whl", hash = "sha256:909f6c033001e5a3b3caf970525bf3614a1bfef9003cf3c3b68207dfdb53e86d", size = 34691, upload-time = "2025-12-16T18:43:04.073Z" },
+]
+
+[[package]]
+name = "waitress"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/cb/04ddb054f45faa306a230769e868c28b8065ea196891f09004ebace5b184/waitress-3.0.2.tar.gz", hash = "sha256:682aaaf2af0c44ada4abfb70ded36393f0e307f4ab9456a215ce0020baefc31f", size = 179901, upload-time = "2024-11-16T20:02:35.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/57/a27182528c90ef38d82b636a11f606b0cbb0e17588ed205435f8affe3368/waitress-3.0.2-py3-none-any.whl", hash = "sha256:c56d67fd6e87c2ee598b76abdd4e96cfad1f24cacdea5078d382b1f9d7b5ed2e", size = 56232, upload-time = "2024-11-16T20:02:33.858Z" },
 ]
 
 [[package]]

--- a/web/src/components/Job/Progress.jsx
+++ b/web/src/components/Job/Progress.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect, useMemo } from 'react';
+import { useRef, useState, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import './Progress.css';
@@ -22,21 +22,23 @@ function JobProgress({
   const preRef = useRef(null);
   const [onlyLast, setOnlyLast] = useState(overrideOnlyLast);
 
+  const isError = job?.status == 'error' || !!job?.error;
+
   useEffect(() => {
     if (preRef.current) {
       preRef.current.scrollTop = preRef.current.scrollHeight;
     }
-    if (job?.status == 'error' && !allwaysOnlyLast) {
+    if (isError && !allwaysOnlyLast) {
       setOnlyLast(false);
     }
-  }, [job, allwaysOnlyLast]);
+  }, [job, isError, allwaysOnlyLast]);
 
   const history = useMemo(() => {
-    return job?.progress.filter((d) => !!d);
+    return (job?.progress || []).filter((d) => !!d);
   }, [job]);
 
   const secondsSinceLastUpdate = Math.round((+new Date() - +new Date(job?.last_update)) / 1000);
-  const totalTime = Math.round((+new Date(job?.last_update) - +new Date(job?.times[0])) / 1000);
+  const totalTime = Math.round((+new Date(job?.last_update) - +new Date(job?.times?.[0])) / 1000);
 
   return (
     <>
@@ -46,6 +48,12 @@ function JobProgress({
           <br />
           <code>{job.command}</code>
           <pre ref={preRef}>{onlyLast ? history[history.length - 1] : history.join('\n')}</pre>
+          {isError ? (
+            <div className="job-progress-error" style={{ color: '#b00020' }}>
+              <b>Job failed{job.error ? `: ${job.error}` : ''}</b>
+              {history.length ? <pre>{history.slice(-5).join('\n')}</pre> : null}
+            </div>
+          ) : null}
           {clearJob && job.status == 'completed' ? (
             <button onClick={clearJob}>👍 Dismiss</button>
           ) : null}
@@ -58,7 +66,7 @@ function JobProgress({
               💀 Kill
             </button>
           ) : null}
-          {job.status == 'error' ? (
+          {isError ? (
             <div className="error-choices">
               {clearJob ? <button onClick={clearJob}>🤬 Dismiss</button> : null}
               {rerunJob ? <button onClick={() => rerunJob(job)}>🔁 Rerun</button> : null}

--- a/web/src/components/Job/Run.jsx
+++ b/web/src/components/Job/Run.jsx
@@ -1,66 +1,139 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 const apiUrl = import.meta.env.VITE_API_URL;
 
+const TERMINAL_STATUSES = ['completed', 'error', 'dead'];
+// number of consecutive failed polls tolerated before giving up
+const MAX_CONSECUTIVE_ERRORS = 5;
+
+/**
+ * Start polling a job's status file. Plain function (no React) so it can be
+ * used outside hooks; returns a cleanup function that stops the polling.
+ *
+ * On transient fetch/HTTP errors it keeps polling for up to
+ * MAX_CONSECUTIVE_ERRORS attempts, then stops and reports an error-shaped job
+ * ({ ...lastKnownJob, status: 'error', error }) instead of null so the UI can
+ * keep showing the terminal output.
+ */
 function jobPolling(dataset, setJob, jobId, intervalms = 500) {
   let intervalId = null;
-  console.log('start polling', jobId);
-  intervalId = setInterval(() => {
+  let stopped = false;
+  let consecutiveErrors = 0;
+  let lastKnownJob = { id: jobId };
+
+  const stop = () => {
+    stopped = true;
+    if (intervalId !== null) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+  };
+
+  const poll = () => {
     fetch(`${apiUrl}/jobs/job?dataset=${dataset?.id}&job_id=${jobId}`)
       .then((response) => {
         if (!response.ok) {
-          clearInterval(intervalId);
-          setJob(null);
           throw new Error(`HTTP error! status: ${response.status}`);
         }
         return response.json();
       })
       .then((jobData) => {
-        console.log('polling job status', jobData);
-        setJob(jobData);
-        if (
-          jobData.status === 'completed' ||
-          jobData.status === 'error' ||
-          jobData.status == 'dead'
-        ) {
-          clearInterval(intervalId);
-          setTimeout(() => {
-            setJob(null);
-            setJob(jobData);
-          }, intervalms);
+        if (stopped) return;
+        consecutiveErrors = 0;
+        lastKnownJob = jobData;
+        if (TERMINAL_STATUSES.includes(jobData.status)) {
+          stop();
         }
+        setJob(jobData);
       })
       .catch((error) => {
+        if (stopped) return;
+        consecutiveErrors += 1;
         console.error('Error polling job status', error);
-        clearInterval(intervalId);
-        setJob(null);
-        // TODO: have some kind of error state persist
+        if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+          stop();
+          setJob({ ...lastKnownJob, status: 'error', error: error.message });
+        }
       });
-  }, intervalms);
-  // console.log("returning jobPolling cleanup")
-  return () => {
-    console.log('inside cleanup', intervalId);
-    if (intervalId) {
-      clearInterval(intervalId);
-    }
   };
+
+  intervalId = setInterval(poll, intervalms);
+  return stop;
 }
 
+/**
+ * Hook wrapper around jobPolling with proper lifecycle:
+ * - keeps the active poller in a ref; starting a new poll stops the previous
+ *   one (no duplicate pollers)
+ * - stops polling and suppresses setJob calls after unmount
+ */
+function useJobPolling(dataset, setJob, intervalms = 500) {
+  const stopRef = useRef(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (stopRef.current) {
+        stopRef.current();
+        stopRef.current = null;
+      }
+    };
+  }, []);
+
+  const safeSetJob = useCallback(
+    (job) => {
+      if (mountedRef.current) setJob(job);
+    },
+    [setJob]
+  );
+
+  const stopPolling = useCallback(() => {
+    if (stopRef.current) {
+      stopRef.current();
+      stopRef.current = null;
+    }
+  }, []);
+
+  const startPolling = useCallback(
+    (jobId) => {
+      stopPolling();
+      stopRef.current = jobPolling(dataset, safeSetJob, jobId, intervalms);
+    },
+    [dataset, safeSetJob, intervalms, stopPolling]
+  );
+
+  return { startPolling, stopPolling, safeSetJob };
+}
+
+/**
+ * Kick off a job via a GET endpoint and poll its status until it reaches a
+ * terminal state. Returns { startJob }.
+ */
 function useStartJobPolling(dataset, setJob, url, intervalms = 500) {
-  // const [job, setJob] = useState(null);
+  const { startPolling, safeSetJob } = useJobPolling(dataset, setJob, intervalms);
+
   const startJob = useCallback(
     (params) => {
-      fetch(`${url}?dataset=${dataset.id}&${new URLSearchParams(params)}`)
-        .then((response) => response.json())
+      fetch(`${url}?dataset=${dataset?.id}&${new URLSearchParams(params)}`)
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+          }
+          return response.json();
+        })
         .then((data) => {
-          const jobId = data.job_id;
-          const cleanup = jobPolling(dataset, setJob, jobId, intervalms);
-          // console.log("start job cleanup", cleanup)
-          // setCleanup(cleanup)
+          startPolling(data.job_id);
+        })
+        .catch((error) => {
+          console.error('Error starting job', error);
+          safeSetJob({ status: 'error', error: error.message });
         });
     },
-    [dataset, setJob, url]
+    [dataset, url, startPolling, safeSetJob]
   );
-  return { startJob }; //, job, setJob };
+
+  return { startJob };
 }
 
-export { jobPolling, useStartJobPolling };
+export { jobPolling, useJobPolling, useStartJobPolling };

--- a/web/src/components/Job/Run.test.jsx
+++ b/web/src/components/Job/Run.test.jsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { jobPolling, useStartJobPolling } from './Run';
+
+const dataset = { id: 'ds1' };
+const URL = 'http://api/jobs/embed';
+
+function jsonResponse(body, ok = true, status = 200) {
+  return Promise.resolve({ ok, status, json: () => Promise.resolve(body) });
+}
+
+async function tick(ms) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('useStartJobPolling', () => {
+  it('polls until the job completes, then stops', async () => {
+    const responses = [
+      { job_id: 'j1' }, // startJob response
+      { id: 'j1', status: 'running', progress: ['step 1'] },
+      { id: 'j1', status: 'running', progress: ['step 1', 'step 2'] },
+      { id: 'j1', status: 'completed', progress: ['step 1', 'step 2', 'done'] },
+    ];
+    const fetchMock = vi.fn(() => jsonResponse(responses.shift()));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const setJob = vi.fn();
+    const { result } = renderHook(() => useStartJobPolling(dataset, setJob, URL));
+
+    await act(async () => {
+      result.current.startJob({ foo: 'bar' });
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toContain(`${URL}?dataset=ds1&foo=bar`);
+
+    await tick(500);
+    expect(setJob).toHaveBeenLastCalledWith(expect.objectContaining({ status: 'running' }));
+
+    await tick(500);
+    await tick(500);
+    expect(setJob).toHaveBeenLastCalledWith(expect.objectContaining({ status: 'completed' }));
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+
+    // terminal status reached: interval must be cleared, no more polling
+    await tick(3000);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('keeps polling through transient errors and recovers', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => jsonResponse({ job_id: 'j1' }))
+      .mockImplementationOnce(() => Promise.reject(new Error('blip')))
+      .mockImplementationOnce(() => jsonResponse({}, false, 500))
+      .mockImplementation(() => jsonResponse({ id: 'j1', status: 'running', progress: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const setJob = vi.fn();
+    const { result } = renderHook(() => useStartJobPolling(dataset, setJob, URL));
+    await act(async () => {
+      result.current.startJob({});
+    });
+
+    await tick(500); // network error — swallowed
+    await tick(500); // HTTP 500 — swallowed
+    expect(setJob).not.toHaveBeenCalled();
+
+    await tick(500); // recovers
+    expect(setJob).toHaveBeenLastCalledWith(expect.objectContaining({ status: 'running' }));
+  });
+
+  it('sets an error-shaped job (not null) after persistent fetch failures', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => jsonResponse({ job_id: 'j1' }))
+      .mockImplementation(() => Promise.reject(new Error('network down')));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const setJob = vi.fn();
+    const { result } = renderHook(() => useStartJobPolling(dataset, setJob, URL));
+    await act(async () => {
+      result.current.startJob({});
+    });
+
+    for (let i = 0; i < 5; i++) {
+      await tick(500);
+    }
+    expect(setJob).toHaveBeenCalledTimes(1);
+    const arg = setJob.mock.calls[0][0];
+    expect(arg).not.toBeNull();
+    expect(arg.status).toBe('error');
+    expect(arg.error).toBe('network down');
+    expect(arg.id).toBe('j1');
+
+    // polling stopped after giving up
+    const calls = fetchMock.mock.calls.length;
+    await tick(3000);
+    expect(fetchMock.mock.calls.length).toBe(calls);
+  });
+
+  it('reports an error when starting the job fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new Error('boom')))
+    );
+    const setJob = vi.fn();
+    const { result } = renderHook(() => useStartJobPolling(dataset, setJob, URL));
+    await act(async () => {
+      result.current.startJob({});
+    });
+    expect(setJob).toHaveBeenCalledWith(expect.objectContaining({ status: 'error', error: 'boom' }));
+  });
+
+  it('clears the interval on unmount: no fetch or setJob afterwards', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => jsonResponse({ job_id: 'j1' }))
+      .mockImplementation(() => jsonResponse({ id: 'j1', status: 'running', progress: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const setJob = vi.fn();
+    const { result, unmount } = renderHook(() => useStartJobPolling(dataset, setJob, URL));
+    await act(async () => {
+      result.current.startJob({});
+    });
+    await tick(500);
+    expect(setJob).toHaveBeenCalledTimes(1);
+
+    const fetchCalls = fetchMock.mock.calls.length;
+    const setJobCalls = setJob.mock.calls.length;
+    unmount();
+
+    await tick(5000);
+    expect(fetchMock.mock.calls.length).toBe(fetchCalls);
+    expect(setJob.mock.calls.length).toBe(setJobCalls);
+  });
+});
+
+describe('jobPolling (plain function API)', () => {
+  it('returns a cleanup function that stops polling', async () => {
+    const fetchMock = vi.fn(() => jsonResponse({ id: 'j1', status: 'running', progress: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const setJob = vi.fn();
+    const stop = jobPolling(dataset, setJob, 'j1', 500);
+    await tick(500);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(setJob).toHaveBeenCalledTimes(1);
+
+    stop();
+    await tick(3000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(setJob).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/pages/Job.jsx
+++ b/web/src/pages/Job.jsx
@@ -1,10 +1,10 @@
 import { useEffect, useState, useMemo, useCallback } from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
-import { useStartJobPolling, jobPolling } from '../components/Job/Run';
+import { useStartJobPolling, useJobPolling } from '../components/Job/Run';
 import JobProgress from '../components/Job/Progress';
 
-import { apiService, apiUrl } from '../lib/apiService';
+import { apiUrl } from '../lib/apiService';
 
 function Job({ datasetId, jobId }) {
   const [dataset, setDataset] = useState(null);
@@ -12,14 +12,18 @@ function Job({ datasetId, jobId }) {
   const navigate = useNavigate();
   const [job, setJob] = useState(null);
 
+  // jobPolling only needs the dataset id; memoize so the polling callbacks
+  // stay stable and don't restart when the dataset metadata loads
+  const datasetRef = useMemo(() => ({ id: datasetId }), [datasetId]);
+  const { startPolling, stopPolling } = useJobPolling(datasetRef, setJob, 200);
+
   const jobCB = useCallback(
     (job) => {
-      console.log('new job', job);
       if (job) navigate(`/datasets/${datasetId}/jobs/${job.id}`);
     },
     [datasetId, navigate]
   );
-  const { startJob: rerunJob } = useStartJobPolling(dataset, jobCB, `${apiUrl}/jobs/rerun`);
+  const { startJob: rerunJob } = useStartJobPolling(datasetRef, jobCB, `${apiUrl}/jobs/rerun`);
 
   useEffect(() => {
     fetch(`${apiUrl}/datasets/${datasetId}/meta`)
@@ -29,18 +33,22 @@ function Job({ datasetId, jobId }) {
   }, [datasetId, setDataset]);
 
   useEffect(() => {
+    let cancelled = false;
     fetch(`${apiUrl}/jobs/job?dataset=${datasetId}&job_id=${jobId}`)
       .then((response) => response.json())
       .then((data) => {
-        console.log('job', data);
+        if (cancelled) return;
         setJob(data);
         if (data?.status === 'running') {
-          // start polling
-          jobPolling(dataset, setJob, data.id, 200);
+          startPolling(data.id);
         }
       })
       .catch(console.error);
-  }, [datasetId, jobId, setJob, dataset]);
+    return () => {
+      cancelled = true;
+      stopPolling();
+    };
+  }, [datasetId, jobId, startPolling, stopPolling]);
 
   function handleKill(job) {
     fetch(`${apiUrl}/jobs/kill?dataset=${datasetId}&job_id=${job.id}`)
@@ -66,8 +74,6 @@ function Job({ datasetId, jobId }) {
           <span className="job-status" style={{ fontWeight: 'bold', padding: '5px' }}>
             {job.status}
           </span>
-          {/* { job.status == "running" ? <button onClick={() => {handleKill(job)}}>💀 Kill</button> : null} */}
-          {/* { job.status == "error" || job.status == "dead" ? <button onClick={() => {handleRerun(job)}}>🔁 Rerun</button> : null} */}
           <JobProgress
             job={job}
             rerunJob={handleRerun}

--- a/web/src/pages/Job.jsx
+++ b/web/src/pages/Job.jsx
@@ -19,7 +19,13 @@ function Job({ datasetId, jobId }) {
 
   const jobCB = useCallback(
     (job) => {
-      if (job) navigate(`/datasets/${datasetId}/jobs/${job.id}`);
+      if (job?.id) {
+        navigate(`/datasets/${datasetId}/jobs/${job.id}`);
+      } else if (job) {
+        // error-shaped object from a failed start/rerun (no id):
+        // show it on this page instead of navigating to /jobs/undefined
+        setJob(job);
+      }
     },
     [datasetId, navigate]
   );


### PR DESCRIPTION
Part 3 of the review-plan series. **Stacked on #118** — merge order: #116 → #117 → #118 → this.

The job runner is the backbone of the entire Setup UX (the terminal passthru showing script output in the browser) and was the most fragile user-facing path. This PR hardens both ends of it.

## Backend (`latentscope/server/jobs.py`)

- **Timeout now kills the subprocess.** The 5-minute no-output timeout previously marked the job as error while the child kept running and holding the GPU.
- **`PROCESSES` registry no longer leaks** — handles popped in `finally` on every exit path.
- **Server restarts no longer leave zombie jobs in the UI.** The subprocess pid is persisted in the job file; `reconcile_stale_jobs()` runs at startup and marks `running` jobs with dead pids as errored (previously the UI polled a stuck "running" file forever).
- **O(n²) I/O fixed**: every output line was rewriting the entire growing job JSON. Now lines stream to a `<job_id>.log` sidecar, `progress` is capped at the last 500 lines, and the JSON is written at most every 0.5s (always on status changes). The UI was re-downloading the unbounded JSON every 500ms.
- **Path traversal closed**: `_safe_dataset()` (400 on `/`, `..`, absolute) applied across jobs/tags/search/bulk/datasets endpoints — query/body params could previously escape the data dir (`?dataset=../../etc`). Ingest uploads go through `secure_filename` and malformed uploads return 400 JSON instead of a 500.
- **JSON error handler** — API errors return JSON instead of HTML 500 pages.
- **Mutations accept POST** (GET kept for frontend compat; client migration lands with Part 4).
- **Production server**: `ls-serve` uses waitress (8 threads) when available — the single-threaded Flask dev server meant any heavy request blocked job-status polling. `LATENT_SCOPE_DEBUG=1` forces the dev server.

## Frontend (`web/src/components/Job/`)

- **Polling lifecycle rewrite**: intervals previously leaked after unmount (cleanup function was discarded), `pages/Job.jsx` started duplicate concurrent pollers, and any single fetch blip cleared the job to `null` — the terminal UI silently vanished while the backend job kept running (the code had a `// TODO: have some kind of error state persist`). Now: ref-managed poller with unmount cleanup, tolerates 5 consecutive transient errors, then surfaces a persistent error state.
- **Progress.jsx renders failures** ("Job failed: …" + last progress lines) instead of disappearing. Kill/dismiss/rerun intact.
- Exported hook API unchanged — all 14 call sites work untouched.

## Tests

- `tests/test_jobs.py` (+31): real-subprocess streaming/run_id/pid capture, failure status, kill endpoint against a live process, startup reconciliation, path-traversal 400s, ingest validation, log-sidecar completeness when progress is capped, POST compat. **The job runner had zero tests before.**
- `Run.test.jsx` (+6): poll-to-completion, persistent-error state, no polling after unmount.

**Verified locally:** 98 passed + 1 skipped (python), 32 passed (web), ruff clean.

Known limitation (unchanged from before): the no-output timeout only fires when `readline()` returns; a child that blocks the pipe without closing it still hangs the reader thread. Fully async pipe handling is follow-up work (issue #4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)