### PR TITLE
Image display: serve images by reference in table and hover tooltip

### DIFF
--- a/latentscope/server/app.py
+++ b/latentscope/server/app.py
@@ -21,6 +21,70 @@ def _parse_bool_env(value):
     return value.lower() in ('true', '1', 't', 'y', 'yes')
 
 
+def _image_columns(data_dir, dataset):
+    """Column names flagged ``type: "image"`` in the dataset's meta.json."""
+    meta_path = os.path.join(data_dir, dataset, "meta.json")
+    try:
+        with open(meta_path, encoding='utf-8') as f:
+            meta = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return []
+    column_metadata = meta.get("column_metadata") or {}
+    return [
+        col for col, col_meta in column_metadata.items()
+        if isinstance(col_meta, dict) and col_meta.get("type") == "image"
+    ]
+
+
+def _load_dataset_dataframe(data_dir, dataset, dataframes):
+    """Load (and cache) a dataset's input.parquet, excluding image columns.
+
+    Binary image columns are dropped at parquet-read time: their bytes can't
+    be JSON serialized and would otherwise bloat the in-memory DATAFRAMES
+    cache by GBs. The frontend reconstructs image display from column
+    metadata + row index via /api/datasets/<dataset>/image. Datasets with no
+    image columns are read exactly as before.
+    """
+    if dataset in dataframes:
+        return dataframes[dataset]
+
+    import pandas as pd
+
+    file_path = os.path.join(data_dir, dataset, "input.parquet")
+    image_cols = _image_columns(data_dir, dataset)
+    if image_cols:
+        import pyarrow.parquet as pq
+        schema_names = pq.ParquetFile(file_path).schema_arrow.names
+        keep = [col for col in schema_names if col not in image_cols]
+        df = pd.read_parquet(file_path, columns=keep)
+    else:
+        df = pd.read_parquet(file_path)
+    dataframes[dataset] = df
+    return df
+
+
+def _sanitize_bytes_for_json(df):
+    """Defensively null out values that would break ``DataFrame.to_json``.
+
+    Raw bytes (or HF-style dicts containing bytes) can't be serialized as
+    JSON; any such value that still reaches the serialization path is
+    replaced with None rather than 500ing. Mutates and returns ``df`` (pass
+    a copy)."""
+    def _contains_bytes(value):
+        if isinstance(value, (bytes, bytearray)):
+            return True
+        if isinstance(value, dict):
+            return any(isinstance(v, (bytes, bytearray)) for v in value.values())
+        return False
+
+    for col in df.columns:
+        if df[col].dtype == object:
+            mask = df[col].map(_contains_bytes)
+            if mask.any():
+                df[col] = df[col].where(~mask, None)
+    return df
+
+
 def create_app(data_dir=None, read_only=None):
     """Application factory.
 
@@ -137,7 +201,6 @@ def create_app(data_dir=None, read_only=None):
     def indexed():
         import h5py
         import numpy as np
-        import pandas as pd
 
         req = request.get_json()
         dataset = req['dataset']
@@ -146,15 +209,12 @@ def create_app(data_dir=None, read_only=None):
         embedding_id = req.get('embedding_id')
         sae_id = req.get('sae_id')
 
-        dataframes = app.config['DATAFRAMES']
-        if dataset not in dataframes:
-            df = pd.read_parquet(os.path.join(data_dir, dataset, "input.parquet"))
-            dataframes[dataset] = df
-        else:
-            df = dataframes[dataset]
+        df = _load_dataset_dataframe(data_dir, dataset, app.config['DATAFRAMES'])
 
         if columns:
-            df = df[columns]
+            # image columns are excluded at read time, so drop them from any
+            # requested column list rather than KeyError-ing
+            df = df[[col for col in columns if col in df.columns]]
 
         valid_indices = [i for i in indices if i < len(df)]
         rows = df.iloc[valid_indices].copy()
@@ -181,22 +241,15 @@ def create_app(data_dir=None, read_only=None):
             rows['sae_acts'] = filtered_acts.tolist()
             rows['sae_indices'] = filtered_top_inds.tolist()
 
-        return rows.to_json(orient="records")
+        return _sanitize_bytes_for_json(rows).to_json(orient="records")
 
     @app.route('/api/column-filter', methods=['POST'])
     def column_filter():
-        import pandas as pd
-
         req = request.get_json()
         dataset = req['dataset']
         filters = req['filters']
 
-        dataframes = app.config['DATAFRAMES']
-        if dataset not in dataframes:
-            df = pd.read_parquet(os.path.join(data_dir, dataset, "input.parquet"))
-            dataframes[dataset] = df
-        else:
-            df = dataframes[dataset]
+        df = _load_dataset_dataframe(data_dir, dataset, app.config['DATAFRAMES'])
 
         rows = df.copy()
         if filters:
@@ -223,7 +276,6 @@ def create_app(data_dir=None, read_only=None):
     def query():
         import h5py
         import numpy as np
-        import pandas as pd
 
         per_page = 100
         req = request.get_json()
@@ -234,12 +286,7 @@ def create_app(data_dir=None, read_only=None):
         sae_id = req.get('sae_id')
         sort = req.get('sort')
 
-        dataframes = app.config['DATAFRAMES']
-        if dataset not in dataframes:
-            df = pd.read_parquet(os.path.join(data_dir, dataset, "input.parquet"))
-            dataframes[dataset] = df
-        else:
-            df = dataframes[dataset]
+        df = _load_dataset_dataframe(data_dir, dataset, app.config['DATAFRAMES'])
 
         rows = df.copy()
         rows['ls_index'] = rows.index
@@ -273,7 +320,8 @@ def create_app(data_dir=None, read_only=None):
         if sort:
             rows = rows.sort_values(by=sort['column'], ascending=sort['ascending'])
 
-        rows_json = json.loads(rows[page * per_page:page * per_page + per_page].to_json(orient="records"))
+        page_rows = rows[page * per_page:page * per_page + per_page].copy()
+        rows_json = json.loads(_sanitize_bytes_for_json(page_rows).to_json(orient="records"))
         return jsonify({
             "rows": rows_json,
             "page": page,

--- a/latentscope/server/datasets.py
+++ b/latentscope/server/datasets.py
@@ -87,6 +87,95 @@ def update_dataset_meta(dataset):
     return jsonify(json_contents)
 
 
+@datasets_bp.route('/<dataset>/image', methods=['GET'])
+def get_dataset_image(dataset):
+    """Serve a single image cell from input.parquet.
+
+    Query params:
+        column: name of an image-typed column (per meta.json column_metadata).
+        index:  row index into the dataset.
+        size:   optional max dimension; when given the image is thumbnailed
+                and re-encoded as WebP. Capped at 1024.
+
+    Only the row group containing the requested row is read (restricted to
+    the one column), so multi-GB image datasets are never fully loaded.
+    """
+    import io
+
+    import pyarrow.parquet as pq
+    from flask import Response
+    from PIL import Image
+
+    column = request.args.get('column')
+    meta_path = os.path.join(_data_dir(), dataset, "meta.json")
+    try:
+        with open(meta_path, encoding='utf-8') as f:
+            meta = json.load(f)
+    except OSError:
+        return jsonify({"error": f"dataset {dataset} not found"}), 404
+    column_meta = (meta.get("column_metadata") or {}).get(column)
+    if not isinstance(column_meta, dict) or column_meta.get("type") != "image":
+        return jsonify({"error": f"column {column!r} is not an image column"}), 400
+
+    size = request.args.get('size')
+    if size is not None:
+        try:
+            size = int(size)
+        except ValueError:
+            return jsonify({"error": "size must be an integer"}), 400
+        if size < 1 or size > 1024:
+            return jsonify({"error": "size must be between 1 and 1024"}), 400
+
+    file_path = os.path.join(_data_dir(), dataset, "input.parquet")
+    parquet_file = pq.ParquetFile(file_path)
+    try:
+        index = int(request.args.get('index'))
+    except (TypeError, ValueError):
+        return jsonify({"error": "index must be an integer"}), 404
+    if index < 0 or index >= parquet_file.metadata.num_rows:
+        return jsonify({"error": "index out of range"}), 404
+
+    # Locate the row group containing the row via cumulative row counts.
+    offset = 0
+    for row_group in range(parquet_file.metadata.num_row_groups):
+        n_rows = parquet_file.metadata.row_group(row_group).num_rows
+        if index < offset + n_rows:
+            break
+        offset += n_rows
+    table = parquet_file.read_row_group(row_group, columns=[column])
+    value = table.column(0)[index - offset].as_py()
+
+    # Cell values are HF-style {"bytes": ..., "path": ...} dicts or raw bytes.
+    if isinstance(value, dict):
+        value = value.get("bytes")
+    if isinstance(value, bytearray):
+        value = bytes(value)
+    if not isinstance(value, bytes) or len(value) == 0:
+        return jsonify({"error": "no image bytes at this index"}), 404
+
+    headers = {"Cache-Control": "public, max-age=86400"}
+
+    if size is not None:
+        try:
+            img = Image.open(io.BytesIO(value))
+            if img.mode not in ("RGB", "RGBA", "L"):
+                img = img.convert("RGB")
+            img.thumbnail((size, size))
+            buf = io.BytesIO()
+            img.save(buf, format="WEBP", quality=80)
+        except Exception:
+            return jsonify({"error": "could not decode image"}), 404
+        return Response(buf.getvalue(), mimetype="image/webp", headers=headers)
+
+    try:
+        fmt = Image.open(io.BytesIO(value)).format
+    except Exception:
+        fmt = None
+    Image.init()  # make sure Image.MIME is populated
+    mimetype = Image.MIME.get(fmt, "application/octet-stream")
+    return Response(value, mimetype=mimetype, headers=headers)
+
+
 @datasets_bp.route('/<dataset>/embeddings', methods=['GET'])
 def get_dataset_embeddings(dataset):
     return scan_for_json_files(os.path.join(_data_dir(), dataset, "embeddings"))

--- a/tests/test_image_endpoint.py
+++ b/tests/test_image_endpoint.py
@@ -1,0 +1,160 @@
+"""Tests for serving binary image columns.
+
+Covers the GET /api/datasets/<dataset>/image endpoint and the regression
+where POST /api/indexed 500ed on datasets with binary image columns
+("Unsupported UTF-8 sequence length when encoding string").
+"""
+
+import io
+
+import pandas as pd
+import pytest
+from PIL import Image
+
+COLORS = [
+    ("red", (255, 0, 0)),
+    ("green", (0, 255, 0)),
+    ("blue", (0, 0, 255)),
+    ("yellow", (255, 255, 0)),
+]
+IMG_SIZE = (32, 16)  # non-square so thumbnail aspect handling is visible
+DATASET_ID = "img-ds"
+
+
+def make_png_bytes(color, size=IMG_SIZE):
+    img = Image.new("RGB", size, color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture
+def image_dataset(tmp_data_dir, monkeypatch):
+    """A tiny ingested dataset with an HF-style binary image column."""
+    monkeypatch.setenv("LATENT_SCOPE_DATA", tmp_data_dir)
+    monkeypatch.setenv("LATENT_SCOPE_NO_DOTENV", "1")
+    from latentscope.scripts.ingest import ingest
+
+    df = pd.DataFrame({
+        "image": [
+            {"bytes": make_png_bytes(rgb), "path": f"{name}.png"}
+            for name, rgb in COLORS
+        ],
+        "text": [f"a {name} image" for name, _ in COLORS],
+    })
+    ingest(DATASET_ID, df, text_column="text")
+    return DATASET_ID
+
+
+def get_image(client, dataset, **params):
+    query = "&".join(f"{k}={v}" for k, v in params.items())
+    return client.get(f"/api/datasets/{dataset}/image?{query}")
+
+
+# ---------------------------------------------------------------------------
+# GET /api/datasets/<dataset>/image
+# ---------------------------------------------------------------------------
+
+def test_image_endpoint_serves_original_bytes(client, image_dataset):
+    for index, (_, rgb) in enumerate(COLORS):
+        response = get_image(client, image_dataset, column="image", index=index)
+        assert response.status_code == 200
+        assert response.content_type == "image/png"
+        assert response.headers["Cache-Control"] == "public, max-age=86400"
+        img = Image.open(io.BytesIO(response.data))
+        assert img.format == "PNG"
+        assert img.size == IMG_SIZE
+        assert img.convert("RGB").getpixel((0, 0)) == rgb
+
+
+def test_image_endpoint_size_param_returns_webp_thumbnail(client, image_dataset):
+    response = get_image(client, image_dataset, column="image", index=1, size=8)
+    assert response.status_code == 200
+    assert response.content_type == "image/webp"
+    assert response.headers["Cache-Control"] == "public, max-age=86400"
+    img = Image.open(io.BytesIO(response.data))
+    assert img.format == "WEBP"
+    assert max(img.size) <= 8
+    # WebP is lossy; just check the dominant channel survived (green)
+    r, g, b = img.convert("RGB").getpixel((0, 0))
+    assert g > 200 and r < 60 and b < 60
+
+
+def test_image_endpoint_non_image_column_400(client, image_dataset):
+    response = get_image(client, image_dataset, column="text", index=0)
+    assert response.status_code == 400
+
+    response = get_image(client, image_dataset, column="nope", index=0)
+    assert response.status_code == 400
+
+    # missing column param entirely
+    response = client.get(f"/api/datasets/{image_dataset}/image?index=0")
+    assert response.status_code == 400
+
+
+def test_image_endpoint_bad_index_404(client, image_dataset):
+    assert get_image(client, image_dataset, column="image", index=99).status_code == 404
+    assert get_image(client, image_dataset, column="image", index=-1).status_code == 404
+    assert get_image(client, image_dataset, column="image", index="abc").status_code == 404
+    response = client.get(f"/api/datasets/{image_dataset}/image?column=image")
+    assert response.status_code == 404
+
+
+def test_image_endpoint_bad_size_400(client, image_dataset):
+    assert get_image(
+        client, image_dataset, column="image", index=0, size=1025
+    ).status_code == 400
+    assert get_image(
+        client, image_dataset, column="image", index=0, size=0
+    ).status_code == 400
+    assert get_image(
+        client, image_dataset, column="image", index=0, size="big"
+    ).status_code == 400
+    # 1024 is the inclusive cap
+    assert get_image(
+        client, image_dataset, column="image", index=0, size=1024
+    ).status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# /api/indexed regression: bytes columns must not 500 the row serialization
+# ---------------------------------------------------------------------------
+
+def test_indexed_returns_rows_without_image_column(client, image_dataset):
+    response = client.post(
+        "/api/indexed",
+        json={"dataset": image_dataset, "indices": [0, 2]},
+    )
+    assert response.status_code == 200
+    # /api/indexed returns a raw JSON string (not an application/json response)
+    rows = response.get_json(force=True)
+    assert len(rows) == 2
+    for row, expected_index in zip(rows, [0, 2]):
+        assert row["index"] == expected_index
+        assert row["text"] == f"a {COLORS[expected_index][0]} image"
+        # the image column is excluded (or at minimum nulled) in the response
+        assert row.get("image") is None
+
+
+def test_indexed_with_explicit_columns_including_image(client, image_dataset):
+    response = client.post(
+        "/api/indexed",
+        json={"dataset": image_dataset, "indices": [1], "columns": ["text", "image"]},
+    )
+    assert response.status_code == 200
+    rows = response.get_json(force=True)
+    assert rows[0]["text"] == "a green image"
+    assert rows[0].get("image") is None
+
+
+def test_query_returns_rows_without_image_column(client, image_dataset):
+    response = client.post(
+        "/api/query",
+        json={"dataset": image_dataset, "indices": [0, 1, 2, 3]},
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["total"] == 4
+    for row in data["rows"]:
+        assert row.get("image") is None
+        assert isinstance(row["text"], str)

--- a/web/src/components/Explore/FilterDataTable.jsx
+++ b/web/src/components/Explore/FilterDataTable.jsx
@@ -7,6 +7,7 @@ import 'react-data-grid/lib/styles.css';
 
 import DataGrid, { Row } from 'react-data-grid';
 import FeaturePlot from './FeaturePlot';
+import { imageUrlFor } from '../../lib/imageUrl';
 
 import styles from './FilterDataTable.module.css';
 
@@ -51,6 +52,12 @@ function FilterDataTable({
   // feature tooltip content
   const [featureTooltipContent, setFeatureTooltipContent] = useState(null);
 
+  // binary image columns get taller rows so thumbnails are visible
+  const hasBinaryImageColumns = useMemo(
+    () => Object.values(dataset?.column_metadata || {}).some((m) => m?.type === 'image'),
+    [dataset]
+  );
+
   const formattedColumns = useMemo(() => {
     // Add index circle column as the first column
     const indexColumn = {
@@ -93,7 +100,21 @@ function FilterDataTable({
       //   };
       // }
 
-      if (metadata?.image) {
+      if (metadata?.type === 'image') {
+        // binary image column: the value is excluded from row payloads, so
+        // reconstruct the display from dataset id + column + row index
+        return {
+          ...baseCol,
+          renderCell: ({ row }) => (
+            <img
+              loading="lazy"
+              src={imageUrlFor(dataset.id, col, row.ls_index, 100)}
+              alt={`${col} ${row.ls_index}`}
+              style={{ height: '100%', maxHeight: '48px', objectFit: 'contain' }}
+            />
+          ),
+        };
+      } else if (metadata?.image) {
         return {
           ...baseCol,
           renderCell: ({ row }) => (
@@ -260,7 +281,7 @@ function FilterDataTable({
             return '';
           }}
           rowGetter={(i) => dataTableRows[i]}
-          rowHeight={sae_id ? 50 : 35}
+          rowHeight={sae_id ? 50 : hasBinaryImageColumns ? 48 : 35}
           style={{ height: '100%', color: 'var(--text-color-main-neutral)' }}
           renderers={{ renderRow: renderRowWithHover }}
           className={styles.dataGrid}

--- a/web/src/components/Explore/VisualizationPane.jsx
+++ b/web/src/components/Explore/VisualizationPane.jsx
@@ -19,6 +19,7 @@ import { useScope } from '../../contexts/ScopeContext';
 import { useFilter } from '../../contexts/FilterContext';
 
 import { mapSelectionKey } from '../../lib/colors';
+import { imageUrlFor } from '../../lib/imageUrl';
 import styles from './VisualizationPane.module.scss';
 import ConfigurationPanel from './ConfigurationPanel';
 import { Button } from 'react-element-forge';
@@ -49,7 +50,13 @@ function VisualizationPane({
   dataTableRows,
   isSmallScreen = false,
 }) {
-  const { scopeRows, clusterLabels, scope, features } = useScope();
+  const { scopeRows, clusterLabels, scope, features, dataset } = useScope();
+
+  // first binary image column (if any) for the hover thumbnail
+  const hoverImageColumn = useMemo(() => {
+    const columnMetadata = dataset?.column_metadata || {};
+    return Object.keys(columnMetadata).find((col) => columnMetadata[col]?.type === 'image');
+  }, [dataset]);
 
   const { featureFilter, clusterFilter, shownIndices, filteredIndices, filterConfig, filterActive } =
     useFilter();
@@ -435,6 +442,20 @@ function VisualizationPane({
             )}
             <br></br>
             <span>Index: {hovered.index}</span>
+            {hoverImageColumn && hovered.index !== null && hovered.index !== undefined && (
+              <img
+                loading="lazy"
+                src={imageUrlFor(dataset.id, hoverImageColumn, hovered.index, 150)}
+                alt={`${hoverImageColumn} ${hovered.index}`}
+                style={{
+                  display: 'block',
+                  maxWidth: '150px',
+                  maxHeight: '150px',
+                  objectFit: 'contain',
+                  marginTop: '4px',
+                }}
+              />
+            )}
             <p className="tooltip-text">{hovered.text}</p>
           </div>
         </Tooltip>

--- a/web/src/components/FilterDataTable.jsx
+++ b/web/src/components/FilterDataTable.jsx
@@ -8,6 +8,7 @@ import 'react-data-grid/lib/styles.css';
 
 import DataGrid, { Row } from 'react-data-grid';
 import { scalePow } from 'd3-scale';
+import { imageUrlFor } from '../lib/imageUrl';
 
 const apiUrl = import.meta.env.VITE_API_URL;
 
@@ -346,6 +347,13 @@ function FilterDataTable({
   const [featureTooltipContent, setFeatureTooltipContent] = useState(null);
 
   const [rowsLoading, setRowsLoading] = useState(false);
+
+  // binary image columns get taller rows so thumbnails are visible
+  const hasBinaryImageColumns = useMemo(
+    () => Object.values(dataset?.column_metadata || {}).some((m) => m?.type === 'image'),
+    [dataset]
+  );
+
   const hydrateIndices = useCallback(
     (indices) => {
       // console.log("hydrate!", dataset)
@@ -421,7 +429,21 @@ function FilterDataTable({
       //   };
       // }
 
-      if (metadata?.image) {
+      if (metadata?.type === 'image') {
+        // binary image column: the value is excluded from row payloads, so
+        // reconstruct the display from dataset id + column + row index
+        return {
+          ...baseCol,
+          renderCell: ({ row }) => (
+            <img
+              loading="lazy"
+              src={imageUrlFor(dataset.id, col, row.ls_index, 100)}
+              alt={`${col} ${row.ls_index}`}
+              style={{ height: '100%', maxHeight: '48px', objectFit: 'contain' }}
+            />
+          ),
+        };
+      } else if (metadata?.image) {
         return {
           ...baseCol,
           renderCell: ({ row }) => (
@@ -577,7 +599,7 @@ function FilterDataTable({
             return '';
           }}
           rowGetter={(i) => rows[i]}
-          rowHeight={sae_id ? 50 : 35}
+          rowHeight={sae_id ? 50 : hasBinaryImageColumns ? 48 : 35}
           style={{ height: '100%', color: 'var(--text-color-main-neutral)' }}
           renderers={{ renderRow: renderRowWithHover }}
         />

--- a/web/src/lib/imageUrl.js
+++ b/web/src/lib/imageUrl.js
@@ -1,0 +1,23 @@
+const apiUrl = import.meta.env.VITE_API_URL;
+
+/**
+ * Build the URL for a binary image cell served by the backend.
+ *
+ * Binary image columns are excluded from row payloads (/indexed, /query);
+ * the image for a given row is fetched from
+ * GET /api/datasets/<dataset>/image?column=<col>&index=<int>&size=<int>.
+ *
+ * @param {string} datasetId - dataset id (directory name)
+ * @param {string} column - name of the image-typed column
+ * @param {number} index - row index into the dataset
+ * @param {number} [size] - optional max dimension; server returns a WebP
+ *   thumbnail when set (capped at 1024 server-side)
+ * @returns {string} fully-qualified image URL
+ */
+export function imageUrlFor(datasetId, column, index, size) {
+  const params = new URLSearchParams({ column, index });
+  if (size != null) {
+    params.set('size', size);
+  }
+  return `${apiUrl}/datasets/${encodeURIComponent(datasetId)}/image?${params.toString()}`;
+}

--- a/web/src/lib/imageUrl.test.js
+++ b/web/src/lib/imageUrl.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.stubEnv('VITE_API_URL', 'http://localhost:5001/api');
+
+const { imageUrlFor } = await import('./imageUrl.js');
+
+describe('imageUrlFor', () => {
+  it('builds the image endpoint URL with column and index', () => {
+    expect(imageUrlFor('my-dataset', 'image', 42)).toBe(
+      'http://localhost:5001/api/datasets/my-dataset/image?column=image&index=42'
+    );
+  });
+
+  it('includes size when provided', () => {
+    expect(imageUrlFor('my-dataset', 'image', 0, 100)).toBe(
+      'http://localhost:5001/api/datasets/my-dataset/image?column=image&index=0&size=100'
+    );
+  });
+
+  it('omits size when null or undefined', () => {
+    expect(imageUrlFor('ds', 'img', 1, null)).not.toContain('size');
+    expect(imageUrlFor('ds', 'img', 1, undefined)).not.toContain('size');
+  });
+
+  it('encodes odd column names', () => {
+    const url = imageUrlFor('ds', 'my image & co?', 3, 100);
+    expect(url).toBe(
+      'http://localhost:5001/api/datasets/ds/image?column=my+image+%26+co%3F&index=3&size=100'
+    );
+    const params = new URL(url).searchParams;
+    expect(params.get('column')).toBe('my image & co?');
+    expect(params.get('index')).toBe('3');
+    expect(params.get('size')).toBe('100');
+  });
+
+  it('encodes the dataset id in the path', () => {
+    expect(imageUrlFor('weird/ds name', 'img', 0)).toContain(
+      '/datasets/weird%2Fds%20name/image?'
+    );
+  });
+});


### PR DESCRIPTION
Follow-up to #124: image datasets embedded fine but were **invisible in the UI** — `POST /api/indexed` 500'd ("Unsupported UTF-8 sequence length") because `to_json` can't serialize raw image bytes, so the Explore table rendered nothing and hover hydration failed for the whole dataset.

## Approach: images by reference, never inline

- **New endpoint** `GET /api/datasets/<dataset>/image?column=&index=&size=` — streams one image straight from `input.parquet` by reading only the row group containing that row, restricted to that column (no full-table load, never enters the DataFrame cache). `size=N` returns an RGB-converted WebP thumbnail (q80, capped 1024); originals are served with PIL-sniffed mimetypes; `Cache-Control: public, max-age=86400` so the browser does the caching.
- **Row serialization fixed structurally**: image-typed columns are excluded at parquet-read time in `/indexed`, `/query`, and `/column-filter` — fixes the 500 *and* keeps multi-GB image blobs out of the server's LRU cache (a 2.5 GB polyvore would otherwise sit in RAM per cache slot). Defensive bytes-sanitizer backstops any stray binary.
- **Frontend**: both data tables render image columns as lazy-loaded 48px thumbnails via a tested `imageUrlFor()` helper; the map hover tooltip shows a 150px thumbnail above the text for datasets with an image column. URL-image columns keep their existing rendering.

## Tests / verification

- Python 123 → **131 passed** (endpoint mimetype/resize/400s/404s + the `/indexed` regression); web 56 → **61**; lint 0 errors; production build green.
- Manually verified read-only against the live marqo-ge-sample data: image fetch (450×450 WebP), thumbnail resize, OOB 404, non-image-column 400, and `/indexed`/`/query`/`/column-filter` all 200.

Skipped: MobileFilterDataTable thumbnails (custom text-only layout, needs a mobile design pass). Map sprite/thumbnail rendering is deliberately not in this PR — design discussion first (memory/space tradeoffs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)