### PR TITLE
Fix: blank scatter map after resize + immediate hover tooltip image

### DIFF
--- a/web/src/components/Explore/HoverThumbnail.jsx
+++ b/web/src/components/Explore/HoverThumbnail.jsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+
+/**
+ * Fixed-size thumbnail for the map hover tooltip. Manages its own loaded
+ * state so it can show a loading placeholder instead of leaving the previous
+ * point's image on screen while the new one fetches. Mount with a key tied to
+ * the hovered index so it resets per point.
+ */
+function HoverThumbnail({ src, alt, size = 150 }) {
+  const [loaded, setLoaded] = useState(false);
+  const [errored, setErrored] = useState(false);
+
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        marginTop: 4,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(0,0,0,0.12)',
+        fontSize: 11,
+        color: 'rgba(0,0,0,0.55)',
+      }}
+    >
+      {!loaded && !errored && <span>loading…</span>}
+      {errored && <span>no image</span>}
+      <img
+        src={src}
+        alt={alt}
+        onLoad={() => setLoaded(true)}
+        onError={() => setErrored(true)}
+        style={{
+          maxWidth: size,
+          maxHeight: size,
+          objectFit: 'contain',
+          display: loaded ? 'block' : 'none',
+        }}
+      />
+    </div>
+  );
+}
+
+export default HoverThumbnail;

--- a/web/src/components/Explore/ScatterGL.jsx
+++ b/web/src/components/Explore/ScatterGL.jsx
@@ -317,7 +317,11 @@ function ScatterGL({
       },
       depth: { enable: false },
     });
-  }, [points, featureIsSelected]);
+    // width/height are in the deps because the regl context is destroyed and
+    // recreated on resize; without rebuilding here the buffers + draw command
+    // would reference the dead context ("no buffer is bound to enabled
+    // attribute" and nothing renders).
+  }, [points, featureIsSelected, width, height]);
 
   const dynamicSize = useMemo(() => {
     let size = calculateDynamicPointScale(points.length, width, height);

--- a/web/src/components/Explore/VisualizationPane.jsx
+++ b/web/src/components/Explore/VisualizationPane.jsx
@@ -20,6 +20,7 @@ import { useFilter } from '../../contexts/FilterContext';
 
 import { mapSelectionKey } from '../../lib/colors';
 import { imageUrlFor } from '../../lib/imageUrl';
+import HoverThumbnail from './HoverThumbnail';
 import styles from './VisualizationPane.module.scss';
 import ConfigurationPanel from './ConfigurationPanel';
 import { Button } from 'react-element-forge';
@@ -443,20 +444,16 @@ function VisualizationPane({
             <br></br>
             <span>Index: {hovered.index}</span>
             {hoverImageColumn && hovered.index !== null && hovered.index !== undefined && (
-              <img
-                loading="lazy"
+              <HoverThumbnail
+                key={hovered.index}
                 src={imageUrlFor(dataset.id, hoverImageColumn, hovered.index, 150)}
                 alt={`${hoverImageColumn} ${hovered.index}`}
-                style={{
-                  display: 'block',
-                  maxWidth: '150px',
-                  maxHeight: '150px',
-                  objectFit: 'contain',
-                  marginTop: '4px',
-                }}
+                size={150}
               />
             )}
-            <p className="tooltip-text">{hovered.text}</p>
+            <p className="tooltip-text">
+              {hovered.loading && !hovered.text ? <em>loading…</em> : hovered.text}
+            </p>
           </div>
         </Tooltip>
       )}

--- a/web/src/pages/FullScreenExplore.jsx
+++ b/web/src/pages/FullScreenExplore.jsx
@@ -104,9 +104,19 @@ function ExploreContent() {
 
   useEffect(() => {
     if (hoveredIndex !== null && hoveredIndex !== undefined && !deletedIndicesSet.has(hoveredIndex)) {
+      // Update the tooltip immediately with the new index + cluster so the
+      // image (keyed on the index) swaps right away; the text arrives after
+      // the hydration fetch, marked loading until then.
+      setHovered({
+        text: null,
+        loading: true,
+        index: hoveredIndex,
+        cluster: clusterMap[hoveredIndex],
+      });
       debouncedHydrateHoverText(hoveredIndex, (text) => {
         setHovered({
           text: text,
+          loading: false,
           index: hoveredIndex,
           cluster: clusterMap[hoveredIndex],
         });


### PR DESCRIPTION
Two Explore-map fixes the dev instance is hitting on image scopes (but both are general, not image-specific).

## Blank map / `WebGL: INVALID_OPERATION: drawArrays: no buffer is bound to enabled attribute`

ScatterGL destroys and recreates the regl context on every container resize (the init effect is keyed on `width`/`height`), but the buffer + draw-command effect was keyed only on `[points, featureIsSelected]`. So after a resize the cached draw command still referenced the **destroyed** context's buffers → the WebGL error and a blank map. The Part 4 ResizeObserver reliably fires a resize once layout settles after data loads, which is exactly when it surfaced. Fix: rebuild buffers + command on `width`/`height` too (effect declaration order guarantees regl is recreated first, then buffers, then draw). No extra rebuilds on zoom/pan.

## Stale tooltip image while the new one loads

The hover tooltip — and its thumbnail — only updated after the text-hydration `/indexed` fetch resolved, so moving between points left the previous point's image on screen until the round-trip finished. Now the hovered index + cluster are set immediately (the image, keyed on the index, swaps at once) and the text is marked loading until it lands. A new `HoverThumbnail` component (keyed on the index) shows a `loading…` placeholder instead of the stale image, with an error fallback.

Verified: lint 0 errors, 61 web tests pass, production build green. (Visual behavior — verify on the dev instance.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)