### PR TITLE
Compare: shared brush selection + color-by-column, cached distance backend (#131, #132)

### DIFF
--- a/latentscope/server/app.py
+++ b/latentscope/server/app.py
@@ -330,6 +330,54 @@ def create_app(data_dir=None, read_only=None):
             "totalPages": math.ceil(len(rows) / per_page),
         })
 
+    @app.route('/api/datasets/<dataset>/column/<column>', methods=['GET'])
+    def get_dataset_column(dataset, column):
+        """Return a single numeric column's values in row order, for color-by.
+
+        Powers the Compare page's continuous color-by-column layer (#131). Reads
+        from the cached input.parquet (``DATAFRAMES``), so repeat requests are
+        free. Non-numeric columns are rejected — coloring needs a numeric ramp.
+        The ``extent`` comes from meta.json's precomputed ``column_metadata`` when
+        available, falling back to the column's own min/max.
+        """
+        import numpy as np
+        import pandas as pd
+
+        df = _load_dataset_dataframe(data_dir, dataset, app.config['DATAFRAMES'])
+        if column not in df.columns:
+            return jsonify({"error": f"unknown column: {column}"}), 404
+        series = df[column]
+        if not pd.api.types.is_numeric_dtype(series):
+            return jsonify({"error": f"column '{column}' is not numeric"}), 400
+
+        # Prefer the extent recorded at ingest time; fall back to live min/max.
+        extent = None
+        try:
+            meta_path = os.path.join(data_dir, dataset, "meta.json")
+            with open(meta_path, encoding='utf-8') as f:
+                meta = json.load(f)
+            extent = (meta.get("column_metadata") or {}).get(column, {}).get("extent")
+        except (OSError, json.JSONDecodeError):
+            extent = None
+        if not extent or extent[0] is None or extent[1] is None:
+            valid = series.replace([np.inf, -np.inf], np.nan).dropna()
+            if len(valid):
+                extent = [float(valid.min()), float(valid.max())]
+            else:
+                extent = [None, None]
+
+        # NaN/inf aren't valid JSON; null them so the client can skip them.
+        values = series.to_numpy(dtype="float64")
+        values = np.where(np.isfinite(values), values, np.nan)
+        values = [None if np.isnan(v) else float(v) for v in values]
+
+        return jsonify({
+            "column": column,
+            "type": "number",
+            "extent": extent,
+            "values": values,
+        })
+
     if not read_only:
         @app.route('/api/settings', methods=['POST'])
         def update_settings():

--- a/latentscope/server/app.py
+++ b/latentscope/server/app.py
@@ -367,7 +367,9 @@ def create_app(data_dir=None, read_only=None):
                 extent = [None, None]
 
         # NaN/inf aren't valid JSON; null them so the client can skip them.
-        values = series.to_numpy(dtype="float64")
+        # na_value is required for pandas nullable/Arrow dtypes (Int64, Float64,
+        # …) — without it to_numpy(dtype="float64") raises on missing values.
+        values = series.to_numpy(dtype="float64", na_value=np.nan)
         values = np.where(np.isfinite(values), values, np.nan)
         values = [None if np.isnan(v) else float(v) for v in values]
 

--- a/latentscope/server/search.py
+++ b/latentscope/server/search.py
@@ -22,6 +22,55 @@ def _data_dir():
 EMBEDDINGS = LRUCache(maxsize=2)  # loaded embedding models
 NN_CACHE = LRUCache(maxsize=2)  # fitted sklearn NearestNeighbors, keyed (dataset, embedding_id)
 
+# UMAP comparison caches. The Compare page hits /compare and /compare/neighbors
+# repeatedly (on every metric/k change and every point click); previously each
+# call re-read both umap parquets and refit a fresh NearestNeighbors index over
+# all N points. These caches make the coordinates and the fitted kNN a shared,
+# reusable resource so repeat clicks are effectively instant.
+UMAP_COORDS = LRUCache(maxsize=6)  # (N,2) float32 coords, keyed (dataset, umap_id)
+UMAP_KNN = LRUCache(maxsize=6)  # (NearestNeighbors, neighbor_idx matrix), keyed (dataset, umap_id, k)
+
+
+def _umap_coords(dataset, umap_id):
+    """Load a umap's (N, 2) float32 coordinate array, cached by (dataset, umap).
+
+    Reads only the ``x``/``y`` columns so extra columns (should they ever be
+    written alongside) can't change the array shape the metrics rely on.
+    """
+    import pandas as pd
+
+    key = (dataset, umap_id)
+    coords = UMAP_COORDS.get(key)
+    if coords is None:
+        DATA_DIR = _data_dir()
+        path = os.path.join(DATA_DIR, dataset, "umaps", f"{umap_id}.parquet")
+        df = pd.read_parquet(path, columns=["x", "y"])
+        coords = df.to_numpy(dtype="float32")
+        UMAP_COORDS[key] = coords
+    return coords
+
+
+def _umap_knn(dataset, umap_id, k):
+    """Fit (once) and cache a NearestNeighbors index + neighbor-index matrix.
+
+    Returns ``(nn, neighbor_idx)`` where ``neighbor_idx`` is an ``(N, k+1)``
+    array of each point's own index followed by its k nearest neighbors (the
+    self-match at column 0 is kept so callers can strip it or reuse it). Keyed
+    by ``(dataset, umap_id, k)`` so changing only k on the other side is cheap.
+    """
+    from sklearn.neighbors import NearestNeighbors
+
+    key = (dataset, umap_id, k)
+    cached = UMAP_KNN.get(key)
+    if cached is None:
+        coords = _umap_coords(dataset, umap_id)
+        n_neighbors = min(k + 1, len(coords))
+        nn = NearestNeighbors(n_neighbors=n_neighbors, algorithm="auto").fit(coords)
+        _, neighbor_idx = nn.kneighbors(coords)
+        cached = (nn, neighbor_idx)
+        UMAP_KNN[key] = cached
+    return cached
+
 
 @search_bp.route('/nn', methods=['GET'])
 def nn():
@@ -247,9 +296,7 @@ def features():
 @search_bp.route('/compare', methods=['GET'])
 def compare():
     import numpy as np
-    import pandas as pd
 
-    DATA_DIR = _data_dir()
     dataset = _safe_dataset(request.args.get('dataset'))
     umap_left = request.args.get('umap_left')
     umap_right = request.args.get('umap_right')
@@ -257,34 +304,32 @@ def compare():
     k = request.args.get('k')
     k = int(k) if k else 10
 
-    umap_dir = os.path.join(DATA_DIR, dataset, "umaps")
-    left = pd.read_parquet(os.path.join(umap_dir, f"{umap_left}.parquet")).to_numpy()
-    right = pd.read_parquet(os.path.join(umap_dir, f"{umap_right}.parquet")).to_numpy()
+    left = _umap_coords(dataset, umap_left)
+    right = _umap_coords(dataset, umap_right)
 
     if metric == 'neighborhood':
-        from sklearn.neighbors import NearestNeighbors
-        nn_left = NearestNeighbors(n_neighbors=k, algorithm='auto').fit(left)
-        nn_right = NearestNeighbors(n_neighbors=k, algorithm='auto').fit(right)
-        _, idx_left = nn_left.kneighbors(left)
-        _, idx_right = nn_right.kneighbors(right)
-        scores = np.zeros(len(left))
+        # Jaccard overlap of each point's k-NN set in the two projections.
+        # Both indices include the point itself at column 0; drop it so the
+        # score reflects the k true neighbors on each side.
+        _, idx_left = _umap_knn(dataset, umap_left, k)
+        _, idx_right = _umap_knn(dataset, umap_right, k)
+        idx_left = idx_left[:, 1:]
+        idx_right = idx_right[:, 1:]
+        scores = np.empty(len(left))
         for i in range(len(left)):
-            set_l = set(idx_left[i])
-            set_r = set(idx_right[i])
-            jaccard = len(set_l & set_r) / len(set_l | set_r)
-            scores[i] = 1 - jaccard  # 0 = same neighborhood, 1 = completely different
+            inter = np.intersect1d(idx_left[i], idx_right[i], assume_unique=True).size
+            union = idx_left.shape[1] + idx_right.shape[1] - inter
+            scores[i] = 1 - inter / union  # 0 = same neighborhood, 1 = completely different
         result = scores
     elif metric == 'relative':
-        from sklearn.neighbors import NearestNeighbors
+        # Per-point displacement minus the mean displacement of its left-map
+        # neighbors — highlights points that move differently than their local
+        # cohort. Vectorized over the cached neighbor-index matrix.
         displacement = np.linalg.norm(right - left, axis=1)
-        nn_left = NearestNeighbors(n_neighbors=k, algorithm='auto').fit(left)
-        _, idx_left = nn_left.kneighbors(left)
-        # For each point, subtract the mean displacement of its neighbors
-        relative = np.zeros(len(left))
-        for i in range(len(left)):
-            neighbor_mean = np.mean(displacement[idx_left[i]])
-            relative[i] = abs(displacement[i] - neighbor_mean)
-        result = relative
+        _, idx_left = _umap_knn(dataset, umap_left, k)
+        idx_left = idx_left[:, 1:]
+        neighbor_means = displacement[idx_left].mean(axis=1)
+        result = np.abs(displacement - neighbor_means)
     else:
         # Default: absolute displacement (L2)
         result = np.linalg.norm(right - left, axis=1)
@@ -302,11 +347,6 @@ def compare():
 
 @search_bp.route('/compare/neighbors', methods=['GET'])
 def compare_neighbors():
-    import numpy as np
-    import pandas as pd
-    from sklearn.neighbors import NearestNeighbors
-
-    DATA_DIR = _data_dir()
     dataset = _safe_dataset(request.args.get('dataset'))
     umap_left = request.args.get('umap_left')
     umap_right = request.args.get('umap_right')
@@ -314,23 +354,105 @@ def compare_neighbors():
     side = request.args.get('side', 'left')
     k = int(request.args.get('k', 10))
 
-    umap_dir = os.path.join(DATA_DIR, dataset, "umaps")
-    left = pd.read_parquet(os.path.join(umap_dir, f"{umap_left}.parquet")).to_numpy()
-    right = pd.read_parquet(os.path.join(umap_dir, f"{umap_right}.parquet")).to_numpy()
-
-    # Find k-NN based on which side was clicked
-    source = left if side == 'left' else right
-    # Clamp k to dataset size to avoid sklearn error
-    k = min(k, len(source) - 1)
-    nn = NearestNeighbors(n_neighbors=k + 1, algorithm='auto').fit(source)
-    _, indices = nn.kneighbors([source[point_index]])
-    # Remove the point itself from neighbors
-    neighbor_indices = [int(i) for i in indices[0] if i != point_index][:k]
+    # Reuse the cached kNN index for the clicked side rather than refitting a
+    # fresh NearestNeighbors over all N points on every click.
+    umap_id = umap_left if side == 'left' else umap_right
+    _, neighbor_idx = _umap_knn(dataset, umap_id, k)
+    # Row point_index holds [self, n1, n2, ...]; drop the point itself.
+    neighbor_indices = [int(i) for i in neighbor_idx[point_index] if int(i) != point_index][:k]
 
     return jsonify({
         "point_index": point_index,
         "side": side,
         "neighbor_indices": neighbor_indices,
+    })
+
+
+# Selections above this many points are subsampled for the O(n^2) mean-pairwise
+# distance so the spread stat stays responsive; the convex hull is cheap and is
+# always computed on the full selection.
+SPREAD_SAMPLE_CAP = 2000
+
+
+def _spread_stats(coords, indices):
+    """Cohesion stats for a selected point set within one projection.
+
+    Returns mean pairwise distance, convex-hull area, bounding-box area and
+    centroid. ``mean_pairwise`` is subsampled above ``SPREAD_SAMPLE_CAP`` points
+    (flagged via ``sampled``); the hull needs >= 3 non-collinear points and is
+    reported as 0 otherwise.
+    """
+    import numpy as np
+    from scipy.spatial import ConvexHull
+    from scipy.spatial.distance import pdist
+
+    pts = coords[indices]
+    n = len(pts)
+    stats = {
+        "n": int(n),
+        "mean_pairwise": None,
+        "hull_area": 0.0,
+        "bbox_area": 0.0,
+        "centroid": None,
+        "sampled": False,
+    }
+    if n == 0:
+        return stats
+
+    centroid = pts.mean(axis=0)
+    stats["centroid"] = [float(centroid[0]), float(centroid[1])]
+
+    mins = pts.min(axis=0)
+    maxs = pts.max(axis=0)
+    stats["bbox_area"] = float((maxs[0] - mins[0]) * (maxs[1] - mins[1]))
+
+    if n >= 2:
+        sample = pts
+        if n > SPREAD_SAMPLE_CAP:
+            # Deterministic evenly-spaced subsample (no RNG => stable readout).
+            step = n / SPREAD_SAMPLE_CAP
+            sel = (np.arange(SPREAD_SAMPLE_CAP) * step).astype(int)
+            sample = pts[sel]
+            stats["sampled"] = True
+        stats["mean_pairwise"] = float(pdist(sample).mean())
+
+    if n >= 3:
+        try:
+            stats["hull_area"] = float(ConvexHull(pts).volume)  # 2D volume == area
+        except Exception:
+            # Degenerate (collinear/coincident) points have no 2D hull.
+            stats["hull_area"] = 0.0
+
+    return stats
+
+
+@search_bp.route('/compare/spread', methods=['POST'])
+def compare_spread():
+    """Compare how coherent a selected set of points is in each projection.
+
+    Body: ``{ dataset, umap_left, umap_right, indices: [...] }``. Returns
+    per-side spread stats so the UI can say e.g. "this region is 2.3x more
+    spread out in the right map".
+    """
+    import numpy as np
+
+    req = request.get_json() or {}
+    dataset = _safe_dataset(req.get('dataset'))
+    umap_left = req.get('umap_left')
+    umap_right = req.get('umap_right')
+    indices = req.get('indices') or []
+
+    left = _umap_coords(dataset, umap_left)
+    right = _umap_coords(dataset, umap_right)
+
+    # Keep only in-range indices so a stale selection can't index out of bounds.
+    n_points = len(left)
+    idx = np.asarray([i for i in indices if 0 <= int(i) < n_points], dtype=int)
+
+    return jsonify({
+        "n_selected": int(len(idx)),
+        "left": _spread_stats(left, idx),
+        "right": _spread_stats(right, idx),
     })
 
 

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -29,20 +29,26 @@ def _make_compare_dataset(data_dir, name="cmp", n=60, seed=0):
         os.path.join(ds_dir, "umaps", "umap-002.parquet"))
 
     score = rng.uniform(0, 10, size=n)
+    # A pandas nullable (Int64) column with a missing value — exercises the
+    # na_value path in the color-by endpoint.
+    nullable = pd.array(rng.integers(0, 5, size=n), dtype="Int64")
+    nullable[0] = pd.NA
     df = pd.DataFrame({
         "text": [f"row {i}" for i in range(n)],
         "score": score,
+        "rating": nullable,
     })
     df.to_parquet(os.path.join(ds_dir, "input.parquet"))
 
     meta = {
         "id": name,
         "length": n,
-        "columns": ["text", "score"],
+        "columns": ["text", "score", "rating"],
         "text_column": "text",
         "column_metadata": {
             "text": {"type": "string"},
             "score": {"type": "number", "extent": [float(score.min()), float(score.max())]},
+            "rating": {"type": "number"},
         },
     }
     with open(os.path.join(ds_dir, "meta.json"), "w", encoding="utf-8") as f:
@@ -146,6 +152,16 @@ class TestColumnEndpoint:
         name, _ = _make_compare_dataset(tmp_data_dir)
         r = client.get(f"/api/datasets/{name}/column/nope")
         assert r.status_code == 404
+
+    def test_nullable_column_with_missing_values(self, app, client, tmp_data_dir):
+        # Regression: nullable/Arrow dtypes with NA must not 500 (na_value path).
+        name, n = _make_compare_dataset(tmp_data_dir)
+        r = client.get(f"/api/datasets/{name}/column/rating")
+        assert r.status_code == 200
+        data = json.loads(r.data)
+        assert len(data["values"]) == n
+        assert data["values"][0] is None  # the NA row serializes as null
+        assert data["extent"][0] is not None and data["extent"][1] is not None
 
 
 class TestSpread:

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,186 @@
+"""Tests for the Compare backend: cached distance metrics, column color-by,
+and the selection spread statistic."""
+import json
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def _make_compare_dataset(data_dir, name="cmp", n=60, seed=0):
+    """Create a dataset with two umaps, an input.parquet and meta.json.
+
+    The two projections share structure but differ (right = left rotated + a
+    little jitter) so the drift metrics produce non-trivial, non-uniform values.
+    """
+    rng = np.random.default_rng(seed)
+    ds_dir = os.path.join(data_dir, name)
+    os.makedirs(os.path.join(ds_dir, "umaps"))
+
+    left = rng.uniform(-1, 1, size=(n, 2)).astype("float32")
+    theta = 0.6
+    rot = np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
+    right = (left @ rot.T + rng.normal(0, 0.05, size=(n, 2))).astype("float32")
+
+    pd.DataFrame(left, columns=["x", "y"]).to_parquet(
+        os.path.join(ds_dir, "umaps", "umap-001.parquet"))
+    pd.DataFrame(right, columns=["x", "y"]).to_parquet(
+        os.path.join(ds_dir, "umaps", "umap-002.parquet"))
+
+    score = rng.uniform(0, 10, size=n)
+    df = pd.DataFrame({
+        "text": [f"row {i}" for i in range(n)],
+        "score": score,
+    })
+    df.to_parquet(os.path.join(ds_dir, "input.parquet"))
+
+    meta = {
+        "id": name,
+        "length": n,
+        "columns": ["text", "score"],
+        "text_column": "text",
+        "column_metadata": {
+            "text": {"type": "string"},
+            "score": {"type": "number", "extent": [float(score.min()), float(score.max())]},
+        },
+    }
+    with open(os.path.join(ds_dir, "meta.json"), "w", encoding="utf-8") as f:
+        json.dump(meta, f)
+    return name, n
+
+
+@pytest.fixture(autouse=True)
+def _clear_umap_caches():
+    """Reset the module-level umap caches between tests.
+
+    They are keyed by (dataset, umap_id) without the data dir, so two tests
+    reusing a dataset name across different tmp dirs would otherwise collide.
+    """
+    from latentscope.server import search
+
+    search.UMAP_COORDS.clear()
+    search.UMAP_KNN.clear()
+    yield
+    search.UMAP_COORDS.clear()
+    search.UMAP_KNN.clear()
+
+
+class TestCompareMetrics:
+    def test_displacement_returns_normalized_values(self, app, client, tmp_data_dir):
+        name, n = _make_compare_dataset(tmp_data_dir)
+        r = client.get(f"/api/search/compare?dataset={name}"
+                       f"&umap_left=umap-001&umap_right=umap-002&metric=displacement")
+        assert r.status_code == 200
+        vals = json.loads(r.data)
+        assert len(vals) == n
+        assert min(vals) == pytest.approx(0.0)
+        assert max(vals) == pytest.approx(1.0)
+        assert all(0.0 <= v <= 1.0 for v in vals)
+
+    @pytest.mark.parametrize("metric", ["displacement", "relative", "neighborhood"])
+    def test_all_metrics_valid(self, app, client, tmp_data_dir, metric):
+        name, n = _make_compare_dataset(tmp_data_dir)
+        r = client.get(f"/api/search/compare?dataset={name}"
+                       f"&umap_left=umap-001&umap_right=umap-002&metric={metric}&k=10")
+        assert r.status_code == 200
+        vals = json.loads(r.data)
+        assert len(vals) == n
+        assert all(np.isfinite(v) for v in vals)
+        assert all(0.0 <= v <= 1.0 for v in vals)
+
+    def test_coords_and_knn_caches_populate(self, app, client, tmp_data_dir):
+        from latentscope.server import search
+
+        name, _ = _make_compare_dataset(tmp_data_dir)
+        assert len(search.UMAP_COORDS) == 0
+        client.get(f"/api/search/compare?dataset={name}"
+                   f"&umap_left=umap-001&umap_right=umap-002&metric=neighborhood&k=5")
+        # both umaps' coords cached, and a knn index per (umap, k)
+        assert (name, "umap-001") in search.UMAP_COORDS
+        assert (name, "umap-002") in search.UMAP_COORDS
+        assert (name, "umap-001", 5) in search.UMAP_KNN
+        assert (name, "umap-002", 5) in search.UMAP_KNN
+
+
+class TestCompareNeighbors:
+    def test_returns_k_neighbors_without_self(self, app, client, tmp_data_dir):
+        name, _ = _make_compare_dataset(tmp_data_dir)
+        r = client.get(f"/api/search/compare/neighbors?dataset={name}"
+                       f"&umap_left=umap-001&umap_right=umap-002&point_index=3&side=left&k=7")
+        assert r.status_code == 200
+        data = json.loads(r.data)
+        assert data["point_index"] == 3
+        assert data["side"] == "left"
+        assert len(data["neighbor_indices"]) == 7
+        assert 3 not in data["neighbor_indices"]
+
+    def test_reuses_cached_knn(self, app, client, tmp_data_dir):
+        from latentscope.server import search
+
+        name, _ = _make_compare_dataset(tmp_data_dir)
+        client.get(f"/api/search/compare/neighbors?dataset={name}"
+                   f"&umap_left=umap-001&umap_right=umap-002&point_index=0&side=right&k=6")
+        assert (name, "umap-002", 6) in search.UMAP_KNN
+
+
+class TestColumnEndpoint:
+    def test_numeric_column_returns_values_and_extent(self, app, client, tmp_data_dir):
+        name, n = _make_compare_dataset(tmp_data_dir)
+        r = client.get(f"/api/datasets/{name}/column/score")
+        assert r.status_code == 200
+        data = json.loads(r.data)
+        assert data["column"] == "score"
+        assert data["type"] == "number"
+        assert len(data["values"]) == n
+        lo, hi = data["extent"]
+        assert lo <= min(v for v in data["values"] if v is not None)
+        assert hi >= max(v for v in data["values"] if v is not None)
+
+    def test_text_column_rejected(self, app, client, tmp_data_dir):
+        name, _ = _make_compare_dataset(tmp_data_dir)
+        r = client.get(f"/api/datasets/{name}/column/text")
+        assert r.status_code == 400
+
+    def test_unknown_column_404s(self, app, client, tmp_data_dir):
+        name, _ = _make_compare_dataset(tmp_data_dir)
+        r = client.get(f"/api/datasets/{name}/column/nope")
+        assert r.status_code == 404
+
+
+class TestSpread:
+    def test_returns_finite_per_side_stats(self, app, client, tmp_data_dir):
+        name, _ = _make_compare_dataset(tmp_data_dir)
+        r = client.post("/api/search/compare/spread", json={
+            "dataset": name, "umap_left": "umap-001", "umap_right": "umap-002",
+            "indices": list(range(10)),
+        })
+        assert r.status_code == 200
+        data = json.loads(r.data)
+        assert data["n_selected"] == 10
+        for side in ("left", "right"):
+            s = data[side]
+            assert s["n"] == 10
+            assert s["mean_pairwise"] > 0
+            assert s["hull_area"] >= 0
+            assert s["centroid"] is not None
+
+    def test_fewer_than_three_points_no_hull(self, app, client, tmp_data_dir):
+        name, _ = _make_compare_dataset(tmp_data_dir)
+        r = client.post("/api/search/compare/spread", json={
+            "dataset": name, "umap_left": "umap-001", "umap_right": "umap-002",
+            "indices": [0, 1],
+        })
+        assert r.status_code == 200
+        data = json.loads(r.data)
+        assert data["left"]["hull_area"] == 0.0
+        assert data["left"]["mean_pairwise"] is not None  # 2 points still have a distance
+
+    def test_out_of_range_indices_dropped(self, app, client, tmp_data_dir):
+        name, n = _make_compare_dataset(tmp_data_dir)
+        r = client.post("/api/search/compare/spread", json={
+            "dataset": name, "umap_left": "umap-001", "umap_right": "umap-002",
+            "indices": [0, 1, 2, n + 100, -5],
+        })
+        assert r.status_code == 200
+        assert json.loads(r.data)["n_selected"] == 3

--- a/web/src/components/Compare/ColorLegend.jsx
+++ b/web/src/components/Compare/ColorLegend.jsx
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+
+// A compact horizontal color ramp with min/max labels, showing what the current
+// continuous color encoding (drift metric or a data column) maps to.
+function ColorLegend({ interpolator, extent, label, width = 120 }) {
+  const gradient = useMemo(() => {
+    if (!interpolator) return '';
+    const stops = [];
+    const n = 12;
+    for (let i = 0; i <= n; i++) {
+      stops.push(`${interpolator(i / n)} ${(100 * i) / n}%`);
+    }
+    return `linear-gradient(to right, ${stops.join(', ')})`;
+  }, [interpolator]);
+
+  const [lo, hi] = extent || [0, 1];
+  const fmt = (v) =>
+    v == null ? '' : Math.abs(v) >= 1000 || (v !== 0 && Math.abs(v) < 0.01)
+      ? v.toExponential(1)
+      : (+v).toFixed(2);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+        fontSize: '0.72em',
+        color: '#888',
+      }}
+    >
+      {label && <span style={{ fontWeight: 600 }}>{label}</span>}
+      <div style={{ height: 8, width, borderRadius: 2, background: gradient }} />
+      <div style={{ display: 'flex', justifyContent: 'space-between', width }}>
+        <span>{fmt(lo)}</span>
+        <span>{fmt(hi)}</span>
+      </div>
+    </div>
+  );
+}
+
+export default ColorLegend;

--- a/web/src/components/Compare/Compare.module.css
+++ b/web/src/components/Compare/Compare.module.css
@@ -181,6 +181,12 @@
   gap: 6px;
 }
 
+.selection-hint {
+  font-size: 0.8em;
+  color: #aaa;
+  font-style: italic;
+}
+
 .clear-neighbors {
   padding: 1px 8px;
   border: 1px solid #4488ff;
@@ -443,4 +449,43 @@
   .side-by-side-container {
     flex-direction: column;
   }
+}
+
+.spread-summary {
+  margin: 6px 0 10px;
+  padding: 6px 8px;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.02);
+}
+
+.spread-title {
+  font-size: 0.78em;
+  font-weight: 600;
+  color: #555;
+  margin-bottom: 4px;
+}
+
+.spread-note {
+  font-weight: 400;
+  color: #999;
+  font-style: italic;
+}
+
+.spread-table {
+  border-collapse: collapse;
+  font-size: 0.78em;
+}
+
+.spread-table th,
+.spread-table td {
+  text-align: right;
+  padding: 1px 10px 1px 0;
+  color: #444;
+}
+
+.spread-table th:first-child,
+.spread-table td:first-child {
+  text-align: left;
+  color: #777;
 }

--- a/web/src/components/Compare/Compare.module.css
+++ b/web/src/components/Compare/Compare.module.css
@@ -1,77 +1,3 @@
-/* Page layout: fill the routed .page height, controls on top, maps flexing to
-   fill, a drag handle, then the bottom data panel. */
-.container {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  gap: 8px;
-  padding: 8px;
-  box-sizing: border-box;
-}
-
-.visualization {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-height: 0;
-}
-
-.view-container {
-  position: relative;
-  flex: 1;
-  min-height: 0;
-}
-
-/* View mode tabs (Transition / Side by Side) */
-.view-tabs {
-  display: flex;
-  gap: 2px;
-}
-
-.view-tab-active,
-.view-tab-inactive {
-  padding: 6px 18px;
-  border: 1px solid #ccc;
-  border-bottom: none;
-  border-radius: 5px 5px 0 0;
-  background: #f1f1f1;
-  color: #666;
-  cursor: pointer;
-  font-size: 0.9em;
-}
-
-.view-tab-active {
-  background: #fff;
-  color: #222;
-  font-weight: 600;
-  border-top: 2px solid seagreen;
-}
-
-.view-tab-inactive:hover {
-  background: #e6e6e6;
-}
-
-/* Resize handle between the maps and the bottom data panel */
-.drag-handle {
-  height: 10px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: ns-resize;
-  flex-shrink: 0;
-}
-
-.drag-grip {
-  width: 40px;
-  height: 4px;
-  border-radius: 2px;
-  background: #ccc;
-}
-
-.drag-handle:hover .drag-grip {
-  background: #999;
-}
-
 /* CompareControls */
 .controls {
   display: flex;
@@ -206,17 +132,42 @@
   min-height: 0;
 }
 
+/* Stack the two maps vertically (top = left umap, bottom = right umap). */
 .side-by-side-container {
   display: flex;
-  flex-direction: row;
-  gap: 12px;
+  flex-direction: column;
+  gap: 10px;
   flex: 1;
   min-height: 0;
 }
 
 .scatter-panel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  gap: 4px;
+}
+
+/* Inline UMAP picker shown directly above each map */
+.umap-inline-select {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.umap-inline-label {
+  font-size: 0.8em;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.umap-inline-select select {
   flex: 1;
   min-width: 0;
+  padding: 3px 6px;
+  font-size: 0.82em;
 }
 
 .link-zoom-toggle {
@@ -553,4 +504,44 @@
 .spread-table td:first-child {
   text-align: left;
   color: #777;
+}
+
+/* Search loading indicator */
+.search-loading {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #666;
+  font-size: 0.85em;
+}
+
+.spinner {
+  width: 12px;
+  height: 12px;
+  border: 2px solid #ccc;
+  border-top-color: seagreen;
+  border-radius: 50%;
+  display: inline-block;
+  animation: compare-spin 0.7s linear infinite;
+}
+
+@keyframes compare-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Full-row hover tooltip in the results tables */
+.row-tooltip {
+  max-width: 460px;
+  z-index: 1000;
+  font-size: 0.82em;
+  line-height: 1.4;
+  text-align: left;
+  white-space: normal;
+}
+
+/* Let wide result tables scroll horizontally within the column */
+.data-panel .tab-content {
+  overflow: auto;
 }

--- a/web/src/components/Compare/Compare.module.css
+++ b/web/src/components/Compare/Compare.module.css
@@ -1,3 +1,77 @@
+/* Page layout: fill the routed .page height, controls on top, maps flexing to
+   fill, a drag handle, then the bottom data panel. */
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  gap: 8px;
+  padding: 8px;
+  box-sizing: border-box;
+}
+
+.visualization {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.view-container {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+}
+
+/* View mode tabs (Transition / Side by Side) */
+.view-tabs {
+  display: flex;
+  gap: 2px;
+}
+
+.view-tab-active,
+.view-tab-inactive {
+  padding: 6px 18px;
+  border: 1px solid #ccc;
+  border-bottom: none;
+  border-radius: 5px 5px 0 0;
+  background: #f1f1f1;
+  color: #666;
+  cursor: pointer;
+  font-size: 0.9em;
+}
+
+.view-tab-active {
+  background: #fff;
+  color: #222;
+  font-weight: 600;
+  border-top: 2px solid seagreen;
+}
+
+.view-tab-inactive:hover {
+  background: #e6e6e6;
+}
+
+/* Resize handle between the maps and the bottom data panel */
+.drag-handle {
+  height: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: ns-resize;
+  flex-shrink: 0;
+}
+
+.drag-grip {
+  width: 40px;
+  height: 4px;
+  border-radius: 2px;
+  background: #ccc;
+}
+
+.drag-handle:hover .drag-grip {
+  background: #999;
+}
+
 /* CompareControls */
 .controls {
   display: flex;
@@ -6,6 +80,7 @@
   padding: 8px 12px;
   border: 1px solid lightgray;
   border-radius: 5px;
+  flex-shrink: 0;
 }
 
 .controls-header {
@@ -39,64 +114,49 @@
   padding: 4px 6px;
 }
 
+/* A single row of equal-height control groups (label on top, control below),
+   all aligned to the top so nothing looks ragged. */
 .metric-controls {
   display: flex;
   flex-direction: row;
-  gap: 12px;
-  align-items: flex-end;
+  gap: 16px;
+  align-items: flex-start;
   flex-wrap: wrap;
 }
 
-.metric-selector {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.metric-selector label {
-  font-size: 0.85em;
-  font-weight: 600;
-  color: #666;
-}
-
-.metric-description {
-  font-size: 0.75em;
-  color: #888;
-  line-height: 1.3;
-  max-width: 300px;
-}
-
-.metric-k {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.metric-k label {
-  font-size: 0.85em;
-  font-weight: 600;
-  color: #666;
-}
-
-.metric-k input[type='range'] {
-  width: 120px;
-}
-
+.metric-selector,
+.metric-k,
 .threshold-control {
-  flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
 }
 
+.metric-selector label,
+.metric-k label,
 .threshold-control label {
   font-size: 0.85em;
   font-weight: 600;
   color: #666;
+  white-space: nowrap;
 }
 
+.metric-selector select {
+  padding: 4px 6px;
+  min-width: 170px;
+}
+
+.metric-k input[type='range'],
 .threshold-control input[type='range'] {
-  width: 100%;
+  width: 150px;
+}
+
+/* One help/description line spanning the row, so per-control descriptions don't
+   make the control heights ragged. */
+.metric-help {
+  font-size: 0.78em;
+  color: #888;
+  line-height: 1.3;
 }
 
 .threshold-count {
@@ -235,7 +295,12 @@
   position: relative;
   border: 1px solid gray;
   border-radius: 5px;
-  padding: 6px;
+  /* No padding: the regl canvas and the absolutely-positioned overlay canvases
+     (.annotation-plot, top:0/left:0) must share the exact same box, or the
+     colored points render offset from the hover/selection markers. */
+  padding: 0;
+  overflow: hidden;
+  box-sizing: border-box;
 }
 
 .scatter canvas {

--- a/web/src/components/Compare/CompareControls.jsx
+++ b/web/src/components/Compare/CompareControls.jsx
@@ -33,6 +33,9 @@ function CompareControls({
   metricK,
   onMetricKChange,
   displacementLoading,
+  colorBy,
+  onColorByChange,
+  numericColumns = [],
 }) {
   const formatUmapOption = useCallback(
     (um) => {
@@ -86,6 +89,24 @@ function CompareControls({
             {METRIC_INFO[metric]?.description}
           </span>
         </div>
+        <div className={styles['metric-selector']}>
+          <label>Color by</label>
+          <select value={colorBy} onChange={(e) => onColorByChange(e.target.value)}>
+            <option value="__drift__">Drift metric</option>
+            {numericColumns.length > 0 && (
+              <optgroup label="Columns">
+                {numericColumns.map((col) => (
+                  <option key={col} value={col}>{col}</option>
+                ))}
+              </optgroup>
+            )}
+          </select>
+          <span className={styles['metric-description']}>
+            {colorBy === '__drift__'
+              ? 'Points are colored by the selected drift metric.'
+              : `Points are colored by the "${colorBy}" column value.`}
+          </span>
+        </div>
         {metric !== 'displacement' && (
           <div className={styles['metric-k']}>
             <label>k = {metricK}</label>
@@ -99,23 +120,25 @@ function CompareControls({
             />
           </div>
         )}
-        <div className={styles['threshold-control']}>
-          <label>
-            Threshold: {threshold.toFixed(2)}
-            {displacementLoading && <span className={styles['loading-indicator']}> computing...</span>}
-          </label>
-          <input
-            type="range"
-            min="0"
-            max="1"
-            step="0.01"
-            value={threshold}
-            onChange={(e) => onThresholdChange(parseFloat(e.target.value))}
-          />
-          <span className={styles['threshold-count']}>
-            {aboveThresholdCount} points above threshold
-          </span>
-        </div>
+        {colorBy === '__drift__' && (
+          <div className={styles['threshold-control']}>
+            <label>
+              Threshold: {threshold.toFixed(2)}
+              {displacementLoading && <span className={styles['loading-indicator']}> computing...</span>}
+            </label>
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.01"
+              value={threshold}
+              onChange={(e) => onThresholdChange(parseFloat(e.target.value))}
+            />
+            <span className={styles['threshold-count']}>
+              {aboveThresholdCount} points above threshold
+            </span>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/src/components/Compare/CompareControls.jsx
+++ b/web/src/components/Compare/CompareControls.jsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import styles from './Compare.module.css';
 
 const METRIC_INFO = {
@@ -19,12 +18,6 @@ const METRIC_INFO = {
 function CompareControls({
   dataset,
   datasetId,
-  umaps,
-  embeddings,
-  left,
-  right,
-  onSetLeft,
-  onSetRight,
   threshold,
   onThresholdChange,
   aboveThresholdCount,
@@ -37,45 +30,11 @@ function CompareControls({
   onColorByChange,
   numericColumns = [],
 }) {
-  const formatUmapOption = useCallback(
-    (um) => {
-      const emb = embeddings.find((d) => um.embedding_id === d.id);
-      const model = emb?.model_id || um.embedding_id;
-      const dims = emb?.dimensions ? `[${emb.dimensions}]` : '';
-      const sae = um.sae_id ? ` (SAE)` : '';
-      const aligned = um.align_id ? ` (aligned)` : '';
-      return `${um.id} - ${model} ${dims}${sae}${aligned}`;
-    },
-    [embeddings]
-  );
-
   return (
     <div className={styles['controls']}>
       <div className={styles['controls-header']}>
         <b>{datasetId}</b>
         <span>{dataset?.length} rows</span>
-      </div>
-      <div className={styles['umap-selectors']}>
-        <div className={styles['umap-selector']}>
-          <label>Left UMAP</label>
-          <select value={left?.id || ''} onChange={(e) => onSetLeft(e.target.value)}>
-            {umaps.map((um) => (
-              <option key={um.id} value={um.id}>
-                {formatUmapOption(um)}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className={styles['umap-selector']}>
-          <label>Right UMAP</label>
-          <select value={right?.id || ''} onChange={(e) => onSetRight(e.target.value)}>
-            {umaps.map((um) => (
-              <option key={um.id} value={um.id}>
-                {formatUmapOption(um)}
-              </option>
-            ))}
-          </select>
-        </div>
       </div>
       <div className={styles['metric-controls']}>
         <div className={styles['metric-selector']}>

--- a/web/src/components/Compare/CompareControls.jsx
+++ b/web/src/components/Compare/CompareControls.jsx
@@ -85,9 +85,6 @@ function CompareControls({
               <option key={key} value={key}>{info.label}</option>
             ))}
           </select>
-          <span className={styles['metric-description']}>
-            {METRIC_INFO[metric]?.description}
-          </span>
         </div>
         <div className={styles['metric-selector']}>
           <label>Color by</label>
@@ -101,11 +98,6 @@ function CompareControls({
               </optgroup>
             )}
           </select>
-          <span className={styles['metric-description']}>
-            {colorBy === '__drift__'
-              ? 'Points are colored by the selected drift metric.'
-              : `Points are colored by the "${colorBy}" column value.`}
-          </span>
         </div>
         {metric !== 'displacement' && (
           <div className={styles['metric-k']}>
@@ -139,6 +131,11 @@ function CompareControls({
             </span>
           </div>
         )}
+      </div>
+      <div className={styles['metric-help']}>
+        {colorBy === '__drift__'
+          ? METRIC_INFO[metric]?.description
+          : `Points are colored by the "${colorBy}" column value.`}
       </div>
     </div>
   );

--- a/web/src/components/Compare/CompareDataPanel.jsx
+++ b/web/src/components/Compare/CompareDataPanel.jsx
@@ -17,6 +17,8 @@ function CompareDataPanel({
   dataset,
   datasetId,
   embeddings,
+  left,
+  right,
   selectedIndices,
   neighborSelectedIndex,
   neighborIndices,
@@ -111,6 +113,14 @@ function CompareDataPanel({
                   </button>
                 )}
               </span>
+              {selectedIndices?.length >= 3 && left && right && (
+                <SpreadSummary
+                  datasetId={datasetId}
+                  left={left}
+                  right={right}
+                  selectedIndices={selectedIndices}
+                />
+              )}
               {selectedIndices?.length > 0 && (
                 <IndexDataTable
                   indices={selectedIndices}
@@ -216,6 +226,97 @@ function NeighborRow({ index, rank, dataset, datasetId, onHover, onClick, isSele
       <span className={styles['neighbor-text']}>
         {text ? (text.length > 150 ? text.slice(0, 150) + '...' : text) : '...'}
       </span>
+    </div>
+  );
+}
+
+/**
+ * Compares how coherent the current selection is in each projection: mean
+ * pairwise distance and convex-hull area per side, with the right/left ratio so
+ * you can read "this region is 2.3x more spread out in the right map".
+ */
+function SpreadSummary({ datasetId, left, right, selectedIndices }) {
+  const [stats, setStats] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!selectedIndices?.length || !left || !right) {
+      setStats(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    // Debounce so dragging a lasso doesn't fire a request per intermediate set.
+    const t = setTimeout(() => {
+      fetch(`${apiUrl}/search/compare/spread`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          dataset: datasetId,
+          umap_left: left.id,
+          umap_right: right.id,
+          indices: selectedIndices,
+        }),
+      })
+        .then((r) => r.json())
+        .then((data) => {
+          if (!cancelled) {
+            setStats(data);
+            setLoading(false);
+          }
+        })
+        .catch(() => !cancelled && setLoading(false));
+    }, 250);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [datasetId, left, right, selectedIndices]);
+
+  if (!stats?.left || !stats?.right) {
+    return loading ? <div className={styles['spread-summary']}>Computing spread…</div> : null;
+  }
+
+  const fmt = (v) => (v == null ? '—' : v.toFixed(3));
+  const ratio = (r, l) => (l && l > 0 && r != null ? `${(r / l).toFixed(2)}×` : '—');
+
+  const rows = [
+    {
+      label: 'Mean pairwise dist',
+      l: stats.left.mean_pairwise,
+      r: stats.right.mean_pairwise,
+    },
+    { label: 'Convex hull area', l: stats.left.hull_area, r: stats.right.hull_area },
+  ];
+
+  return (
+    <div className={styles['spread-summary']}>
+      <div className={styles['spread-title']}>
+        Selection spread ({stats.n_selected} points)
+        {(stats.left.sampled || stats.right.sampled) && (
+          <span className={styles['spread-note']}> (sampled)</span>
+        )}
+      </div>
+      <table className={styles['spread-table']}>
+        <thead>
+          <tr>
+            <th></th>
+            <th>Left</th>
+            <th>Right</th>
+            <th>R / L</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.label}>
+              <td>{row.label}</td>
+              <td>{fmt(row.l)}</td>
+              <td>{fmt(row.r)}</td>
+              <td>{ratio(row.r, row.l)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/web/src/components/Compare/CompareDataPanel.jsx
+++ b/web/src/components/Compare/CompareDataPanel.jsx
@@ -1,8 +1,11 @@
 import { useState, useEffect, useCallback } from 'react';
 import { scaleOrdinal } from 'd3-scale';
 import { schemeTableau10 } from 'd3-scale-chromatic';
+import { Tooltip } from 'react-tooltip';
 import IndexDataTable from '../IndexDataTable';
 import styles from './Compare.module.css';
+
+const ROW_TOOLTIP_ID = 'compare-row-tooltip';
 
 const apiUrl = import.meta.env.VITE_API_URL;
 
@@ -29,6 +32,7 @@ function CompareDataPanel({
   onSearch,
   searchModel,
   onSearchModelChange,
+  searchLoading,
   onHover,
   onClick,
 }) {
@@ -128,6 +132,7 @@ function CompareDataPanel({
                   maxRows={150}
                   onHover={onHover}
                   onClick={onClick}
+                  rowTooltipId={ROW_TOOLTIP_ID}
                 />
               )}
             </>
@@ -155,10 +160,15 @@ function CompareDataPanel({
             </form>
           </div>
           <span>
-            {searchIndices.length > 0 && (
+            {searchLoading && (
+              <span className={styles['search-loading']}>
+                <span className={styles['spinner']} /> Searching…
+              </span>
+            )}
+            {!searchLoading && searchIndices.length > 0 && (
               <span>Nearest Neighbors: {searchIndices.length} (capped at 150) </span>
             )}
-            {searchIndices.length > 0 && (
+            {!searchLoading && searchIndices.length > 0 && (
               <button
                 className={styles['deselect']}
                 onClick={() => {
@@ -178,10 +188,20 @@ function CompareDataPanel({
               dataset={dataset}
               onHover={onHover}
               onClick={onClick}
+              rowTooltipId={ROW_TOOLTIP_ID}
             />
           )}
         </div>
       )}
+
+      <Tooltip
+        id={ROW_TOOLTIP_ID}
+        className={styles['row-tooltip']}
+        float
+        offset={12}
+        place="left"
+        noArrow
+      />
     </div>
   );
 }

--- a/web/src/components/Compare/SelectionOverlay.jsx
+++ b/web/src/components/Compare/SelectionOverlay.jsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from 'react';
+import { scaleLinear } from 'd3-scale';
+import '../AnnotationPlot.css';
+
+// Match Explore's selection green (mapSelectionColorsLight[selected] in lib/colors.js).
+const SELECTION_COLOR = '#5cb85c';
+// Cap how many points we stroke per frame so a huge brush can't stall panning;
+// the selection table/spread stat still reflect the full set.
+const MAX_DRAWN = 20000;
+
+/**
+ * Canvas overlay that paints a set of selected points green on top of a Compare
+ * scatter pane, in the same visual language as Explore's selection. Driven by
+ * shared `selectedIndices`, so brushing in one pane lights up the same rows in
+ * both panes.
+ */
+function SelectionOverlay({ points, selectedIndices, xDomain, yDomain, width, height }) {
+  const canvasRef = useRef();
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, width, height);
+
+    if (!selectedIndices?.length || !points?.length || !xDomain || !yDomain) return;
+
+    const xScale = scaleLinear().domain(xDomain).range([0, width]);
+    const yScale = scaleLinear().domain(yDomain).range([height, 0]);
+
+    ctx.fillStyle = SELECTION_COLOR;
+    ctx.strokeStyle = '#2d6a2d';
+    ctx.lineWidth = 0.75;
+    ctx.globalAlpha = 0.9;
+
+    const count = Math.min(selectedIndices.length, MAX_DRAWN);
+    for (let i = 0; i < count; i++) {
+      const p = points[selectedIndices[i]];
+      if (!p) continue;
+      const px = xScale(p[0]);
+      const py = yScale(p[1]);
+      if (px < -4 || px > width + 4 || py < -4 || py > height + 4) continue;
+      ctx.beginPath();
+      ctx.arc(px, py, 3, 0, 2 * Math.PI);
+      ctx.fill();
+      ctx.stroke();
+    }
+  }, [points, selectedIndices, xDomain, yDomain, width, height]);
+
+  return <canvas ref={canvasRef} className="annotation-plot" width={width} height={height} />;
+}
+
+export default SelectionOverlay;

--- a/web/src/components/Compare/SelectionOverlay.jsx
+++ b/web/src/components/Compare/SelectionOverlay.jsx
@@ -9,12 +9,21 @@ const SELECTION_COLOR = '#5cb85c';
 const MAX_DRAWN = 20000;
 
 /**
- * Canvas overlay that paints a set of selected points green on top of a Compare
- * scatter pane, in the same visual language as Explore's selection. Driven by
- * shared `selectedIndices`, so brushing in one pane lights up the same rows in
- * both panes.
+ * Canvas overlay that paints a set of highlighted points on top of a Compare
+ * scatter pane, in the same visual language as Explore's selection. Used both
+ * for the shared brush selection (green) and for similarity-search hits (blue),
+ * so highlighting in one context lights up the same rows in both panes.
  */
-function SelectionOverlay({ points, selectedIndices, xDomain, yDomain, width, height }) {
+function SelectionOverlay({
+  points,
+  selectedIndices,
+  xDomain,
+  yDomain,
+  width,
+  height,
+  color = SELECTION_COLOR,
+  stroke = '#2d6a2d',
+}) {
   const canvasRef = useRef();
 
   useEffect(() => {
@@ -28,8 +37,8 @@ function SelectionOverlay({ points, selectedIndices, xDomain, yDomain, width, he
     const xScale = scaleLinear().domain(xDomain).range([0, width]);
     const yScale = scaleLinear().domain(yDomain).range([height, 0]);
 
-    ctx.fillStyle = SELECTION_COLOR;
-    ctx.strokeStyle = '#2d6a2d';
+    ctx.fillStyle = color;
+    ctx.strokeStyle = stroke;
     ctx.lineWidth = 0.75;
     ctx.globalAlpha = 0.9;
 
@@ -45,7 +54,7 @@ function SelectionOverlay({ points, selectedIndices, xDomain, yDomain, width, he
       ctx.fill();
       ctx.stroke();
     }
-  }, [points, selectedIndices, xDomain, yDomain, width, height]);
+  }, [points, selectedIndices, xDomain, yDomain, width, height, color, stroke]);
 
   return <canvas ref={canvasRef} className="annotation-plot" width={width} height={height} />;
 }

--- a/web/src/components/Compare/SideBySideView.jsx
+++ b/web/src/components/Compare/SideBySideView.jsx
@@ -7,6 +7,7 @@ import CrosshairPlot from './CrosshairPlot';
 import NeighborPlot from './NeighborPlot';
 import SelectionOverlay from './SelectionOverlay';
 import ColorLegend from './ColorLegend';
+import UmapSelect from './UmapSelect';
 import styles from './Compare.module.css';
 
 const isIOS = () => /iPhone|iPad|iPod/i.test(navigator.userAgent);
@@ -16,8 +17,12 @@ const apiUrl = import.meta.env.VITE_API_URL;
 function SideBySideView({
   datasetId,
   dataset,
+  umaps,
+  embeddings,
   left,
   right,
+  onSetLeft,
+  onSetRight,
   leftPoints,
   rightPoints,
   drawPoints,
@@ -218,7 +223,10 @@ function SideBySideView({
       ? displacementData[hoveredIndex].toFixed(3)
       : null;
 
-  const halfWidth = Math.floor((width - 12) / 2);
+  // Maps are stacked vertically: each is full column width, and shares the
+  // available height (minus the per-map dropdown rows + gaps).
+  const mapWidth = width;
+  const mapHeight = Math.max(120, Math.floor((height - 88) / 2));
 
   return (
     <div className={styles['side-by-side-view']}>
@@ -254,16 +262,21 @@ function SideBySideView({
             extent={colorExtent}
             label={colorLabel}
           />
-          <span className={styles['side-label']}>← Left</span>
-          <span className={styles['side-label']}>Right →</span>
         </div>
       </div>
       <div className={styles['side-by-side-container']}>
-        {/* Left scatter */}
+        {/* Left scatter (top) */}
         <div className={styles['scatter-panel']}>
+          <UmapSelect
+            label="Left"
+            value={left?.id}
+            umaps={umaps}
+            embeddings={embeddings}
+            onChange={onSetLeft}
+          />
           <div
             className={styles['scatter-container']}
-            style={{ width: halfWidth, height }}
+            style={{ width: mapWidth, height: mapHeight }}
             data-tooltip-id="compare-hover-tooltip"
           >
             {leftDisplayPoints.length > 0 && (
@@ -276,8 +289,8 @@ function SideBySideView({
                       pointScale={1}
                       pointSizeRange={pointSizeRange}
                       opacityRange={clickedIndex != null ? [0.15, 0.15] : opacityRange}
-                      width={halfWidth}
-                      height={height}
+                      width={mapWidth}
+                      height={mapHeight}
                       colorScaleType="continuous"
                       colorInterpolator={colorInterpolator || interpolateReds}
                       opacityBy="valueA"
@@ -294,8 +307,8 @@ function SideBySideView({
                       size="8"
                       xDomain={leftXDomain}
                       yDomain={leftYDomain}
-                      width={halfWidth}
-                      height={height}
+                      width={mapWidth}
+                      height={mapHeight}
                     />
                   )}
                 </div>
@@ -305,8 +318,8 @@ function SideBySideView({
                     selectedIndices={searchIndices}
                     xDomain={leftXDomain}
                     yDomain={leftYDomain}
-                    width={halfWidth}
-                    height={height}
+                    width={mapWidth}
+                    height={mapHeight}
                     color="#4488ff"
                     stroke="#22508a"
                   />
@@ -317,8 +330,8 @@ function SideBySideView({
                     selectedIndices={selectedIndices}
                     xDomain={leftXDomain}
                     yDomain={leftYDomain}
-                    width={halfWidth}
-                    height={height}
+                    width={mapWidth}
+                    height={mapHeight}
                   />
                 )}
                 {clickedIndex != null ? (
@@ -328,16 +341,16 @@ function SideBySideView({
                     neighborIndices={neighborIndices}
                     xDomain={leftXDomain}
                     yDomain={leftYDomain}
-                    width={halfWidth}
-                    height={height}
+                    width={mapWidth}
+                    height={mapHeight}
                   />
                 ) : (
                   <CrosshairPlot
                     point={leftHoverPoint}
                     xDomain={leftXDomain}
                     yDomain={leftYDomain}
-                    width={halfWidth}
-                    height={height}
+                    width={mapWidth}
+                    height={mapHeight}
                   />
                 )}
               </>
@@ -345,11 +358,18 @@ function SideBySideView({
           </div>
         </div>
 
-        {/* Right scatter */}
+        {/* Right scatter (bottom) */}
         <div className={styles['scatter-panel']}>
+          <UmapSelect
+            label="Right"
+            value={right?.id}
+            umaps={umaps}
+            embeddings={embeddings}
+            onChange={onSetRight}
+          />
           <div
             className={styles['scatter-container']}
-            style={{ width: halfWidth, height }}
+            style={{ width: mapWidth, height: mapHeight }}
             data-tooltip-id="compare-hover-tooltip"
           >
             {rightDisplayPoints.length > 0 && (
@@ -362,8 +382,8 @@ function SideBySideView({
                       pointScale={1}
                       pointSizeRange={pointSizeRange}
                       opacityRange={clickedIndex != null ? [0.15, 0.15] : opacityRange}
-                      width={halfWidth}
-                      height={height}
+                      width={mapWidth}
+                      height={mapHeight}
                       colorScaleType="continuous"
                       colorInterpolator={colorInterpolator || interpolateReds}
                       opacityBy="valueA"
@@ -380,8 +400,8 @@ function SideBySideView({
                       size="8"
                       xDomain={rightXDomain}
                       yDomain={rightYDomain}
-                      width={halfWidth}
-                      height={height}
+                      width={mapWidth}
+                      height={mapHeight}
                     />
                   )}
                 </div>
@@ -391,8 +411,8 @@ function SideBySideView({
                     selectedIndices={searchIndices}
                     xDomain={rightXDomain}
                     yDomain={rightYDomain}
-                    width={halfWidth}
-                    height={height}
+                    width={mapWidth}
+                    height={mapHeight}
                     color="#4488ff"
                     stroke="#22508a"
                   />
@@ -403,8 +423,8 @@ function SideBySideView({
                     selectedIndices={selectedIndices}
                     xDomain={rightXDomain}
                     yDomain={rightYDomain}
-                    width={halfWidth}
-                    height={height}
+                    width={mapWidth}
+                    height={mapHeight}
                   />
                 )}
                 {clickedIndex != null ? (
@@ -414,16 +434,16 @@ function SideBySideView({
                     neighborIndices={neighborIndices}
                     xDomain={rightXDomain}
                     yDomain={rightYDomain}
-                    width={halfWidth}
-                    height={height}
+                    width={mapWidth}
+                    height={mapHeight}
                   />
                 ) : (
                   <CrosshairPlot
                     point={rightHoverPoint}
                     xDomain={rightXDomain}
                     yDomain={rightYDomain}
-                    width={halfWidth}
-                    height={height}
+                    width={mapWidth}
+                    height={mapHeight}
                   />
                 )}
               </>

--- a/web/src/components/Compare/SideBySideView.jsx
+++ b/web/src/components/Compare/SideBySideView.jsx
@@ -29,6 +29,7 @@ function SideBySideView({
   onNeighborSelect,
   onRegionSelect,
   selectedIndices,
+  searchIndices,
   pointSizeRange,
   opacityRange,
   hoveredIndex,
@@ -39,14 +40,11 @@ function SideBySideView({
 }) {
   const leftScatterRef = useRef(null);
   const rightScatterRef = useRef(null);
-  const [linkZoom, setLinkZoom] = useState(true);
 
   const [leftXDomain, setLeftXDomain] = useState([-1, 1]);
   const [leftYDomain, setLeftYDomain] = useState([-1, 1]);
   const [rightXDomain, setRightXDomain] = useState([-1, 1]);
   const [rightYDomain, setRightYDomain] = useState([-1, 1]);
-
-  const zoomSourceRef = useRef(null);
 
   // Click/neighbor state
   const [clickedIndex, setClickedIndex] = useState(null);
@@ -94,53 +92,18 @@ function SideBySideView({
     rightScatterRef.current = s;
   }, []);
 
-  const handleLeftView = useCallback(
-    (xd, yd) => {
-      setLeftXDomain(xd);
-      setLeftYDomain(yd);
-      if (linkZoom && zoomSourceRef.current !== 'right') {
-        zoomSourceRef.current = 'left';
-        setRightXDomain(xd);
-        setRightYDomain(yd);
-        try {
-          rightScatterRef.current?.zoomToArea({
-            x: xd[0],
-            y: yd[0],
-            width: xd[1] - xd[0],
-            height: yd[1] - yd[0],
-          })?.catch?.(() => {});
-        } catch (e) { /* scatter not ready yet */ }
-        setTimeout(() => {
-          zoomSourceRef.current = null;
-        }, 50);
-      }
-    },
-    [linkZoom]
-  );
+  // Each pane zooms independently — the same viewport coordinates mean different
+  // things in two different projections, so linking them isn't meaningful. We
+  // only track each pane's domain to keep its overlays aligned.
+  const handleLeftView = useCallback((xd, yd) => {
+    setLeftXDomain(xd);
+    setLeftYDomain(yd);
+  }, []);
 
-  const handleRightView = useCallback(
-    (xd, yd) => {
-      setRightXDomain(xd);
-      setRightYDomain(yd);
-      if (linkZoom && zoomSourceRef.current !== 'left') {
-        zoomSourceRef.current = 'right';
-        setLeftXDomain(xd);
-        setLeftYDomain(yd);
-        try {
-          leftScatterRef.current?.zoomToArea({
-            x: xd[0],
-            y: yd[0],
-            width: xd[1] - xd[0],
-            height: yd[1] - yd[0],
-          })?.catch?.(() => {});
-        } catch (e) { /* scatter not ready yet */ }
-        setTimeout(() => {
-          zoomSourceRef.current = null;
-        }, 50);
-      }
-    },
-    [linkZoom]
-  );
+  const handleRightView = useCallback((xd, yd) => {
+    setRightXDomain(xd);
+    setRightYDomain(yd);
+  }, []);
 
   // Fetch hover text for tooltip
   useEffect(() => {
@@ -260,14 +223,6 @@ function SideBySideView({
   return (
     <div className={styles['side-by-side-view']}>
       <div className={styles['view-toolbar']}>
-        <label className={styles['link-zoom-toggle']}>
-          <input
-            type="checkbox"
-            checked={linkZoom}
-            onChange={(e) => setLinkZoom(e.target.checked)}
-          />
-          Link zoom
-        </label>
         {clickedIndex != null && (
           <span className={styles['neighbor-info']}>
             Showing k={metricK} neighbors from {clickedSide} map (point {clickedIndex})
@@ -344,6 +299,18 @@ function SideBySideView({
                     />
                   )}
                 </div>
+                {clickedIndex == null && searchIndices?.length > 0 && (
+                  <SelectionOverlay
+                    points={leftPoints}
+                    selectedIndices={searchIndices}
+                    xDomain={leftXDomain}
+                    yDomain={leftYDomain}
+                    width={halfWidth}
+                    height={height}
+                    color="#4488ff"
+                    stroke="#22508a"
+                  />
+                )}
                 {clickedIndex == null && selectedIndices?.length > 0 && (
                   <SelectionOverlay
                     points={leftPoints}
@@ -418,6 +385,18 @@ function SideBySideView({
                     />
                   )}
                 </div>
+                {clickedIndex == null && searchIndices?.length > 0 && (
+                  <SelectionOverlay
+                    points={rightPoints}
+                    selectedIndices={searchIndices}
+                    xDomain={rightXDomain}
+                    yDomain={rightYDomain}
+                    width={halfWidth}
+                    height={height}
+                    color="#4488ff"
+                    stroke="#22508a"
+                  />
+                )}
                 {clickedIndex == null && selectedIndices?.length > 0 && (
                   <SelectionOverlay
                     points={rightPoints}

--- a/web/src/components/Compare/SideBySideView.jsx
+++ b/web/src/components/Compare/SideBySideView.jsx
@@ -5,6 +5,8 @@ import Scatter from '../Scatter';
 import AnnotationPlot from '../AnnotationPlot';
 import CrosshairPlot from './CrosshairPlot';
 import NeighborPlot from './NeighborPlot';
+import SelectionOverlay from './SelectionOverlay';
+import ColorLegend from './ColorLegend';
 import styles from './Compare.module.css';
 
 const isIOS = () => /iPhone|iPad|iPod/i.test(navigator.userAgent);
@@ -25,10 +27,15 @@ function SideBySideView({
   onScatter,
   onHover,
   onNeighborSelect,
+  onRegionSelect,
+  selectedIndices,
   pointSizeRange,
   opacityRange,
   hoveredIndex,
   metricK,
+  colorInterpolator,
+  colorExtent,
+  colorLabel,
 }) {
   const leftScatterRef = useRef(null);
   const rightScatterRef = useRef(null);
@@ -169,6 +176,21 @@ function SideBySideView({
     onNeighborSelect && onNeighborSelect(null, []);
   }, [onNeighborSelect]);
 
+  // A lasso (shift+drag) in either pane. Region brushing supersedes the
+  // single-point neighbor mode, and the same row set lights up in both panes.
+  const handleRegionSelect = useCallback(
+    (indices) => {
+      if (indices?.length) {
+        setClickedIndex(null);
+        setClickedSide(null);
+        setNeighborIndices([]);
+        onNeighborSelect && onNeighborSelect(null, []);
+      }
+      onRegionSelect && onRegionSelect(indices || []);
+    },
+    [onRegionSelect, onNeighborSelect]
+  );
+
   // Handle click on a scatter — toggle neighbor mode
   const handleLeftClick = useCallback(
     (indices) => {
@@ -257,8 +279,29 @@ function SideBySideView({
             </button>
           </span>
         )}
-        <span className={styles['side-label']}>← Left</span>
-        <span className={styles['side-label']}>Right →</span>
+        {clickedIndex == null && selectedIndices?.length > 0 && (
+          <span className={styles['neighbor-info']}>
+            {selectedIndices.length} points selected
+            <button
+              className={styles['clear-neighbors']}
+              onClick={() => handleRegionSelect([])}
+            >
+              Clear
+            </button>
+          </span>
+        )}
+        {clickedIndex == null && !selectedIndices?.length && (
+          <span className={styles['selection-hint']}>⇧ + drag to select a region</span>
+        )}
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 16 }}>
+          <ColorLegend
+            interpolator={colorInterpolator || interpolateReds}
+            extent={colorExtent}
+            label={colorLabel}
+          />
+          <span className={styles['side-label']}>← Left</span>
+          <span className={styles['side-label']}>Right →</span>
+        </div>
       </div>
       <div className={styles['side-by-side-container']}>
         {/* Left scatter */}
@@ -281,11 +324,12 @@ function SideBySideView({
                       width={halfWidth}
                       height={height}
                       colorScaleType="continuous"
-                      colorInterpolator={interpolateReds}
+                      colorInterpolator={colorInterpolator || interpolateReds}
                       opacityBy="valueA"
                       onScatter={handleLeftScatter}
                       onView={handleLeftView}
                       onSelect={handleLeftClick}
+                      onLassoSelect={handleRegionSelect}
                       onHover={onHover}
                     />
                   ) : (
@@ -300,6 +344,16 @@ function SideBySideView({
                     />
                   )}
                 </div>
+                {clickedIndex == null && selectedIndices?.length > 0 && (
+                  <SelectionOverlay
+                    points={leftPoints}
+                    selectedIndices={selectedIndices}
+                    xDomain={leftXDomain}
+                    yDomain={leftYDomain}
+                    width={halfWidth}
+                    height={height}
+                  />
+                )}
                 {clickedIndex != null ? (
                   <NeighborPlot
                     points={leftPoints}
@@ -344,11 +398,12 @@ function SideBySideView({
                       width={halfWidth}
                       height={height}
                       colorScaleType="continuous"
-                      colorInterpolator={interpolateReds}
+                      colorInterpolator={colorInterpolator || interpolateReds}
                       opacityBy="valueA"
                       onScatter={handleRightScatter}
                       onView={handleRightView}
                       onSelect={handleRightClick}
+                      onLassoSelect={handleRegionSelect}
                       onHover={onHover}
                     />
                   ) : (
@@ -363,6 +418,16 @@ function SideBySideView({
                     />
                   )}
                 </div>
+                {clickedIndex == null && selectedIndices?.length > 0 && (
+                  <SelectionOverlay
+                    points={rightPoints}
+                    selectedIndices={selectedIndices}
+                    xDomain={rightXDomain}
+                    yDomain={rightYDomain}
+                    width={halfWidth}
+                    height={height}
+                  />
+                )}
                 {clickedIndex != null ? (
                   <NeighborPlot
                     points={rightPoints}

--- a/web/src/components/Compare/TransitionView.jsx
+++ b/web/src/components/Compare/TransitionView.jsx
@@ -2,12 +2,19 @@ import { useState, useEffect, useCallback } from 'react';
 import { interpolateReds } from 'd3-scale-chromatic';
 import Scatter from '../Scatter';
 import AnnotationPlot from '../AnnotationPlot';
+import UmapSelect from './UmapSelect';
 import styles from './Compare.module.css';
 
 // unfortunately regl-scatter doesn't even render in iOS
 const isIOS = () => /iPhone|iPad|iPod/i.test(navigator.userAgent);
 
 function TransitionView({
+  umaps,
+  embeddings,
+  left,
+  right,
+  onSetLeft,
+  onSetRight,
   leftPoints,
   rightPoints,
   drawPoints,
@@ -46,6 +53,9 @@ function TransitionView({
     onDirectionChange(direction === 'left' ? 'right' : 'left');
   }, [direction, onDirectionChange]);
 
+  // Leave room for the toolbar (swap button + dropdowns) above the map.
+  const mapHeight = Math.max(120, height - 44);
+
   return (
     <div className={styles['transition-view']}>
       <div className={styles['view-toolbar']}>
@@ -53,8 +63,24 @@ function TransitionView({
           {direction === 'left' ? '← Showing Left' : 'Showing Right →'}
           {' · Click to swap'}
         </button>
+        <UmapSelect
+          label="Left"
+          value={left?.id}
+          umaps={umaps}
+          embeddings={embeddings}
+          onChange={onSetLeft}
+          accent={direction === 'left' ? '#222' : '#aaa'}
+        />
+        <UmapSelect
+          label="Right"
+          value={right?.id}
+          umaps={umaps}
+          embeddings={embeddings}
+          onChange={onSetRight}
+          accent={direction === 'right' ? '#222' : '#aaa'}
+        />
       </div>
-      <div className={styles['scatter-container']} style={{ width, height }}>
+      <div className={styles['scatter-container']} style={{ width, height: mapHeight }}>
         {displayPoints.length > 0 && (
           <>
             <div className={styles['scatter']}>
@@ -66,7 +92,7 @@ function TransitionView({
                   pointSizeRange={pointSizeRange}
                   opacityRange={opacityRange}
                   width={width}
-                  height={height}
+                  height={mapHeight}
                   colorScaleType="continuous"
                   colorInterpolator={interpolateReds}
                   opacityBy="valueA"
@@ -83,7 +109,7 @@ function TransitionView({
                   xDomain={xDomain}
                   yDomain={yDomain}
                   width={width}
-                  height={height}
+                  height={mapHeight}
                 />
               )}
             </div>
@@ -95,7 +121,7 @@ function TransitionView({
               xDomain={xDomain}
               yDomain={yDomain}
               width={width}
-              height={height}
+              height={mapHeight}
             />
             <AnnotationPlot
               points={hoverAnnotations}
@@ -105,7 +131,7 @@ function TransitionView({
               xDomain={xDomain}
               yDomain={yDomain}
               width={width}
-              height={height}
+              height={mapHeight}
             />
           </>
         )}

--- a/web/src/components/Compare/UmapSelect.jsx
+++ b/web/src/components/Compare/UmapSelect.jsx
@@ -1,0 +1,34 @@
+import styles from './Compare.module.css';
+
+function formatUmapOption(um, embeddings) {
+  const emb = embeddings?.find((d) => um.embedding_id === d.id);
+  const model = emb?.model_id || um.embedding_id;
+  const dims = emb?.dimensions ? `[${emb.dimensions}]` : '';
+  const sae = um.sae_id ? ' (SAE)' : '';
+  const aligned = um.align_id ? ' (aligned)' : '';
+  return `${um.id} - ${model} ${dims}${sae}${aligned}`;
+}
+
+/**
+ * A compact labeled UMAP picker, rendered right above the map it controls.
+ */
+function UmapSelect({ label, value, umaps = [], embeddings = [], onChange, accent }) {
+  return (
+    <div className={styles['umap-inline-select']}>
+      {label && (
+        <span className={styles['umap-inline-label']} style={accent ? { color: accent } : undefined}>
+          {label}
+        </span>
+      )}
+      <select value={value || ''} onChange={(e) => onChange(e.target.value)}>
+        {umaps.map((um) => (
+          <option key={um.id} value={um.id}>
+            {formatUmapOption(um, embeddings)}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export default UmapSelect;

--- a/web/src/components/DataTable.jsx
+++ b/web/src/components/DataTable.jsx
@@ -12,8 +12,29 @@ DataTable.propTypes = {
   onTagset: PropTypes.func,
   onHover: PropTypes.func,
   onClick: PropTypes.func,
+  rowTooltipId: PropTypes.string,
 };
-function DataTable({ data, tagset, dataset, maxRows, onTagset, onHover, onClick }) {
+
+const escapeHtml = (s) =>
+  String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+// Build a readable "column: value" HTML block for a row's hover tooltip.
+function rowTooltipHtml(row, headers) {
+  return headers
+    .filter((h) => h !== 'index')
+    .map((h) => {
+      let v = row[h];
+      if (v == null) v = '';
+      if (typeof v === 'object') v = JSON.stringify(v);
+      return `<div><b>${escapeHtml(h)}:</b> ${escapeHtml(v)}</div>`;
+    })
+    .join('');
+}
+
+function DataTable({ data, tagset, dataset, maxRows, onTagset, onHover, onClick, rowTooltipId }) {
   if (!data.length) {
     return <p>No data available.</p>;
   }
@@ -63,11 +84,13 @@ function DataTable({ data, tagset, dataset, maxRows, onTagset, onHover, onClick 
       </thead>
       <tbody>
         {rows.map((row, index) => (
-          <tr 
-            key={index} 
-            onMouseEnter={() => onHover && onHover(row.index)} 
+          <tr
+            key={index}
+            onMouseEnter={() => onHover && onHover(row.index)}
             onMouseLeave={() => onHover && onHover()}
             onClick={() => onClick && onClick(row.index)}
+            data-tooltip-id={rowTooltipId || undefined}
+            data-tooltip-html={rowTooltipId ? rowTooltipHtml(row, headers) : undefined}
             >
             {headers.map((header, idx) => {
               let d = row[header]

--- a/web/src/components/IndexDataTable.jsx
+++ b/web/src/components/IndexDataTable.jsx
@@ -17,16 +17,17 @@ IndexDataTable.propTypes = {
 };
 
 function IndexDataTable({
-  dataset, 
-  indices, 
-  distances = [], 
-  clusterIndices = [], 
-  clusterLabels = [], 
-  maxRows, 
-  tagset, 
-  onHover, 
-  onClick, 
-  onTagset
+  dataset,
+  indices,
+  distances = [],
+  clusterIndices = [],
+  clusterLabels = [],
+  maxRows,
+  tagset,
+  onHover,
+  onClick,
+  onTagset,
+  rowTooltipId
 }) {
 
   const [rows, setRows] = useState([]);
@@ -71,14 +72,15 @@ function IndexDataTable({
 
   return (
     <div>
-      <DataTable 
-        data={rows} 
-        tagset={tagset} 
-        dataset={dataset} 
-        maxRows={maxRows} 
-        onTagset={onTagset} 
-        onHover={onHover} 
+      <DataTable
+        data={rows}
+        tagset={tagset}
+        dataset={dataset}
+        maxRows={maxRows}
+        onTagset={onTagset}
+        onHover={onHover}
         onClick={onClick}
+        rowTooltipId={rowTooltipId}
         />
     </div>
   )

--- a/web/src/components/Scatter.jsx
+++ b/web/src/components/Scatter.jsx
@@ -23,6 +23,7 @@ ScatterPlot.propTypes = {
   onScatter: PropTypes.func,
   onView: PropTypes.func,
   onSelect: PropTypes.func,
+  onLassoSelect: PropTypes.func,
   onHover: PropTypes.func,
 };
 
@@ -62,6 +63,7 @@ function ScatterPlot({
   onScatter,
   onView,
   onSelect,
+  onLassoSelect,
   onHover,
   activeFilterTab,
 }) {
@@ -69,6 +71,10 @@ function ScatterPlot({
   const xDomain = useRef([-1, 1]);
   const yDomain = useRef([-1, 1]);
   const scatterplotRef = useRef(null);
+  // Set on `lassoEnd` (which fires just before the paired `select`) so the
+  // select handler can tell a shift-drag lasso apart from a single click —
+  // regl's `select` payload is identical for both.
+  const lassoActiveRef = useRef(false);
 
   // Store callbacks in refs so they never trigger effect re-runs.
   // Recreating the scatterplot destroys the WebGL context and causes
@@ -76,10 +82,12 @@ function ScatterPlot({
   const onScatterRef = useRef(onScatter);
   const onViewRef = useRef(onView);
   const onSelectRef = useRef(onSelect);
+  const onLassoSelectRef = useRef(onLassoSelect);
   const onHoverRef = useRef(onHover);
   onScatterRef.current = onScatter;
   onViewRef.current = onView;
   onSelectRef.current = onSelect;
+  onLassoSelectRef.current = onLassoSelect;
   onHoverRef.current = onHover;
 
   const handleMouseLeave = useCallback(() => {
@@ -116,11 +124,25 @@ function ScatterPlot({
       yDomain.current = ys.domain();
       onViewRef.current && onViewRef.current(xDomain.current, yDomain.current);
     });
+    scatterplot.subscribe('lassoEnd', () => {
+      lassoActiveRef.current = true;
+    });
     scatterplot.subscribe('select', ({ points }) => {
-      onSelectRef.current && onSelectRef.current(points);
+      if (lassoActiveRef.current) {
+        // A region brush. Route it to onLassoSelect and immediately drop regl's
+        // internal selection — under colorBy:'valueB' the library can't render a
+        // custom active color, so the highlight is drawn as an overlay instead.
+        lassoActiveRef.current = false;
+        onLassoSelectRef.current && onLassoSelectRef.current(points);
+        scatterplot.deselect({ preventEvent: true });
+      } else {
+        onSelectRef.current && onSelectRef.current(points);
+      }
     });
     scatterplot.subscribe('deselect', () => {
+      lassoActiveRef.current = false;
       onSelectRef.current && onSelectRef.current([]);
+      onLassoSelectRef.current && onLassoSelectRef.current([]);
     });
     scatterplot.subscribe('pointOver', (pointIndex) => {
       onHoverRef.current && onHoverRef.current(pointIndex);

--- a/web/src/pages/Compare.jsx
+++ b/web/src/pages/Compare.jsx
@@ -265,24 +265,39 @@ function Compare() {
   // Search
   const handleSearch = useCallback(
     (query) => {
-      if (!searchModel) return;
-      fetch(
-        `${apiUrl}/search/nn?${new URLSearchParams({
-          dataset: datasetId,
-          query,
-          embedding_id: searchModel.id,
-          dimensions: searchModel.dimensions,
-        })}`
-      )
+      if (!searchModel || !query) return;
+      const params = new URLSearchParams({
+        dataset: datasetId,
+        query,
+        embedding_id: searchModel.id,
+      });
+      // Only send dimensions when the embedding actually declares them —
+      // otherwise the string "undefined" reaches the server and int() 500s,
+      // making search appear completely broken (matches apiService's guard).
+      if (searchModel.dimensions != null) {
+        params.set('dimensions', searchModel.dimensions);
+      }
+      fetch(`${apiUrl}/search/nn?${params}`)
         .then((r) => r.json())
         .then((data) => {
-          setDistances(data.distances);
-          setSearchIndices(data.indices);
-          scatter?.zoomToPoints(data.indices, {
-            transition: true,
-            padding: 0.2,
-            transitionDuration: 1500,
-          });
+          const indices = data.indices || [];
+          setDistances(data.distances || []);
+          setSearchIndices(indices);
+          if (indices.length) {
+            try {
+              scatter?.zoomToPoints(indices, {
+                transition: true,
+                padding: 0.2,
+                transitionDuration: 1500,
+              });
+            } catch (e) {
+              /* scatter not ready — results still render in the panel */
+            }
+          }
+        })
+        .catch(() => {
+          setDistances([]);
+          setSearchIndices([]);
         });
     },
     [searchModel, datasetId, scatter]
@@ -437,6 +452,7 @@ function Compare() {
               onNeighborSelect={handleNeighborSelect}
               onRegionSelect={handleRegionSelect}
               selectedIndices={selectedIndices}
+              searchIndices={searchIndices}
               pointSizeRange={pointSizeRange}
               opacityRange={opacityRange}
               hoveredIndex={hoveredIndex}

--- a/web/src/pages/Compare.jsx
+++ b/web/src/pages/Compare.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { extent } from 'd3-array';
-import { scaleSymlog } from 'd3-scale';
+import { scaleSymlog, scaleLinear } from 'd3-scale';
+import { interpolateReds, interpolateViridis } from 'd3-scale-chromatic';
 
 import CompareControls from '../components/Compare/CompareControls';
 import TransitionView from '../components/Compare/TransitionView';
@@ -33,7 +34,6 @@ function Compare() {
 
   // Displacement data and display points
   const [drawPoints, setDrawPoints] = useState([]);
-  const drawPointsRef = useRef([]);
   const [displacementLoading, setDisplacementLoading] = useState(false);
   const [threshold, setThreshold] = useState(0.5);
   const [aboveThresholdCount, setAboveThresholdCount] = useState(0);
@@ -41,6 +41,10 @@ function Compare() {
   // Metric controls
   const [metric, setMetric] = useState('relative');
   const [metricK, setMetricK] = useState(10);
+
+  // Color-by: '__drift__' (the compare metric) or a numeric column name (#131)
+  const [colorBy, setColorBy] = useState('__drift__');
+  const [columnData, setColumnData] = useState(null); // { values, extent }
 
   // Raw displacement data (before threshold) for tooltip display
   const [rawDisplacementData, setRawDisplacementData] = useState([]);
@@ -137,6 +141,8 @@ function Compare() {
 
   const prevCompareKey = useRef('');
 
+  // Always compute the drift metric — it powers the tooltip readout and is the
+  // default color source. Color-by-column (#131) reuses the same [3] slot.
   useEffect(() => {
     if (!left || !right || !leftPoints.length || !rightPoints.length) return;
     const key = `${left.id}:${right.id}:${metric}:${metricK}`;
@@ -149,31 +155,58 @@ function Compare() {
       .then((r) => r.json())
       .then((displacementData) => {
         setRawDisplacementData(displacementData);
-        const log = scaleSymlog(extent(displacementData), [0, 1]);
-        const dpts = leftPoints.map((d, i) => {
-          const displacement = log(displacementData[i]);
-          return [d[0], d[1], displacement < threshold ? 1 : 0, displacement];
-        });
-        setDrawPoints(dpts);
-        drawPointsRef.current = dpts;
-        setAboveThresholdCount(dpts.filter((d) => d[2] !== 1).length);
         setDisplacementLoading(false);
         prevCompareKey.current = key;
       });
-  }, [datasetId, left, right, leftPoints, rightPoints, metric, metricK, threshold]);
+  }, [datasetId, left, right, leftPoints, rightPoints, metric, metricK]);
 
-  // Update threshold without re-fetching
+  // Fetch the selected numeric column's values when coloring by a column.
   useEffect(() => {
-    if (!drawPointsRef.current.length) return;
-    const newPoints = drawPointsRef.current.map((point) => [
-      point[0],
-      point[1],
-      point[3] < threshold ? 1 : 0,
-      point[3],
-    ]);
-    setDrawPoints(newPoints);
-    setAboveThresholdCount(newPoints.filter((d) => d[2] !== 1).length);
-  }, [threshold]);
+    if (colorBy === '__drift__') {
+      setColumnData(null);
+      return;
+    }
+    let cancelled = false;
+    fetch(`${apiUrl}/datasets/${datasetId}/column/${encodeURIComponent(colorBy)}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        setColumnData({ values: data.values, extent: data.extent });
+      })
+      .catch(() => !cancelled && setColumnData(null));
+    return () => {
+      cancelled = true;
+    };
+  }, [datasetId, colorBy]);
+
+  // Derive the drawn points ([x, y, dimFlag, normalizedColorValue]) from either
+  // the drift metric (symlog + threshold dimming) or the chosen column (linear
+  // normalize, no dimming). Slot [3] is what Scatter maps to color via valueB.
+  useEffect(() => {
+    if (!leftPoints.length) return;
+
+    if (colorBy === '__drift__') {
+      if (!rawDisplacementData.length) return;
+      const norm = scaleSymlog(extent(rawDisplacementData), [0, 1]);
+      const dpts = leftPoints.map((d, i) => {
+        const v = norm(rawDisplacementData[i]);
+        return [d[0], d[1], v < threshold ? 1 : 0, v];
+      });
+      setDrawPoints(dpts);
+      setAboveThresholdCount(dpts.filter((d) => d[2] !== 1).length);
+    } else {
+      if (!columnData?.values?.length) return;
+      const [lo, hi] = columnData.extent || extent(columnData.values.filter((v) => v != null));
+      const norm = scaleLinear().domain([lo, hi]).range([0, 1]).clamp(true);
+      const dpts = leftPoints.map((d, i) => {
+        const raw = columnData.values[i];
+        // Nulls (NaN/missing) fall to 0 on the ramp and stay fully visible.
+        return [d[0], d[1], 0, raw == null ? 0 : norm(raw)];
+      });
+      setDrawPoints(dpts);
+      setAboveThresholdCount(0);
+    }
+  }, [colorBy, rawDisplacementData, columnData, threshold, leftPoints]);
 
   // ===== Interaction Handlers =====
 
@@ -184,6 +217,16 @@ function Compare() {
 
   const handleSelected = useCallback((indices) => {
     setSelectedIndices(indices);
+  }, []);
+
+  // A lasso brush in either Compare pane. Region selection supersedes the
+  // single-point neighbor mode; both panes highlight the same rows.
+  const handleRegionSelect = useCallback((indices) => {
+    setSelectedIndices(indices || []);
+    if (indices?.length) {
+      setNeighborSelectedIndex(null);
+      setNeighborIndices([]);
+    }
   }, []);
 
   const handleHover = useCallback((index) => {
@@ -276,6 +319,13 @@ function Compare() {
   const pointSizeRange = [5, 1];
   const opacityRange = [1, 0.2];
 
+  // Color-by derived values (#131)
+  const colorInterpolator = colorBy === '__drift__' ? interpolateReds : interpolateViridis;
+  const colorExtent = colorBy === '__drift__' ? [0, 1] : columnData?.extent || [0, 1];
+  const numericColumns = Object.entries(dataset?.column_metadata || {})
+    .filter(([, m]) => m?.type === 'number')
+    .map(([name]) => name);
+
   // Resizable bottom panel
   const [panelHeight, setPanelHeight] = useState(200);
   const isDraggingRef = useRef(false);
@@ -326,6 +376,9 @@ function Compare() {
         metricK={metricK}
         onMetricKChange={setMetricK}
         displacementLoading={displacementLoading}
+        colorBy={colorBy}
+        onColorByChange={setColorBy}
+        numericColumns={numericColumns}
       />
 
       <div className={styles['visualization']}>
@@ -382,10 +435,15 @@ function Compare() {
               onSelect={handleSelected}
               onHover={handleHover}
               onNeighborSelect={handleNeighborSelect}
+              onRegionSelect={handleRegionSelect}
+              selectedIndices={selectedIndices}
               pointSizeRange={pointSizeRange}
               opacityRange={opacityRange}
               hoveredIndex={hoveredIndex}
               metricK={metricK}
+              colorInterpolator={colorInterpolator}
+              colorExtent={colorExtent}
+              colorLabel={colorBy === '__drift__' ? 'Drift' : colorBy}
             />
           )}
         </div>
@@ -399,6 +457,8 @@ function Compare() {
           dataset={dataset}
           datasetId={datasetId}
           embeddings={embeddings}
+          left={left}
+          right={right}
           selectedIndices={selectedIndices}
           neighborSelectedIndex={neighborSelectedIndex}
           neighborIndices={neighborIndices}

--- a/web/src/pages/Compare.jsx
+++ b/web/src/pages/Compare.jsx
@@ -70,21 +70,37 @@ function Compare() {
   const [searchModel, setSearchModel] = useState(null);
   const [searchIndices, setSearchIndices] = useState([]);
   const [distances, setDistances] = useState([]);
+  const [searchLoading, setSearchLoading] = useState(false);
 
   // Layout sizing
   const containerRef = useRef(null);
   const [containerSize, setContainerSize] = useState([500, 500]);
 
+  // Measure the maps column so the scatterplots get pixel dimensions. A plain
+  // rAF/timeout pass catches the settled layout on mount; a ResizeObserver then
+  // keeps them in sync when the window or the draggable table column changes.
   useEffect(() => {
     function updateSize() {
-      if (!containerRef.current) return;
-      const { height, width } = containerRef.current.getBoundingClientRect();
-      setContainerSize([width - 15, height - 25]);
+      const el = containerRef.current;
+      if (!el) return;
+      const { height, width } = el.getBoundingClientRect();
+      if (width > 0 && height > 0) setContainerSize([width - 15, height - 25]);
     }
-    window.addEventListener('resize', updateSize);
     updateSize();
-    setTimeout(updateSize, 200);
-    return () => window.removeEventListener('resize', updateSize);
+    const raf = requestAnimationFrame(updateSize);
+    const t = setTimeout(updateSize, 200);
+    window.addEventListener('resize', updateSize);
+    let ro;
+    if (containerRef.current && typeof ResizeObserver !== 'undefined') {
+      ro = new ResizeObserver(updateSize);
+      ro.observe(containerRef.current);
+    }
+    return () => {
+      cancelAnimationFrame(raf);
+      clearTimeout(t);
+      window.removeEventListener('resize', updateSize);
+      ro && ro.disconnect();
+    };
   }, []);
 
   const [scopeWidth, scopeHeight] = containerSize;
@@ -277,12 +293,14 @@ function Compare() {
       if (searchModel.dimensions != null) {
         params.set('dimensions', searchModel.dimensions);
       }
+      setSearchLoading(true);
       fetch(`${apiUrl}/search/nn?${params}`)
         .then((r) => r.json())
         .then((data) => {
           const indices = data.indices || [];
           setDistances(data.distances || []);
           setSearchIndices(indices);
+          setSearchLoading(false);
           if (indices.length) {
             try {
               scatter?.zoomToPoints(indices, {
@@ -298,6 +316,7 @@ function Compare() {
         .catch(() => {
           setDistances([]);
           setSearchIndices([]);
+          setSearchLoading(false);
         });
     },
     [searchModel, datasetId, scatter]
@@ -341,23 +360,24 @@ function Compare() {
     .filter(([, m]) => m?.type === 'number')
     .map(([name]) => name);
 
-  // Resizable bottom panel
-  const [panelHeight, setPanelHeight] = useState(200);
+  // Resizable right-hand table column (horizontal drag)
+  const [tableWidth, setTableWidth] = useState(440);
   const isDraggingRef = useRef(false);
-  const dragStartYRef = useRef(0);
-  const dragStartHeightRef = useRef(0);
+  const dragStartXRef = useRef(0);
+  const dragStartWidthRef = useRef(0);
 
   const handleDragStart = useCallback((e) => {
     e.preventDefault();
     isDraggingRef.current = true;
-    dragStartYRef.current = e.clientY;
-    dragStartHeightRef.current = panelHeight;
+    dragStartXRef.current = e.clientX;
+    dragStartWidthRef.current = tableWidth;
 
     const handleDragMove = (e) => {
       if (!isDraggingRef.current) return;
-      const delta = dragStartYRef.current - e.clientY;
-      const newHeight = Math.max(40, Math.min(600, dragStartHeightRef.current + delta));
-      setPanelHeight(newHeight);
+      // Dragging left widens the table column.
+      const delta = dragStartXRef.current - e.clientX;
+      const newWidth = Math.max(280, Math.min(900, dragStartWidthRef.current + delta));
+      setTableWidth(newWidth);
     };
 
     const handleDragEnd = () => {
@@ -368,21 +388,24 @@ function Compare() {
 
     document.addEventListener('mousemove', handleDragMove);
     document.addEventListener('mouseup', handleDragEnd);
-  }, [panelHeight]);
+  }, [tableWidth]);
 
   if (!dataset) return <div>Loading...</div>;
+
+  const umapSelectProps = {
+    umaps,
+    embeddings,
+    left,
+    right,
+    onSetLeft: handleSetLeft,
+    onSetRight: handleSetRight,
+  };
 
   return (
     <div className={styles['container']}>
       <CompareControls
         dataset={dataset}
         datasetId={datasetId}
-        umaps={umaps}
-        embeddings={embeddings}
-        left={left}
-        right={right}
-        onSetLeft={handleSetLeft}
-        onSetRight={handleSetRight}
         threshold={threshold}
         onThresholdChange={setThreshold}
         aboveThresholdCount={aboveThresholdCount}
@@ -396,98 +419,103 @@ function Compare() {
         numericColumns={numericColumns}
       />
 
-      <div className={styles['visualization']}>
-        <div className={styles['view-tabs']}>
-          {viewModes.map((mode) => (
-            <button
-              key={mode.id}
-              onClick={() => setViewMode(mode.id)}
-              className={
-                mode.id === viewMode ? styles['view-tab-active'] : styles['view-tab-inactive']
-              }
-            >
-              {mode.name}
-            </button>
-          ))}
+      {/* Two-column workspace: stacked maps on the left, data table on the right */}
+      <div className={styles['workspace']}>
+        <div className={styles['maps-column']}>
+          <div className={styles['view-tabs']}>
+            {viewModes.map((mode) => (
+              <button
+                key={mode.id}
+                onClick={() => setViewMode(mode.id)}
+                className={
+                  mode.id === viewMode ? styles['view-tab-active'] : styles['view-tab-inactive']
+                }
+              >
+                {mode.name}
+              </button>
+            ))}
+          </div>
+
+          <div ref={containerRef} className={styles['view-container']}>
+            {viewMode === 'transition' && (
+              <TransitionView
+                {...umapSelectProps}
+                leftPoints={leftPoints}
+                rightPoints={rightPoints}
+                drawPoints={drawPoints}
+                width={scopeWidth}
+                height={scopeHeight}
+                direction={direction}
+                onDirectionChange={setDirection}
+                onScatter={setScatter}
+                onView={handleView}
+                onSelect={handleSelected}
+                onHover={handleHover}
+                xDomain={xDomain}
+                yDomain={yDomain}
+                searchAnnotations={searchAnnotations}
+                hoverAnnotations={hoverAnnotations}
+                pointSizeRange={pointSizeRange}
+                opacityRange={opacityRange}
+              />
+            )}
+
+            {viewMode === 'side-by-side' && (
+              <SideBySideView
+                {...umapSelectProps}
+                datasetId={datasetId}
+                dataset={dataset}
+                leftPoints={leftPoints}
+                rightPoints={rightPoints}
+                drawPoints={drawPoints}
+                displacementData={rawDisplacementData}
+                width={scopeWidth}
+                height={scopeHeight}
+                onScatter={setScatter}
+                onSelect={handleSelected}
+                onHover={handleHover}
+                onNeighborSelect={handleNeighborSelect}
+                onRegionSelect={handleRegionSelect}
+                selectedIndices={selectedIndices}
+                searchIndices={searchIndices}
+                pointSizeRange={pointSizeRange}
+                opacityRange={opacityRange}
+                hoveredIndex={hoveredIndex}
+                metricK={metricK}
+                colorInterpolator={colorInterpolator}
+                colorExtent={colorExtent}
+                colorLabel={colorBy === '__drift__' ? 'Drift' : colorBy}
+              />
+            )}
+          </div>
         </div>
 
-        <div ref={containerRef} className={styles['view-container']}>
-          {viewMode === 'transition' && (
-            <TransitionView
-              leftPoints={leftPoints}
-              rightPoints={rightPoints}
-              drawPoints={drawPoints}
-              width={scopeWidth}
-              height={scopeHeight}
-              direction={direction}
-              onDirectionChange={setDirection}
-              onScatter={setScatter}
-              onView={handleView}
-              onSelect={handleSelected}
-              onHover={handleHover}
-              xDomain={xDomain}
-              yDomain={yDomain}
-              searchAnnotations={searchAnnotations}
-              hoverAnnotations={hoverAnnotations}
-              pointSizeRange={pointSizeRange}
-              opacityRange={opacityRange}
-            />
-          )}
-
-          {viewMode === 'side-by-side' && (
-            <SideBySideView
-              datasetId={datasetId}
-              dataset={dataset}
-              left={left}
-              right={right}
-              leftPoints={leftPoints}
-              rightPoints={rightPoints}
-              drawPoints={drawPoints}
-              displacementData={rawDisplacementData}
-              width={scopeWidth}
-              height={scopeHeight}
-              onScatter={setScatter}
-              onSelect={handleSelected}
-              onHover={handleHover}
-              onNeighborSelect={handleNeighborSelect}
-              onRegionSelect={handleRegionSelect}
-              selectedIndices={selectedIndices}
-              searchIndices={searchIndices}
-              pointSizeRange={pointSizeRange}
-              opacityRange={opacityRange}
-              hoveredIndex={hoveredIndex}
-              metricK={metricK}
-              colorInterpolator={colorInterpolator}
-              colorExtent={colorExtent}
-              colorLabel={colorBy === '__drift__' ? 'Drift' : colorBy}
-            />
-          )}
+        <div className={styles['col-resize-handle']} onMouseDown={handleDragStart}>
+          <div className={styles['col-resize-grip']} />
         </div>
-      </div>
 
-      <div className={styles['drag-handle']} onMouseDown={handleDragStart}>
-        <div className={styles['drag-grip']} />
-      </div>
-      <div style={{ height: panelHeight, minHeight: 40 }}>
-        <CompareDataPanel
-          dataset={dataset}
-          datasetId={datasetId}
-          embeddings={embeddings}
-          left={left}
-          right={right}
-          selectedIndices={selectedIndices}
-          neighborSelectedIndex={neighborSelectedIndex}
-          neighborIndices={neighborIndices}
-          onClearSelection={handleClearSelection}
-          searchIndices={searchIndices}
-          distances={distances}
-          onClearSearch={handleClearSearch}
-          onSearch={handleSearch}
-          searchModel={searchModel}
-          onSearchModelChange={handleSearchModelChange}
-          onHover={handleHover}
-          onClick={handleClicked}
-        />
+        <div className={styles['table-column']} style={{ width: tableWidth }}>
+          <CompareDataPanel
+            dataset={dataset}
+            datasetId={datasetId}
+            embeddings={embeddings}
+            left={left}
+            right={right}
+            selectedIndices={selectedIndices}
+            neighborSelectedIndex={neighborSelectedIndex}
+            neighborIndices={neighborIndices}
+            onClearSelection={handleClearSelection}
+            searchIndices={searchIndices}
+            distances={distances}
+            searchLoading={searchLoading}
+            onClearSearch={handleClearSearch}
+            onSearch={handleSearch}
+            searchModel={searchModel}
+            onSearchModelChange={handleSearchModelChange}
+            onHover={handleHover}
+            onClick={handleClicked}
+          />
+        </div>
       </div>
     </div>
   );

--- a/web/src/pages/Compare.jsx
+++ b/web/src/pages/Compare.jsx
@@ -360,8 +360,10 @@ function Compare() {
     .filter(([, m]) => m?.type === 'number')
     .map(([name]) => name);
 
-  // Resizable right-hand table column (horizontal drag)
-  const [tableWidth, setTableWidth] = useState(440);
+  // Resizable right-hand table column (horizontal drag). Defaults to null so the
+  // column starts at a 50/50 flex split; the first drag pins it to a pixel width.
+  const [tableWidth, setTableWidth] = useState(null);
+  const tableColRef = useRef(null);
   const isDraggingRef = useRef(false);
   const dragStartXRef = useRef(0);
   const dragStartWidthRef = useRef(0);
@@ -370,13 +372,15 @@ function Compare() {
     e.preventDefault();
     isDraggingRef.current = true;
     dragStartXRef.current = e.clientX;
-    dragStartWidthRef.current = tableWidth;
+    // Start from the current rendered width (handles the initial 50/50 case).
+    dragStartWidthRef.current =
+      tableWidth ?? tableColRef.current?.getBoundingClientRect().width ?? 440;
 
     const handleDragMove = (e) => {
       if (!isDraggingRef.current) return;
       // Dragging left widens the table column.
       const delta = dragStartXRef.current - e.clientX;
-      const newWidth = Math.max(280, Math.min(900, dragStartWidthRef.current + delta));
+      const newWidth = Math.max(280, Math.min(1100, dragStartWidthRef.current + delta));
       setTableWidth(newWidth);
     };
 
@@ -494,7 +498,15 @@ function Compare() {
           <div className={styles['col-resize-grip']} />
         </div>
 
-        <div className={styles['table-column']} style={{ width: tableWidth }}>
+        <div
+          ref={tableColRef}
+          className={styles['table-column']}
+          style={
+            tableWidth != null
+              ? { width: tableWidth, flexGrow: 0, flexShrink: 0 }
+              : { flex: 1 }
+          }
+        >
           <CompareDataPanel
             dataset={dataset}
             datasetId={datasetId}

--- a/web/src/pages/Compare.module.css
+++ b/web/src/pages/Compare.module.css
@@ -1,19 +1,59 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: 0;
+  gap: 6px;
   height: 100%;
   overflow: hidden;
   padding: 6px;
 }
 
-/* Visualization area */
-.visualization {
+/* Two-column workspace: stacked maps on the left, results table on the right. */
+.workspace {
+  display: flex;
+  flex-direction: row;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.maps-column {
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  min-height: 0;
   flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.table-column {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.col-resize-handle {
+  width: 10px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: ew-resize;
+  user-select: none;
+}
+
+.col-resize-grip {
+  width: 3px;
+  height: 40px;
+  border-radius: 2px;
+  background: #ccc;
+  transition: background 0.15s;
+}
+
+.col-resize-handle:hover .col-resize-grip,
+.col-resize-handle:active .col-resize-grip {
+  background: #aaa;
 }
 
 .view-tabs {
@@ -50,34 +90,23 @@
   overflow: hidden;
 }
 
-/* Drag handle between visualization and data panel */
-.drag-handle {
-  height: 8px;
-  cursor: ns-resize;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  user-select: none;
-}
-
-.drag-handle:hover .drag-grip,
-.drag-handle:active .drag-grip {
-  background: #aaa;
-}
-
-.drag-grip {
-  width: 40px;
-  height: 3px;
-  border-radius: 2px;
-  background: #ccc;
-  transition: background 0.15s;
-}
-
-/* Responsive */
+/* Responsive: stack the table under the maps on narrow screens */
 @media screen and (max-width: 1024px) {
   .container {
     overflow-y: auto;
+  }
+
+  .workspace {
+    flex-direction: column;
+  }
+
+  .table-column {
+    width: auto !important;
+    min-height: 240px;
+  }
+
+  .col-resize-handle {
+    display: none;
   }
 }
 
@@ -90,12 +119,12 @@
     background: #333;
   }
 
-  .drag-grip {
+  .col-resize-grip {
     background: #555;
   }
 
-  .drag-handle:hover .drag-grip,
-  .drag-handle:active .drag-grip {
+  .col-resize-handle:hover .col-resize-grip,
+  .col-resize-handle:active .col-resize-grip {
     background: #888;
   }
 }


### PR DESCRIPTION
Makes the Compare page a real projection-comparison tool and turns its distance code into a shared, cached resource. Closes #131 and #132.

## Backend — distance is now a cached, shared resource (`search.py`)
The Compare endpoints re-read both umap parquets and **re-fit a full `NearestNeighbors` index on every request** — and `/compare/neighbors` did it on *every click*.
- Added `_umap_coords` / `_umap_knn` (`UMAP_COORDS` / `UMAP_KNN` LRUs, mirroring the existing `NN_CACHE` pattern). Coordinates and fitted kNN are built once and reused.
- Vectorized the `relative` metric (dropped its Python per-point loop); `neighborhood` reuses cached neighbor matrices.
- `/compare/neighbors` now reads the cached neighbor matrix instead of refitting → clicks are effectively instant.

## #131 — continuous color-by column (Compare)
- New `GET /api/datasets/<ds>/column/<col>` — numeric column values + extent from the cached `input.parquet` (400 on non-numeric).
- "Color by" picker in `CompareControls` (Drift metric or any numeric column), normalized into the existing continuous color channel, with a new `ColorLegend` ramp. Threshold slider hides in column mode.

## #132 — shared brush selection + spread stat
- `Scatter.jsx` distinguishes a Shift-drag lasso from a single click (via `lassoEnd`→`select` ordering). This also **fixes a latent bug**: a Shift-lasso previously mis-fired a single-point neighbor fetch.
- Brushing in either pane highlights the same rows **green in both panes** via a new `SelectionOverlay` (the existing `NeighborPlot`/`CrosshairPlot` overlay pattern) — chosen because regl's `pointColorActive` is silently ignored under `colorBy:'valueB'`.
- New `POST /api/search/compare/spread` + a spread readout in `CompareDataPanel`: mean pairwise distance + convex-hull area per side with the R/L ratio ("2.3× more spread out in the right map"). O(n²) mean-pairwise is subsampled above 2000 points.

The two features compose: brush a suspicious region while colored by an external error column.

## Tests / checks
- 13 new backend tests (`tests/test_compare.py`): metrics, cached neighbors, column endpoint (+400 on text), spread stats + edge cases. Full suite: no new failures.
- `ruff check` clean; frontend `eslint` clean, `vitest` 82 pass, production build succeeds.
- Verified end-to-end over real HTTP against a built 2-umap dataset (all metrics, neighbors, column, spread).

> Note: base is `sprite-atlas` (the Compare page lives there, not yet on `main`).
> Manual browser QA of the Shift+drag lasso is still recommended — it's a WebGL interaction unit tests can't exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)