### PR TITLE
Images on the map: optional sprite generation + viewport-culled DOM overlay (#24)

### DIFF
--- a/latentscope/scripts/sprites.py
+++ b/latentscope/scripts/sprites.py
@@ -1,0 +1,175 @@
+# Usage: ls-sprites <dataset_id> <image_column> [--size 64] [--quality 80]
+#
+# Generate individual WebP thumbnail "sprites" for an image column, one small
+# file per row, sharded by index so no directory holds more than ~1000 files.
+# This is an OPTIONAL pipeline step (like embed / umap) that powers the
+# viewport-culled DOM image overlay in the scatter map.
+import argparse
+import json
+import os
+import sys
+
+try:
+    if 'ipykernel' in sys.modules and 'IPython' in sys.modules:
+        from tqdm.notebook import tqdm
+    else:
+        from tqdm import tqdm
+except ImportError:
+    from tqdm import tqdm
+
+from latentscope.util import get_data_dir
+
+SHARD_SIZE = 1000
+
+
+def shard_for(index):
+    """Return the zero-padded shard directory name for a row index."""
+    return f"{index // SHARD_SIZE:03d}"
+
+
+def _image_bytes(value):
+    """Extract raw image bytes from a stored cell (HF-style {"bytes": ...}
+    dict or raw bytes), or None if there are none."""
+    if isinstance(value, dict):
+        value = value.get("bytes")
+    if isinstance(value, bytearray):
+        value = bytes(value)
+    if not isinstance(value, bytes) or len(value) == 0:
+        return None
+    return value
+
+
+def generate_sprites(dataset_id, image_column, size=64, quality=80):
+    """Generate sharded WebP thumbnails for *image_column* of *dataset_id*.
+
+    Output layout::
+
+        <DATA_DIR>/<dataset>/sprites/<column>-<size>/<shard>/<index>.webp
+        <DATA_DIR>/<dataset>/sprites/<column>-<size>.json   (manifest)
+
+    Streams input.parquet row-group by row-group so the full image set is
+    never held in RAM.  Resumable: an index whose .webp already exists is
+    skipped.  Null / undecodable cells write no file and are recorded in the
+    manifest's ``missing`` list so the frontend can skip them.
+    """
+    import io
+
+    import pyarrow.parquet as pq
+    from PIL import Image
+
+    DATA_DIR = get_data_dir()
+    dataset_dir = os.path.join(DATA_DIR, dataset_id)
+
+    meta_path = os.path.join(dataset_dir, "meta.json")
+    with open(meta_path, encoding="utf-8") as f:
+        meta = json.load(f)
+    column_meta = (meta.get("column_metadata") or {}).get(image_column)
+    if not isinstance(column_meta, dict) or column_meta.get("type") != "image":
+        raise ValueError(
+            f"column {image_column!r} is not an image column in {dataset_id}"
+        )
+
+    run_id = f"sprites-{image_column}-{size}"
+    print("RUNNING:", run_id)
+
+    sprites_root = os.path.join(dataset_dir, "sprites")
+    out_dir = os.path.join(sprites_root, f"{image_column}-{size}")
+    os.makedirs(out_dir, exist_ok=True)
+
+    input_path = os.path.join(dataset_dir, "input.parquet")
+    parquet_file = pq.ParquetFile(input_path)
+    total = parquet_file.metadata.num_rows
+
+    def out_path(index):
+        return os.path.join(out_dir, shard_for(index), f"{index}.webp")
+
+    # Count what already exists so a rerun reports resumed progress.
+    existing_start = sum(
+        1 for i in range(total) if os.path.exists(out_path(i))
+    )
+    print(f"{existing_start} of {total} sprites already exist; resuming")
+
+    manifest_path = os.path.join(sprites_root, f"{image_column}-{size}.json")
+
+    def write_manifest(missing, count, complete):
+        os.makedirs(sprites_root, exist_ok=True)
+        manifest = {
+            "column": image_column,
+            "size": size,
+            "shard_size": SHARD_SIZE,
+            "count": count,
+            "total": total,
+            "missing": missing,
+            "complete": complete,
+        }
+        tmp_path = manifest_path + ".tmp"
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f)
+        os.replace(tmp_path, manifest_path)
+
+    missing = []
+    written_total = 0
+    index = 0
+    with tqdm(total=total, desc=run_id) as pbar:
+        for rg in range(parquet_file.metadata.num_row_groups):
+            table = parquet_file.read_row_group(rg, columns=[image_column])
+            column = table.column(0)
+            for cell in column:
+                value = cell.as_py()
+                target = out_path(index)
+                if os.path.exists(target):
+                    written_total += 1
+                    index += 1
+                    pbar.update(1)
+                    continue
+
+                raw = _image_bytes(value)
+                img = None
+                if raw is not None:
+                    try:
+                        img = Image.open(io.BytesIO(raw))
+                        img = img.convert("RGB")
+                        img.thumbnail((size, size))
+                    except Exception:
+                        img = None
+
+                if img is None:
+                    # null or undecodable: write nothing, record as missing
+                    missing.append(index)
+                else:
+                    os.makedirs(os.path.dirname(target), exist_ok=True)
+                    tmp_target = target + ".tmp"
+                    img.save(tmp_target, format="WEBP", quality=quality)
+                    os.replace(tmp_target, target)
+                    written_total += 1
+
+                index += 1
+                pbar.update(1)
+
+    write_manifest(missing, written_total, complete=True)
+    print(
+        f"wrote {written_total} sprites ({len(missing)} missing) "
+        f"of {total} rows to {out_dir}"
+    )
+    return manifest_path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate sharded WebP image sprites for a dataset column"
+    )
+    parser.add_argument("dataset_id", type=str,
+                        help="Dataset id (directory name in data/)")
+    parser.add_argument("image_column", type=str,
+                        help="Name of the image-typed column")
+    parser.add_argument("--size", type=int, default=64,
+                        help="Max thumbnail dimension in px (default 64)")
+    parser.add_argument("--quality", type=int, default=80,
+                        help="WebP quality 1-100 (default 80)")
+    args = parser.parse_args()
+    generate_sprites(args.dataset_id, args.image_column,
+                     size=args.size, quality=args.quality)
+
+
+if __name__ == "__main__":
+    main()

--- a/latentscope/server/datasets.py
+++ b/latentscope/server/datasets.py
@@ -176,6 +176,95 @@ def get_dataset_image(dataset):
     return Response(value, mimetype=mimetype, headers=headers)
 
 
+def _sprite_size_param():
+    """Parse the optional ?size= param, default 64. Returns (size, error).
+
+    error is a (response, status) tuple when invalid, else None.
+    """
+    size = request.args.get('size', '64')
+    try:
+        size = int(size)
+    except (TypeError, ValueError):
+        return None, (jsonify({"error": "size must be an integer"}), 400)
+    if size < 1 or size > 1024:
+        return None, (jsonify({"error": "size must be between 1 and 1024"}), 400)
+    return size, None
+
+
+@datasets_bp.route('/<dataset>/sprites/status', methods=['GET'])
+def get_dataset_sprites_status(dataset):
+    """Report whether sprites have been generated for a column.
+
+    Query params: column (image column name), size (default 64).
+    Reads the sprite manifest if present. Never 500s.
+    """
+    column = request.args.get('column')
+    size, err = _sprite_size_param()
+    if err:
+        return err
+
+    manifest_path = os.path.join(
+        _data_dir(), dataset, "sprites", f"{column}-{size}.json"
+    )
+    try:
+        with open(manifest_path, encoding='utf-8') as f:
+            manifest = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return jsonify({"generated": False})
+
+    return jsonify({
+        "generated": bool(manifest.get("complete")),
+        "count": manifest.get("count"),
+        "total": manifest.get("total"),
+        "size": manifest.get("size"),
+        "missing_count": len(manifest.get("missing") or []),
+    })
+
+
+@datasets_bp.route('/<dataset>/sprite', methods=['GET'])
+def get_dataset_sprite(dataset):
+    """Serve a single pre-generated WebP sprite thumbnail.
+
+    Query params: column (image column), index (row index), size (default 64).
+    Resolves the sharded path and 404s when the file is absent (e.g. a missing
+    or undecodable source image).
+    """
+    from flask import send_file
+
+    column = request.args.get('column')
+    meta_path = os.path.join(_data_dir(), dataset, "meta.json")
+    try:
+        with open(meta_path, encoding='utf-8') as f:
+            meta = json.load(f)
+    except OSError:
+        return jsonify({"error": f"dataset {dataset} not found"}), 404
+    column_meta = (meta.get("column_metadata") or {}).get(column)
+    if not isinstance(column_meta, dict) or column_meta.get("type") != "image":
+        return jsonify({"error": f"column {column!r} is not an image column"}), 400
+
+    size, err = _sprite_size_param()
+    if err:
+        return err
+
+    try:
+        index = int(request.args.get('index'))
+    except (TypeError, ValueError):
+        return jsonify({"error": "index must be an integer"}), 404
+    if index < 0 or index >= meta.get("length", 0):
+        return jsonify({"error": "index out of range"}), 404
+
+    shard = f"{index // 1000:03d}"
+    sprite_path = os.path.join(
+        _data_dir(), dataset, "sprites", f"{column}-{size}", shard, f"{index}.webp"
+    )
+    if not os.path.exists(sprite_path):
+        return jsonify({"error": "no sprite at this index"}), 404
+
+    response = send_file(sprite_path, mimetype="image/webp")
+    response.headers["Cache-Control"] = "public, max-age=86400"
+    return response
+
+
 @datasets_bp.route('/<dataset>/embeddings', methods=['GET'])
 def get_dataset_embeddings(dataset):
     return scan_for_json_files(os.path.join(_data_dir(), dataset, "embeddings"))

--- a/latentscope/server/jobs.py
+++ b/latentscope/server/jobs.py
@@ -685,6 +685,23 @@ def run_scope():
     return jsonify({"job_id": job_id})
 
 
+@jobs_write_bp.route('/sprites', methods=['GET', 'POST'])
+def run_sprites():
+    data_dir = _data_dir()
+    dataset = _safe_dataset(request.values.get('dataset'))
+    image_column = request.values.get('image_column')
+    size = request.values.get('size') or '64'
+
+    err = _require_params(dataset=dataset, image_column=image_column)
+    if err:
+        return err
+
+    job_id = str(uuid.uuid4())
+    command = ['ls-sprites', dataset, image_column, '--size', str(size)]
+    threading.Thread(target=run_job, args=(data_dir, dataset, job_id, command)).start()
+    return jsonify({"job_id": job_id})
+
+
 @jobs_write_bp.route('/delete/scope', methods=['GET', 'POST'])
 def delete_scope():
     data_dir = _data_dir()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ ls-scope = "latentscope.scripts.scope:main"
 ls-export-plot = "latentscope.scripts.export_plot:main"
 ls-update-embedding-stats = "latentscope.scripts.embed:update_embedding_stats"
 ls-sae = "latentscope.scripts.sae:main"
+ls-sprites = "latentscope.scripts.sprites:main"
 ls-download-dataset = "latentscope.scripts.download_dataset:main"
 ls-upload-dataset = "latentscope.scripts.upload_dataset:main"
 

--- a/tests/test_sprites.py
+++ b/tests/test_sprites.py
@@ -1,0 +1,177 @@
+"""Tests for the optional image-sprite generation step and serving endpoints.
+
+generate_sprites() writes one small sharded WebP per row; the /sprite and
+/sprites/status endpoints serve them and report progress.
+"""
+
+import io
+import json
+import os
+
+import pandas as pd
+import pytest
+from PIL import Image
+
+COLORS = [
+    ("red", (255, 0, 0)),
+    ("green", (0, 255, 0)),
+    ("blue", (0, 0, 255)),
+    ("yellow", (255, 255, 0)),
+]
+IMG_SIZE = (96, 48)  # non-square + larger than sprite size so thumbnailing bites
+DATASET_ID = "sprite-ds"
+
+
+def make_png_bytes(color, size=IMG_SIZE):
+    img = Image.new("RGB", size, color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture
+def sprite_dataset(tmp_data_dir, monkeypatch):
+    """A tiny ingested image dataset; row 2 has a null image (missing)."""
+    monkeypatch.setenv("LATENT_SCOPE_DATA", tmp_data_dir)
+    monkeypatch.setenv("LATENT_SCOPE_NO_DOTENV", "1")
+    from latentscope.scripts.ingest import ingest
+
+    images = [
+        {"bytes": make_png_bytes(rgb), "path": f"{name}.png"}
+        for name, rgb in COLORS
+    ]
+    images[2] = None  # blue row -> missing image
+    df = pd.DataFrame({
+        "image": images,
+        "text": [f"a {name} image" for name, _ in COLORS],
+    })
+    ingest(DATASET_ID, df, text_column="text")
+    return DATASET_ID
+
+
+def sprite_path(data_dir, dataset, column, size, index):
+    shard = f"{index // 1000:03d}"
+    return os.path.join(
+        data_dir, dataset, "sprites", f"{column}-{size}", shard, f"{index}.webp"
+    )
+
+
+def load_manifest(data_dir, dataset, column, size):
+    path = os.path.join(data_dir, dataset, "sprites", f"{column}-{size}.json")
+    with open(path) as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# generate_sprites
+# ---------------------------------------------------------------------------
+
+def test_generate_sprites_writes_sharded_webp(tmp_data_dir, sprite_dataset):
+    from latentscope.scripts.sprites import generate_sprites
+
+    generate_sprites(sprite_dataset, "image", size=64)
+
+    # present images -> valid 64px WEBP in shard 000
+    for index in (0, 1, 3):
+        path = sprite_path(tmp_data_dir, sprite_dataset, "image", 64, index)
+        assert os.path.exists(path)
+        img = Image.open(path)
+        assert img.format == "WEBP"
+        assert max(img.size) <= 64
+
+    # null image row -> no file
+    assert not os.path.exists(
+        sprite_path(tmp_data_dir, sprite_dataset, "image", 64, 2)
+    )
+
+
+def test_generate_sprites_manifest(tmp_data_dir, sprite_dataset):
+    from latentscope.scripts.sprites import generate_sprites
+
+    generate_sprites(sprite_dataset, "image", size=64)
+    manifest = load_manifest(tmp_data_dir, sprite_dataset, "image", 64)
+
+    assert manifest["column"] == "image"
+    assert manifest["size"] == 64
+    assert manifest["shard_size"] == 1000
+    assert manifest["total"] == 4
+    assert manifest["count"] == 3
+    assert manifest["missing"] == [2]
+    assert manifest["complete"] is True
+
+
+def test_generate_sprites_resumable(tmp_data_dir, sprite_dataset):
+    from latentscope.scripts.sprites import generate_sprites
+
+    generate_sprites(sprite_dataset, "image", size=64)
+
+    kept = sprite_path(tmp_data_dir, sprite_dataset, "image", 64, 0)
+    regen = sprite_path(tmp_data_dir, sprite_dataset, "image", 64, 3)
+    kept_mtime = os.path.getmtime(kept)
+    os.remove(regen)
+
+    generate_sprites(sprite_dataset, "image", size=64)
+
+    # untouched file not rewritten, deleted file regenerated
+    assert os.path.getmtime(kept) == kept_mtime
+    assert os.path.exists(regen)
+
+
+def test_generate_sprites_non_image_column_raises(sprite_dataset):
+    from latentscope.scripts.sprites import generate_sprites
+
+    with pytest.raises(ValueError):
+        generate_sprites(sprite_dataset, "text", size=64)
+
+
+# ---------------------------------------------------------------------------
+# endpoints
+# ---------------------------------------------------------------------------
+
+def test_sprites_status_endpoint(client, tmp_data_dir, sprite_dataset):
+    from latentscope.scripts.sprites import generate_sprites
+
+    # before generation
+    before = client.get(
+        f"/api/datasets/{sprite_dataset}/sprites/status?column=image&size=64"
+    )
+    assert before.status_code == 200
+    assert before.get_json()["generated"] is False
+
+    generate_sprites(sprite_dataset, "image", size=64)
+
+    after = client.get(
+        f"/api/datasets/{sprite_dataset}/sprites/status?column=image&size=64"
+    )
+    assert after.status_code == 200
+    data = after.get_json()
+    assert data["generated"] is True
+    assert data["count"] == 3
+    assert data["total"] == 4
+    assert data["missing_count"] == 1
+
+
+def test_sprite_endpoint_serves_and_404s(client, sprite_dataset):
+    from latentscope.scripts.sprites import generate_sprites
+
+    generate_sprites(sprite_dataset, "image", size=64)
+
+    ok = client.get(f"/api/datasets/{sprite_dataset}/sprite?column=image&index=0&size=64")
+    assert ok.status_code == 200
+    assert ok.content_type == "image/webp"
+    assert ok.headers["Cache-Control"] == "public, max-age=86400"
+    img = Image.open(io.BytesIO(ok.data))
+    assert img.format == "WEBP"
+    assert max(img.size) <= 64
+
+    # missing (null) image -> 404
+    missing = client.get(f"/api/datasets/{sprite_dataset}/sprite?column=image&index=2&size=64")
+    assert missing.status_code == 404
+
+    # out-of-range index -> 404
+    oob = client.get(f"/api/datasets/{sprite_dataset}/sprite?column=image&index=99&size=64")
+    assert oob.status_code == 404
+
+    # non-image column -> 400
+    bad = client.get(f"/api/datasets/{sprite_dataset}/sprite?column=text&index=0&size=64")
+    assert bad.status_code == 400

--- a/web/src/components/Explore/ConfigurationPanel.jsx
+++ b/web/src/components/Explore/ConfigurationPanel.jsx
@@ -10,8 +10,15 @@ const ConfigurationPanel = ({
   toggleShowClusterOutlines,
   updatePointSize,
   updatePointOpacity,
+  hasImageColumn = false,
+  spriteStatus = { generated: false },
+  spriteJob = null,
+  showSprites = false,
+  toggleShowSprites,
+  onGenerateSprites,
 }) => {
   const { showHeatMap, showClusterOutlines, pointSize, pointOpacity } = vizConfig;
+  const spriteJobRunning = spriteJob && !['completed', 'error', 'dead'].includes(spriteJob.status);
 
   return (
     <div className={`${styles.panel} ${isOpen ? styles.open : ''}`}>
@@ -75,6 +82,31 @@ const ConfigurationPanel = ({
           color="secondary"
           label="Show Heat Map"
         />
+
+        {hasImageColumn &&
+          (spriteStatus.generated ? (
+            <Switch
+              value={showSprites}
+              onChange={toggleShowSprites}
+              defaultState={showSprites}
+              color="secondary"
+              label="Show Images (zoom in)"
+            />
+          ) : (
+            <div className={styles.configSection}>
+              <Button
+                onClick={onGenerateSprites}
+                disabled={spriteJobRunning}
+                variant="outline"
+                text={spriteJobRunning ? 'Generating image sprites…' : 'Generate image sprites'}
+              />
+              {spriteJobRunning && spriteJob?.progress?.length > 0 && (
+                <div className={styles.spriteProgress}>
+                  {spriteJob.progress[spriteJob.progress.length - 1]}
+                </div>
+              )}
+            </div>
+          ))}
 
         <div className={styles.configSection}></div>
       </div>

--- a/web/src/components/Explore/SpriteOverlay.jsx
+++ b/web/src/components/Explore/SpriteOverlay.jsx
@@ -1,0 +1,120 @@
+import { useMemo } from 'react';
+import { scaleLinear } from 'd3-scale';
+import { spriteUrlFor } from '../../lib/spriteUrl';
+
+// Zoom level (ScatterGL transform.k) past which sprites replace dots. Below
+// this the map is zoomed out far enough that individual images would be tiny
+// and too numerous, so we render dots-only.
+const ZOOM_THRESHOLD = 4;
+
+// Hard cap on how many <img> the browser is asked to decode at once. When more
+// than this many points are visible we render none and let the dots show,
+// keeping browser memory bounded regardless of dataset size.
+const MAX_SPRITES = 600;
+
+// Base on-screen sprite size (px); scales modestly with zoom but the source
+// file is always the generated `size` (e.g. 64px).
+const BASE_SPRITE_PX = 32;
+const MIN_SPRITE_PX = 32;
+const MAX_SPRITE_PX = 96;
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Viewport-culled DOM image overlay for the scatter map. Renders absolutely
+ * positioned <img> elements only for points currently visible, past a zoom
+ * threshold, capped at MAX_SPRITES. The container is pointer-events:none so the
+ * scatter canvas underneath keeps receiving mouse/zoom events.
+ *
+ * Projection matches AnnotationPlot exactly:
+ *   xScale = scaleLinear().domain(xDomain).range([0, width])
+ *   yScale = scaleLinear().domain(yDomain).range([height, 0])
+ */
+function SpriteOverlay({
+  dataset,
+  imageColumn,
+  scopeRows,
+  xDomain,
+  yDomain,
+  width,
+  height,
+  transform,
+  enabled,
+  manifest,
+}) {
+  const size = manifest?.size || 64;
+  const missingSet = manifest?.missing;
+  const k = transform?.k || 1;
+
+  const spritePx = useMemo(() => clamp(BASE_SPRITE_PX * (k / ZOOM_THRESHOLD), MIN_SPRITE_PX, MAX_SPRITE_PX), [k]);
+
+  const visibleSprites = useMemo(() => {
+    if (!enabled || !manifest?.generated) return [];
+    if (k < ZOOM_THRESHOLD) return [];
+    if (!xDomain || !yDomain || !scopeRows?.length) return [];
+
+    const xScale = scaleLinear().domain(xDomain).range([0, width]);
+    const yScale = scaleLinear().domain(yDomain).range([height, 0]);
+
+    const result = [];
+    for (let i = 0; i < scopeRows.length; i++) {
+      const row = scopeRows[i];
+      if (!row || row.deleted) continue;
+      // xDomain/yDomain ARE the visible data-domain: cull to it.
+      if (row.x < xDomain[0] || row.x > xDomain[1]) continue;
+      if (row.y < yDomain[0] || row.y > yDomain[1]) continue;
+      const index = row.ls_index;
+      if (missingSet && missingSet.has(index)) continue;
+      result.push({
+        index,
+        left: xScale(row.x) - spritePx / 2,
+        top: yScale(row.y) - spritePx / 2,
+      });
+      // Over the cap: bail out and render none (dots remain), bounding memory.
+      if (result.length > MAX_SPRITES) return [];
+    }
+    return result;
+  }, [enabled, manifest, k, xDomain, yDomain, scopeRows, width, height, spritePx, missingSet]);
+
+  if (!visibleSprites.length) return null;
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width,
+        height,
+        pointerEvents: 'none',
+        overflow: 'hidden',
+      }}
+    >
+      {visibleSprites.map((s) => (
+        <img
+          key={s.index}
+          loading="lazy"
+          width={spritePx}
+          height={spritePx}
+          src={spriteUrlFor(dataset.id, imageColumn, s.index, size)}
+          alt=""
+          // A sprite may 404 (missing/undecodable source image not in the
+          // manifest's missing set) — hide it rather than show a broken icon.
+          onError={(e) => {
+            e.currentTarget.style.visibility = 'hidden';
+          }}
+          style={{
+            position: 'absolute',
+            left: s.left,
+            top: s.top,
+            pointerEvents: 'none',
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default SpriteOverlay;

--- a/web/src/components/Explore/VisualizationPane.jsx
+++ b/web/src/components/Explore/VisualizationPane.jsx
@@ -20,10 +20,16 @@ import { useFilter } from '../../contexts/FilterContext';
 
 import { mapSelectionKey } from '../../lib/colors';
 import { imageUrlFor } from '../../lib/imageUrl';
+import { fetchSpriteStatus } from '../../lib/spriteUrl';
 import HoverThumbnail from './HoverThumbnail';
+import SpriteOverlay from './SpriteOverlay';
 import styles from './VisualizationPane.module.scss';
 import ConfigurationPanel from './ConfigurationPanel';
 import { Button } from 'react-element-forge';
+import { useStartJobPolling } from '../Job/Run';
+
+const apiUrl = import.meta.env.VITE_API_URL;
+const SPRITE_SIZE = 64;
 
 // VisualizationPane.propTypes = {
 //   hoverAnnotations: PropTypes.array.isRequired,
@@ -58,6 +64,67 @@ function VisualizationPane({
     const columnMetadata = dataset?.column_metadata || {};
     return Object.keys(columnMetadata).find((col) => columnMetadata[col]?.type === 'image');
   }, [dataset]);
+
+  // ====================================================================================================
+  // Image sprite overlay (optional generated thumbnails shown when zoomed in)
+  // ====================================================================================================
+  const [showSprites, setShowSprites] = useState(false);
+  const [spriteStatus, setSpriteStatus] = useState({ generated: false });
+  const [spriteJob, setSpriteJob] = useState(null);
+  const { startJob: startSpriteJob } = useStartJobPolling(
+    dataset,
+    setSpriteJob,
+    `${apiUrl}/jobs/sprites`
+  );
+
+  // fetch sprite status whenever the dataset / image column changes
+  useEffect(() => {
+    let cancelled = false;
+    if (!dataset?.id || !hoverImageColumn) {
+      setSpriteStatus({ generated: false });
+      return;
+    }
+    fetchSpriteStatus(dataset.id, hoverImageColumn, SPRITE_SIZE)
+      .then((status) => {
+        if (!cancelled) setSpriteStatus(status);
+      })
+      .catch(() => {
+        if (!cancelled) setSpriteStatus({ generated: false });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [dataset?.id, hoverImageColumn]);
+
+  // when a generation job completes, re-fetch status and enable the toggle
+  useEffect(() => {
+    if (spriteJob?.status === 'completed' && dataset?.id && hoverImageColumn) {
+      fetchSpriteStatus(dataset.id, hoverImageColumn, SPRITE_SIZE).then((status) => {
+        setSpriteStatus(status);
+        if (status.generated) setShowSprites(true);
+      });
+    }
+  }, [spriteJob?.status, dataset?.id, hoverImageColumn]);
+
+  const spriteManifest = useMemo(
+    () => ({
+      generated: !!spriteStatus.generated,
+      size: spriteStatus.size || SPRITE_SIZE,
+      // status endpoint only returns a count; the overlay also hides 404s via
+      // onError, so an empty set here is safe.
+      missing: new Set(),
+    }),
+    [spriteStatus]
+  );
+
+  const handleGenerateSprites = useCallback(() => {
+    if (!hoverImageColumn) return;
+    startSpriteJob({ image_column: hoverImageColumn, size: SPRITE_SIZE });
+  }, [hoverImageColumn, startSpriteJob]);
+
+  const toggleShowSprites = useCallback(() => {
+    setShowSprites((prev) => !prev);
+  }, []);
 
   const { featureFilter, clusterFilter, shownIndices, filteredIndices, filterConfig, filterActive } =
     useFilter();
@@ -271,6 +338,12 @@ function VisualizationPane({
           toggleShowClusterOutlines={toggleShowClusterOutlines}
           updatePointSize={updatePointSize}
           updatePointOpacity={updatePointOpacity}
+          hasImageColumn={!!hoverImageColumn}
+          spriteStatus={spriteStatus}
+          spriteJob={spriteJob}
+          showSprites={showSprites}
+          toggleShowSprites={toggleShowSprites}
+          onGenerateSprites={handleGenerateSprites}
         />
       </div>
 
@@ -357,6 +430,21 @@ function VisualizationPane({
               label={scope.cluster_labels_lookup[clusterFilter.cluster.cluster]}
             />
           )}
+        {/* Viewport-culled DOM image overlay (renders only when zoomed in) */}
+        {hoverImageColumn && (
+          <SpriteOverlay
+            dataset={dataset}
+            imageColumn={hoverImageColumn}
+            scopeRows={scopeRows}
+            xDomain={xDomain}
+            yDomain={yDomain}
+            width={width}
+            height={height}
+            transform={transform}
+            enabled={showSprites}
+            manifest={spriteManifest}
+          />
+        )}
         <AnnotationPlot
           points={hoverAnnotations}
           stroke="black"

--- a/web/src/lib/spriteUrl.js
+++ b/web/src/lib/spriteUrl.js
@@ -1,0 +1,39 @@
+const apiUrl = import.meta.env.VITE_API_URL;
+
+/**
+ * Build the URL for a single pre-generated sprite thumbnail served by the
+ * backend (the optional sprite generation step).
+ *
+ * Sprites are individual sharded WebP files; the one for a given row is
+ * fetched from
+ * GET /api/datasets/<dataset>/sprite?column=<col>&index=<int>&size=<int>.
+ *
+ * @param {string} datasetId - dataset id (directory name)
+ * @param {string} column - name of the image-typed column
+ * @param {number} index - row index into the dataset
+ * @param {number} [size=64] - sprite size the step was generated at
+ * @returns {string} fully-qualified sprite URL
+ */
+export function spriteUrlFor(datasetId, column, index, size = 64) {
+  const params = new URLSearchParams({ column, index, size });
+  return `${apiUrl}/datasets/${encodeURIComponent(datasetId)}/sprite?${params.toString()}`;
+}
+
+/**
+ * Fetch the sprite generation status for an image column.
+ *
+ * @param {string} datasetId
+ * @param {string} column - image column name
+ * @param {number} [size=64]
+ * @returns {Promise<{generated: boolean, count?: number, total?: number,
+ *   size?: number, missing_count?: number}>}
+ */
+export async function fetchSpriteStatus(datasetId, column, size = 64) {
+  const params = new URLSearchParams({ column, size });
+  const url = `${apiUrl}/datasets/${encodeURIComponent(datasetId)}/sprites/status?${params.toString()}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    return { generated: false };
+  }
+  return response.json();
+}

--- a/web/src/lib/spriteUrl.test.js
+++ b/web/src/lib/spriteUrl.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.stubEnv('VITE_API_URL', 'http://localhost:5001/api');
+
+const { spriteUrlFor } = await import('./spriteUrl.js');
+
+describe('spriteUrlFor', () => {
+  it('builds the sprite endpoint URL with column, index and default size', () => {
+    expect(spriteUrlFor('my-dataset', 'image', 42)).toBe(
+      'http://localhost:5001/api/datasets/my-dataset/sprite?column=image&index=42&size=64'
+    );
+  });
+
+  it('includes a custom size when provided', () => {
+    expect(spriteUrlFor('my-dataset', 'image', 0, 128)).toBe(
+      'http://localhost:5001/api/datasets/my-dataset/sprite?column=image&index=0&size=128'
+    );
+  });
+
+  it('encodes odd column names', () => {
+    const url = spriteUrlFor('ds', 'my image & co?', 3, 64);
+    const params = new URL(url).searchParams;
+    expect(params.get('column')).toBe('my image & co?');
+    expect(params.get('index')).toBe('3');
+    expect(params.get('size')).toBe('64');
+  });
+
+  it('encodes the dataset id in the path', () => {
+    expect(spriteUrlFor('weird/ds name', 'img', 0)).toContain(
+      '/datasets/weird%2Fds%20name/sprite?'
+    );
+  });
+});


### PR DESCRIPTION
Implements the images-on-the-map half of #24, on top of the image-embedding (#124) and image-display (#125) work. Storage design (individual 64px WebP files) and the DOM-overlay-first approach were chosen with the maintainer for memory efficiency.

## Generation — optional background-job step

- `latentscope/scripts/sprites.py` + `ls-sprites` CLI streams `input.parquet` row-group by row-group (no full-RAM load) and writes one 64px WebP per row to `sprites/<col>-64/<index//1000>/<index>.webp` — sharded ≤1000 files/dir — plus an atomic manifest (`count/total/missing/complete`). **Resumable** (skips existing files); null/undecodable images are recorded in `missing` and get no file.
- `run_sprites` route (`/api/jobs/sprites`) runs it through the web job system like embed/umap.
- `datasets.py`: `/sprites/status` (generated? counts) and `/sprite` (serve one webp, 1-day cache, 404 on missing) read endpoints.

## Overlay — DOM, individual files, memory-bounded

`SpriteOverlay.jsx` renders absolutely-positioned `<img>` **only** for points inside the visible domain, past a zoom threshold (`k≥4`), **hard-capped at 600** (over the cap → render none, dots remain). So the browser only ever decodes what's on screen (~hundreds × 64² regardless of dataset size — 20k or 1M behave identically). Projection matches `AnnotationPlot` exactly; the container is `pointer-events:none` so zoom/hover still reach the canvas; rare 404s are hidden via `onError`.

`VisualizationPane` wires it in with a **"Show Images"** toggle when sprites exist, or a **"Generate image sprites"** button that launches the job and auto-enables the toggle on completion.

## Why this design

Individual files give the best browser-memory profile for a viewport-culled overlay: only visible cells decode (~5MB), and serving is a cheap static file read. Packed atlases/CSS-sprites would force full-sheet decode (~67MB per 4096² sheet) — deferred to a possible WebGL "all sprites at once" v2.

## Verified

Python 131→137 (sharding/manifest/resume/missing + status/serve endpoints), web 61→65; lint 0 errors; production build green. Sprites generated for the live marqo-ge-sample (20k) for manual testing on the dev instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
