### PR TITLE
Fix Codex review on #127: sprite path sanitization + viewport-indexed culling

### DIFF
--- a/latentscope/scripts/sprites.py
+++ b/latentscope/scripts/sprites.py
@@ -7,6 +7,7 @@
 import argparse
 import json
 import os
+import re
 import sys
 
 try:
@@ -20,6 +21,27 @@ except ImportError:
 from latentscope.util import get_data_dir
 
 SHARD_SIZE = 1000
+
+
+def sprite_slug(column):
+    """Path-safe directory component for an image column name.
+
+    The writer (this script) and the server endpoints must produce the same
+    slug so generated files can be served back. Stripping path separators and
+    dots keeps thumbnails contained under ``<dataset>/sprites/`` even when a
+    column name contains ``/``, ``\\`` or ``..``.
+    """
+    return re.sub(r"[^A-Za-z0-9_-]", "_", str(column)) or "_"
+
+
+def sprite_dir_name(column, size):
+    """Directory name for a column's sprites of a given size."""
+    return f"{sprite_slug(column)}-{size}"
+
+
+def sprite_manifest_name(column, size):
+    """Manifest filename for a column's sprites of a given size."""
+    return f"{sprite_slug(column)}-{size}.json"
 
 
 def shard_for(index):
@@ -73,7 +95,7 @@ def generate_sprites(dataset_id, image_column, size=64, quality=80):
     print("RUNNING:", run_id)
 
     sprites_root = os.path.join(dataset_dir, "sprites")
-    out_dir = os.path.join(sprites_root, f"{image_column}-{size}")
+    out_dir = os.path.join(sprites_root, sprite_dir_name(image_column, size))
     os.makedirs(out_dir, exist_ok=True)
 
     input_path = os.path.join(dataset_dir, "input.parquet")
@@ -89,7 +111,7 @@ def generate_sprites(dataset_id, image_column, size=64, quality=80):
     )
     print(f"{existing_start} of {total} sprites already exist; resuming")
 
-    manifest_path = os.path.join(sprites_root, f"{image_column}-{size}.json")
+    manifest_path = os.path.join(sprites_root, sprite_manifest_name(image_column, size))
 
     def write_manifest(missing, count, complete):
         os.makedirs(sprites_root, exist_ok=True)

--- a/latentscope/server/datasets.py
+++ b/latentscope/server/datasets.py
@@ -203,8 +203,10 @@ def get_dataset_sprites_status(dataset):
     if err:
         return err
 
+    from latentscope.scripts.sprites import sprite_manifest_name
+
     manifest_path = os.path.join(
-        _data_dir(), dataset, "sprites", f"{column}-{size}.json"
+        _data_dir(), dataset, "sprites", sprite_manifest_name(column, size)
     )
     try:
         with open(manifest_path, encoding='utf-8') as f:
@@ -253,9 +255,11 @@ def get_dataset_sprite(dataset):
     if index < 0 or index >= meta.get("length", 0):
         return jsonify({"error": "index out of range"}), 404
 
+    from latentscope.scripts.sprites import sprite_dir_name
+
     shard = f"{index // 1000:03d}"
     sprite_path = os.path.join(
-        _data_dir(), dataset, "sprites", f"{column}-{size}", shard, f"{index}.webp"
+        _data_dir(), dataset, "sprites", sprite_dir_name(column, size), shard, f"{index}.webp"
     )
     if not os.path.exists(sprite_path):
         return jsonify({"error": "no sprite at this index"}), 404

--- a/tests/test_sprites.py
+++ b/tests/test_sprites.py
@@ -175,3 +175,22 @@ def test_sprite_endpoint_serves_and_404s(client, sprite_dataset):
     # non-image column -> 400
     bad = client.get(f"/api/datasets/{sprite_dataset}/sprite?column=text&index=0&size=64")
     assert bad.status_code == 400
+
+
+def test_sprite_slug_contains_path_traversal():
+    """Column names with path separators must not escape the sprites dir."""
+    from latentscope.scripts.sprites import (
+        sprite_dir_name,
+        sprite_manifest_name,
+        sprite_slug,
+    )
+
+    for bad in ["../../etc", "a/b", "a\\b", "..", "x/../y"]:
+        slug = sprite_slug(bad)
+        assert "/" not in slug and "\\" not in slug
+        assert ".." not in slug
+        assert "/" not in sprite_dir_name(bad, 64)
+        assert "/" not in sprite_manifest_name(bad, 64)
+    # ordinary names stay readable
+    assert sprite_slug("image") == "image"
+    assert sprite_dir_name("image", 64) == "image-64"

--- a/web/src/components/Explore/SpriteOverlay.jsx
+++ b/web/src/components/Explore/SpriteOverlay.jsx
@@ -22,6 +22,19 @@ function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
 }
 
+// Spatial grid resolution over the normalized umap space [-1, 1]^2. 64 matches
+// the scope's own tile grid; cells are ~0.03 wide so a zoomed-in viewport
+// touches only a handful.
+const GRID = 64;
+
+function toCell(v) {
+  return clamp(Math.floor(((v + 1) / 2) * GRID), 0, GRID - 1);
+}
+
+function cellKey(cx, cy) {
+  return cy * GRID + cx;
+}
+
 /**
  * Viewport-culled DOM image overlay for the scatter map. Renders absolutely
  * positioned <img> elements only for points currently visible, past a zoom
@@ -50,33 +63,67 @@ function SpriteOverlay({
 
   const spritePx = useMemo(() => clamp(BASE_SPRITE_PX * (k / ZOOM_THRESHOLD), MIN_SPRITE_PX, MAX_SPRITE_PX), [k]);
 
+  // Spatial grid over the normalized umap space [-1, 1]^2 so viewport culling
+  // scans only the cells in view rather than every row. Built once per
+  // scopeRows, queried on each pan/zoom — keeps per-interaction work
+  // O(visible) instead of O(N) for large scopes.
+  const grid = useMemo(() => {
+    const cells = new Map();
+    if (!scopeRows?.length) return cells;
+    for (let i = 0; i < scopeRows.length; i++) {
+      const row = scopeRows[i];
+      if (!row || row.deleted) continue;
+      const key = cellKey(toCell(row.x), toCell(row.y));
+      let bucket = cells.get(key);
+      if (!bucket) {
+        bucket = [];
+        cells.set(key, bucket);
+      }
+      bucket.push(row);
+    }
+    return cells;
+  }, [scopeRows]);
+
   const visibleSprites = useMemo(() => {
     if (!enabled || !manifest?.generated) return [];
     if (k < ZOOM_THRESHOLD) return [];
-    if (!xDomain || !yDomain || !scopeRows?.length) return [];
+    if (!xDomain || !yDomain || !grid.size) return [];
 
     const xScale = scaleLinear().domain(xDomain).range([0, width]);
     const yScale = scaleLinear().domain(yDomain).range([height, 0]);
 
+    // The visible data-domain (domains may run either direction depending on
+    // the zoom math, so normalize to lo/hi).
+    const xlo = Math.min(xDomain[0], xDomain[1]);
+    const xhi = Math.max(xDomain[0], xDomain[1]);
+    const ylo = Math.min(yDomain[0], yDomain[1]);
+    const yhi = Math.max(yDomain[0], yDomain[1]);
+    const cx0 = toCell(xlo);
+    const cx1 = toCell(xhi);
+    const cy0 = toCell(ylo);
+    const cy1 = toCell(yhi);
+
     const result = [];
-    for (let i = 0; i < scopeRows.length; i++) {
-      const row = scopeRows[i];
-      if (!row || row.deleted) continue;
-      // xDomain/yDomain ARE the visible data-domain: cull to it.
-      if (row.x < xDomain[0] || row.x > xDomain[1]) continue;
-      if (row.y < yDomain[0] || row.y > yDomain[1]) continue;
-      const index = row.ls_index;
-      if (missingSet && missingSet.has(index)) continue;
-      result.push({
-        index,
-        left: xScale(row.x) - spritePx / 2,
-        top: yScale(row.y) - spritePx / 2,
-      });
-      // Over the cap: bail out and render none (dots remain), bounding memory.
-      if (result.length > MAX_SPRITES) return [];
+    for (let cy = cy0; cy <= cy1; cy++) {
+      for (let cx = cx0; cx <= cx1; cx++) {
+        const bucket = grid.get(cellKey(cx, cy));
+        if (!bucket) continue;
+        for (let j = 0; j < bucket.length; j++) {
+          const row = bucket[j];
+          if (row.x < xlo || row.x > xhi || row.y < ylo || row.y > yhi) continue;
+          if (missingSet && missingSet.has(row.ls_index)) continue;
+          result.push({
+            index: row.ls_index,
+            left: xScale(row.x) - spritePx / 2,
+            top: yScale(row.y) - spritePx / 2,
+          });
+          // Over the cap: render none (dots remain), bounding browser memory.
+          if (result.length > MAX_SPRITES) return [];
+        }
+      }
     }
     return result;
-  }, [enabled, manifest, k, xDomain, yDomain, scopeRows, width, height, spritePx, missingSet]);
+  }, [enabled, manifest, k, xDomain, yDomain, grid, width, height, spritePx, missingSet]);
 
   if (!visibleSprites.length) return null;
 


### PR DESCRIPTION
Two P2 findings from the Codex review of #127.

**Path traversal via column name** — the image column name was interpolated raw into sprite filesystem paths (generator + both serving endpoints), so a column named `../x` or with `/` could write/serve outside `<dataset>/sprites`. Added shared `sprite_slug()` / `sprite_dir_name()` / `sprite_manifest_name()` in `sprites.py`, used by the generator and by `datasets.py`'s `/sprite` + `/sprites/status`, so paths stay contained and the writer/reader agree. (`/sprite` already gated on column-type; this is defense-in-depth and closes the status read path.) Test asserts traversal names produce contained slugs.

**O(N) overlay culling per interaction** — `SpriteOverlay` scanned every `scopeRows` entry on each `onView` (fires continuously during zoom), which would peg the UI thread on million-row scopes and defeat the bounded overlay. Now builds a 64×64 spatial grid once per `scopeRows` and iterates only the cells overlapping the visible domain, so per-pan work is O(visible) regardless of dataset size. Behavior (zoom gate, cap, missing/deleted skips) unchanged.

Verified: 138 python + 2 skipped, 65 web, lint 0 errors, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)