### PR TITLE
Address open Codex review comments on #123, #126, #128

### DIFF
--- a/latentscope/scripts/sprites.py
+++ b/latentscope/scripts/sprites.py
@@ -5,6 +5,7 @@
 # This is an OPTIONAL pipeline step (like embed / umap) that powers the
 # viewport-culled DOM image overlay in the scatter map.
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -30,8 +31,19 @@ def sprite_slug(column):
     slug so generated files can be served back. Stripping path separators and
     dots keeps thumbnails contained under ``<dataset>/sprites/`` even when a
     column name contains ``/``, ``\\`` or ``..``.
+
+    The substitution is lossy, so distinct columns ("a/b", "a.b", "a b") could
+    collapse to the same string and clobber each other's manifest/thumbnails.
+    When a name needs sanitizing we append a short stable hash of the original
+    to keep slugs collision-free. Names that are already path-safe (e.g.
+    "image") pass through unchanged so previously generated sprites stay valid.
     """
-    return re.sub(r"[^A-Za-z0-9_-]", "_", str(column)) or "_"
+    col = str(column)
+    safe = re.sub(r"[^A-Za-z0-9_-]", "_", col)
+    if safe == col and safe:
+        return safe
+    digest = hashlib.sha1(col.encode("utf-8")).hexdigest()[:8]
+    return f"{safe or '_'}-{digest}"
 
 
 def sprite_dir_name(column, size):

--- a/latentscope/server/search.py
+++ b/latentscope/server/search.py
@@ -56,14 +56,21 @@ def nn():
         emb_meta = json.load(f)
     has_token_vecs = emb_meta.get('late_interaction', False)
 
-    if use_late_interaction and is_late_interaction and has_token_vecs:
-        return nn_late_interaction(DATA_DIR, dataset, embedding_id, model, query, dimensions)
-
-    # If lancedb is available, use it for search (scope-level table)
+    # A scoped request must stay within its scope. The scope-level LanceDB
+    # table holds only the rows in that scope, so it has to take precedence
+    # over the MaxSim default below — otherwise a ColBERT embedding would fall
+    # into nn_late_interaction(), which searches the full token table and
+    # returns global indices outside the current scope (the UI has no way to
+    # pass late_interaction=false for that path). Scoped late-interaction
+    # therefore degrades to mean-vector ANN within the scope, which is correct
+    # if less precise than global MaxSim.
     if scope_id is not None:
         lance_path = os.path.join(DATA_DIR, dataset, "lancedb", scope_id + ".lance")
         if os.path.exists(lance_path):
             return nn_lance(DATA_DIR, dataset, scope_id, model, query, dimensions)
+
+    if use_late_interaction and is_late_interaction and has_token_vecs:
+        return nn_late_interaction(DATA_DIR, dataset, embedding_id, model, query, dimensions)
 
     # Try embedding-level LanceDB table. Only the existence check is guarded:
     # once a table exists this path is always taken, so an embed/search error

--- a/tests/test_search_late_interaction.py
+++ b/tests/test_search_late_interaction.py
@@ -74,3 +74,37 @@ def test_nn_defaults_to_maxsim_for_late_interaction(client, li_dataset, monkeypa
                      f"&late_interaction=false")
     assert res.status_code == 200
     assert not any(c["is_query"] for c in provider.embed_multi_calls)
+
+
+def test_scoped_request_stays_in_scope_for_late_interaction(
+    client, li_dataset, tmp_data_dir, monkeypatch
+):
+    """Codex review on #123 (P1): a scoped search against a ColBERT embedding
+    must use the scope table, not fall into global MaxSim (which would return
+    indices outside the scope)."""
+    import lancedb
+
+    import latentscope.server.search as search_mod
+
+    provider = FakeLIProvider()
+    monkeypatch.setattr(search_mod, "get_embedding_model", lambda mid: provider)
+    search_mod.EMBEDDINGS.clear() if hasattr(search_mod.EMBEDDINGS, "clear") else None
+
+    # Build a minimal scope-level LanceDB table (rows 0..4 only).
+    scope_id = "scopes-001"
+    rng = np.random.default_rng(2)
+    rows = [
+        {"index": i, "vector": rng.normal(size=8).astype(np.float32).tolist()}
+        for i in range(5)
+    ]
+    db = lancedb.connect(os.path.join(tmp_data_dir, li_dataset, "lancedb"))
+    db.create_table(scope_id, data=rows)
+
+    res = client.get(f"/api/search/nn?dataset={li_dataset}"
+                     f"&embedding_id=embedding-001&query=hello&scope_id={scope_id}")
+    assert res.status_code == 200
+    data = res.get_json()
+    # Every returned index must belong to the scope (rows 0..4)...
+    assert data["indices"] and all(0 <= i < 5 for i in data["indices"])
+    # ...and the global MaxSim path must NOT have run (it encodes is_query=True).
+    assert not any(c["is_query"] for c in provider.embed_multi_calls)

--- a/tests/test_sprites.py
+++ b/tests/test_sprites.py
@@ -194,3 +194,21 @@ def test_sprite_slug_contains_path_traversal():
     # ordinary names stay readable
     assert sprite_slug("image") == "image"
     assert sprite_dir_name("image", 64) == "image-64"
+
+
+def test_sprite_slug_distinct_columns_do_not_collide():
+    """Codex review on #128 (P2): lossy substitution must not map distinct
+    columns onto the same slug, or one column's sprites would clobber the
+    other's."""
+    from latentscope.scripts.sprites import sprite_dir_name, sprite_slug
+
+    # These all normalize to "a_b" under the raw substitution.
+    colliding = ["a/b", "a.b", "a b", "a\\b"]
+    slugs = {sprite_slug(c) for c in colliding}
+    assert len(slugs) == len(colliding)
+    dirs = {sprite_dir_name(c, 64) for c in colliding}
+    assert len(dirs) == len(colliding)
+    # A genuinely path-safe column that equals another's pre-hash base must
+    # also stay distinct from the sanitized ones.
+    assert sprite_slug("a_b") == "a_b"
+    assert sprite_slug("a_b") not in slugs

--- a/web/src/pages/FullScreenExplore.jsx
+++ b/web/src/pages/FullScreenExplore.jsx
@@ -104,6 +104,11 @@ function ExploreContent() {
 
   useEffect(() => {
     if (hoveredIndex !== null && hoveredIndex !== undefined && !deletedIndicesSet.has(hoveredIndex)) {
+      // Invalidate any in-flight hydration for the previous point before we
+      // render this one. The hydration fetch is debounced 5ms, so without this
+      // the ref would still point at the old index during that window and a
+      // late response for the old point could overwrite the new tooltip/image.
+      latestHoverIndexRef.current = hoveredIndex;
       // Update the tooltip immediately with the new index + cluster so the
       // image (keyed on the index) swaps right away; the text arrives after
       // the hydration fetch, marked loading until then.


### PR DESCRIPTION
While auditing review comments on the last several merged PRs, three findings turned out to have been flagged but never addressed in code. This PR closes all three.

## Findings fixed

### #123 (P1) — scoped searches leaked out-of-scope results
`/api/search/nn` defaults to MaxSim for late-interaction embeddings, but that branch ran **before** the scope-level LanceDB branch. A scoped ColBERT search therefore went to `nn_late_interaction()`, which searches the full token table and returns global indices outside the requested scope (the UI has no way to pass `late_interaction=false`). The scope branch now takes precedence, so scoped late-interaction searches degrade to in-scope mean-vector ANN — correct, if less precise than global MaxSim.

### #126 (P2) — tooltip could revert to the previous point
The immediate hover render didn't advance `latestHoverIndexRef`, so during the 5ms hydration debounce a late response for the previous point still passed the staleness guard and overwrote the new tooltip/image. The ref is now advanced the moment the new point renders.

### #128 (P2) — distinct image columns could collide on disk
`sprite_slug()` was lossy (`a/b`, `a.b`, `a b` → `a_b`), so two image columns could clobber each other's thumbnails/manifest, and `/sprite` could serve the wrong images. A short stable hash is now appended whenever a name needs sanitizing. Path-safe names like `image` pass through unchanged, so already-generated sprites (e.g. marqo's `image-64/`) remain valid.

## Verification
- Added regression tests: scope precedence (`test_scoped_request_stays_in_scope_for_late_interaction`) and slug collision (`test_sprite_slug_distinct_columns_do_not_collide`).
- Python: 140 passed / 2 skipped. Web: 65 passed. ruff clean. Production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)