### PR TITLE
Fix: late-interaction search was unreachable from the UI

### DIFF
--- a/latentscope/server/search.py
+++ b/latentscope/server/search.py
@@ -34,7 +34,10 @@ def nn():
     dimensions = request.args.get('dimensions')
     dimensions = int(dimensions) if dimensions else None
     query = request.args.get('query')
-    use_late_interaction = request.args.get('late_interaction', 'false').lower() == 'true'
+    # Late interaction (MaxSim over stored token vectors) is the point of a
+    # ColBERT-style embedding, so it's the default whenever the embedding
+    # supports it. Pass late_interaction=false to force mean-vector ANN.
+    use_late_interaction = request.args.get('late_interaction', 'true').lower() == 'true'
 
     cache_key = dataset + "-" + embedding_id
     model = EMBEDDINGS.get(cache_key)

--- a/tests/test_search_late_interaction.py
+++ b/tests/test_search_late_interaction.py
@@ -1,0 +1,76 @@
+"""Regression (Codex review on #122): the UI never sends late_interaction=true,
+so MaxSim search must be the server-side default whenever the embedding has
+token vectors."""
+
+import json
+import os
+
+import numpy as np
+import pytest
+
+
+class FakeLIProvider:
+    late_interaction = True
+
+    def __init__(self):
+        self.embed_multi_calls = []
+        self.embed_calls = []
+
+    def load_model(self):
+        pass
+
+    def embed_multi(self, inputs, dimensions=None, is_query=False):
+        self.embed_multi_calls.append({"inputs": inputs, "is_query": is_query})
+        rng = np.random.default_rng(0)
+        tokens = [rng.normal(size=(4, 8)).astype(np.float32) for _ in inputs]
+        tokens = [t / np.linalg.norm(t, axis=1, keepdims=True) for t in tokens]
+        means = np.array([t.mean(axis=0) for t in tokens], dtype=np.float32)
+        return means, tokens
+
+    def embed(self, inputs, dimensions=None):
+        self.embed_calls.append(inputs)
+        means, _ = self.embed_multi(inputs, dimensions)
+        return means.tolist()
+
+
+@pytest.fixture
+def li_dataset(tmp_data_dir):
+    from latentscope.util.embedding_store import append_embeddings
+
+    dataset_id = "li-ds"
+    emb_dir = os.path.join(tmp_data_dir, dataset_id, "embeddings")
+    os.makedirs(emb_dir)
+    rng = np.random.default_rng(1)
+    vectors = rng.normal(size=(20, 8)).astype(np.float32)
+    tokens = [rng.normal(size=(4, 8)).astype(np.float32) for _ in range(20)]
+    append_embeddings(tmp_data_dir, dataset_id, "embedding-001", vectors,
+                      token_vectors_list=tokens)
+    with open(os.path.join(emb_dir, "embedding-001.json"), "w") as f:
+        json.dump({"id": "embedding-001", "model_id": "fake-li",
+                   "late_interaction": True, "dimensions": 8}, f)
+    return dataset_id
+
+
+def test_nn_defaults_to_maxsim_for_late_interaction(client, li_dataset, monkeypatch):
+    import latentscope.server.search as search_mod
+
+    provider = FakeLIProvider()
+    monkeypatch.setattr(search_mod, "get_embedding_model", lambda mid: provider)
+    search_mod.EMBEDDINGS.clear() if hasattr(search_mod.EMBEDDINGS, "clear") else None
+
+    # no late_interaction param — the UI's actual request shape
+    res = client.get(f"/api/search/nn?dataset={li_dataset}"
+                     f"&embedding_id=embedding-001&query=hello")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert "indices" in data and len(data["indices"]) > 0
+    # MaxSim path encodes the query with is_query=True via embed_multi
+    assert any(c["is_query"] for c in provider.embed_multi_calls)
+
+    # explicit opt-out forces the mean-vector path
+    provider.embed_multi_calls.clear()
+    res = client.get(f"/api/search/nn?dataset={li_dataset}"
+                     f"&embedding_id=embedding-001&query=hello"
+                     f"&late_interaction=false")
+    assert res.status_code == 200
+    assert not any(c["is_query"] for c in provider.embed_multi_calls)


### PR DESCRIPTION
Follow-up to the Codex comment on #122: `/search/nn` only entered the MaxSim/token-vector path when the request carried `late_interaction=true`, and no client ever sent that flag — so searches against ColBERT embeddings silently used ordinary mean-vector ANN.

Fix: the server now defaults to late-interaction search whenever the embedding actually has token vectors (the existing capability checks still gate it); `late_interaction=false` forces the mean-vector path. Clients don't need to know about storage internals, so no frontend change is required.

Regression test: a flag-less `/nn` request (the UI's real shape) against a late-interaction embedding must encode the query with `is_query=True` and rank via MaxSim; the explicit opt-out must not.

Verified: 114 passed + 1 skipped, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)