### PR TITLE
Example-dataset build recipes + --revision (1.0 demo rebuild)

### DIFF
--- a/examples/datasets/README.md
+++ b/examples/datasets/README.md
@@ -37,7 +37,7 @@ README/docs should point downloads at `--revision v1.0`.
 | [`marqo-ge-sample`](marqo-ge-sample/build.sh) | `enjalot/ls-marqo-ge-sample` | 20k | **images** + text/numeric/categorical | image map (sprite atlas), **color-by** (`position` numeric, `source` categorical) | featured / hero |
 | [`dadabase`](dadabase/build.sh) | `enjalot/ls-dadabase` | 53k | text | fast text pipeline, LLM labels | ✅ quickstart |
 | [`fineweb-edu-100k`](fineweb-edu-100k/build.sh) | `enjalot/ls-fineweb-edu-100k` | 100k | text | scale, TF-IDF labels | — |
-| [`common-corpus-100k`](common-corpus-100k/build.sh) | `enjalot/ls-common-corpus-100k` | 100k | text | multilingual, jina-v3 | — |
+| [`common-corpus-100k`](common-corpus-100k/build.sh) | `enjalot/ls-common-corpus-100k` | 100k | text | multilingual | — |
 | [`dataisplural`](dataisplural/build.sh) | `enjalot/ls-dataisplural` | 2k | text | tiny, LLM labels | — |
 
 **Starter recommendation:** make `marqo-ge-sample` the **featured** demo (it
@@ -55,10 +55,17 @@ LATENT_SCOPE_DATA=~/latent-scope-data LATENT_SCOPE_DEVICE=auto \
 ```
 
 Recipes source [`_lib.sh`](_lib.sh) for CLI resolution (works for a pip install
-or a dev checkout) and common env. Parameters (embedding model, umap/cluster
-settings, label model) were recovered from the existing published datasets; the
-**SOURCE** section of each recipe documents where the raw input comes from —
-verify/adjust it, since some original source ids are best-effort.
+or a dev checkout) and common env. The umap/cluster/label parameters were
+recovered from the existing published datasets; the **SOURCE** section of each
+recipe documents where the raw input comes from — verify/adjust it, since some
+original source ids are best-effort.
+
+**Text embedder:** all text demos share
+`jinaai/jina-embeddings-v5-text-nano-retrieval` (768-dim, multilingual, embedded
+with the `Document: ` task prefix) — the same model the SAE work targets, so the
+demos, the SAEs, and the taxonomy line up on one embedding space. (This replaces
+the previous per-dataset mix of nomic-embed-text-v1.5 / jina-embeddings-v3.) The
+`marqo-ge-sample` image demo uses CLIP.
 
 > **Note:** these recipes are scaffolding for a follow-up to the 1.0 release.
 > The `--revision` flag ships in 1.0; the actual re-bake + republish is a

--- a/examples/datasets/README.md
+++ b/examples/datasets/README.md
@@ -1,0 +1,65 @@
+# Example datasets
+
+Reproducible build recipes for the published Latent Scope demo datasets (the
+`enjalot/ls-*` Hugging Face repos linked from the top-level README), plus the
+`marqo-ge-sample` image showcase.
+
+Each `<name>/build.sh` records the **provenance and exact pipeline** for one
+demo, so anyone can regenerate it in the current (1.0) data format and republish
+it with `ls-upload-dataset`. This replaces the previous hand-built demos, which
+had no recorded recipe and shipped older-format artifacts.
+
+## Why rebuild for 1.0
+
+The published repos bake in the full pipeline artifacts (LanceDB tables, scope
+schema, sprites). The originals predate 1.0, so a fresh download lacks the new
+fields (`cluster_on`, named steps, quality metrics, image sprite atlas) and may
+carry legacy (HDF5-era, emoji model-id) metadata. Rebuilding gives clean,
+full-featured 1.0 examples.
+
+## Versioning the published repos
+
+`ls-download-dataset` now takes `--revision` so downloads can pin a
+format-compatible tag:
+
+```bash
+ls-download-dataset enjalot/ls-dadabase dadabase ~/latent-scope-data --revision v1.0
+```
+
+Recommended flow when republishing: push the rebuilt data and **tag it `v1.0`**
+on the HF repo, keeping the old state reachable (e.g. a `v0.6` tag). The 1.0
+README/docs should point downloads at `--revision v1.0`.
+
+## The datasets
+
+| recipe | HF repo | rows | modality | showcases | first-run? |
+| --- | --- | --- | --- | --- | --- |
+| [`marqo-ge-sample`](marqo-ge-sample/build.sh) | `enjalot/ls-marqo-ge-sample` | 20k | **images** + text/numeric/categorical | image map (sprite atlas), **color-by** (`position` numeric, `source` categorical) | featured / hero |
+| [`dadabase`](dadabase/build.sh) | `enjalot/ls-dadabase` | 53k | text | fast text pipeline, LLM labels | ✅ quickstart |
+| [`fineweb-edu-100k`](fineweb-edu-100k/build.sh) | `enjalot/ls-fineweb-edu-100k` | 100k | text | scale, TF-IDF labels | — |
+| [`common-corpus-100k`](common-corpus-100k/build.sh) | `enjalot/ls-common-corpus-100k` | 100k | text | multilingual, jina-v3 | — |
+| [`dataisplural`](dataisplural/build.sh) | `enjalot/ls-dataisplural` | 2k | text | tiny, LLM labels | — |
+
+**Starter recommendation:** make `marqo-ge-sample` the **featured** demo (it
+shows off the headline 1.0 features — image map + color-by), and keep
+`dadabase` (text-only, no images to download) as the literal 2-minute
+quickstart. A `dadabase`-style text set is the fastest first run; marqo is the
+most impressive.
+
+## Running a recipe
+
+```bash
+# GPU (uses cuML if the [gpu] extra is installed) or CPU:
+LATENT_SCOPE_DATA=~/latent-scope-data LATENT_SCOPE_DEVICE=auto \
+  bash examples/datasets/dadabase/build.sh
+```
+
+Recipes source [`_lib.sh`](_lib.sh) for CLI resolution (works for a pip install
+or a dev checkout) and common env. Parameters (embedding model, umap/cluster
+settings, label model) were recovered from the existing published datasets; the
+**SOURCE** section of each recipe documents where the raw input comes from —
+verify/adjust it, since some original source ids are best-effort.
+
+> **Note:** these recipes are scaffolding for a follow-up to the 1.0 release.
+> The `--revision` flag ships in 1.0; the actual re-bake + republish is a
+> deliberate, reviewed step (it overwrites public HF repos).

--- a/examples/datasets/_lib.sh
+++ b/examples/datasets/_lib.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Shared helpers for the latent-scope example-dataset build recipes.
+#
+# Each recipe (`<name>/build.sh`) sources this file, then runs the pipeline with
+# recovered parameters. The goal is a REPRODUCIBLE rebuild: the same commands
+# regenerate a demo dataset in the current (1.0) data format, ready to publish
+# with `ls-upload-dataset`.
+#
+# Env (override as needed):
+#   LATENT_SCOPE_DATA   where datasets are written   (default ~/latent-scope-data)
+#   LATENT_SCOPE_DEVICE cpu|cuda|auto                (default auto — uses GPU if present)
+#   HF_HOME             model/dataset cache          (default ~/.cache/huggingface)
+#   LS_BIN              dir holding the ls-* CLIs     (default: PATH, then dev .venv)
+
+set -euo pipefail
+
+# Resolve the ls-* CLIs for both a pip install and a dev checkout (mirrors
+# examples/colbert_quickstart/run.sh).
+_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$_LIB_DIR/../.." && pwd)"
+if [[ -n "${LS_BIN:-}" ]]; then
+  BIN="${LS_BIN%/}/"
+elif command -v ls-ingest >/dev/null 2>&1; then
+  BIN=""
+elif [[ -x "$REPO/.venv/bin/ls-ingest" ]]; then
+  BIN="$REPO/.venv/bin/"
+else
+  echo "error: latent-scope CLIs not found. Install it (pip install latentscope)" >&2
+  echo "       or set LS_BIN to the directory containing ls-ingest." >&2
+  exit 1
+fi
+
+export LATENT_SCOPE_DATA="${LATENT_SCOPE_DATA:-$HOME/latent-scope-data}"
+export LATENT_SCOPE_DEVICE="${LATENT_SCOPE_DEVICE:-auto}"
+export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"
+
+ls_ingest()  { "${BIN}ls-ingest"  "$@"; }
+ls_embed()   { "${BIN}ls-embed"   "$@"; }
+ls_umap()    { "${BIN}ls-umap"    "$@"; }
+ls_cluster() { "${BIN}ls-cluster" "$@"; }
+ls_label()   { "${BIN}ls-label"   "$@"; }
+ls_scope()   { "${BIN}ls-scope"   "$@"; }
+ls_atlas()   { "${BIN}ls-sprite-atlas" "$@"; }
+ls_upload()  { "${BIN}ls-upload-dataset" "$@"; }
+
+# Guard: a recipe needs an input file (CSV/parquet/jsonl). Recipes document how
+# to obtain it; this just fails clearly if it's missing.
+require_input() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    echo "error: input data not found at: $path" >&2
+    echo "       See the SOURCE section in this recipe for how to obtain it." >&2
+    exit 1
+  fi
+}
+
+echo "== recipe env: DATA=$LATENT_SCOPE_DATA DEVICE=$LATENT_SCOPE_DEVICE BIN=${BIN:-<PATH>} =="

--- a/examples/datasets/common-corpus-100k/build.sh
+++ b/examples/datasets/common-corpus-100k/build.sh
@@ -12,8 +12,8 @@ INPUT="${INPUT:-$LATENT_SCOPE_DATA/../sources/common-corpus-100k.parquet}"
 require_input "$INPUT"
 
 ls_ingest  "$DS" --path "$INPUT" --text_column text
-ls_embed   "$DS" text transformers-jinaai___jina-embeddings-v3
-ls_umap    "$DS" embedding-001 25 0.1 --name "jina-v3 n25"
+ls_embed   "$DS" text transformers-jinaai___jina-embeddings-v5-text-nano-retrieval --prefix "Document: "
+ls_umap    "$DS" embedding-001 25 0.1 --name "jina-v5-nano n25"
 ls_cluster "$DS" umap-001 25 5 0.0 --method evoc --name "evoc 25"
 ls_label   "$DS" text cluster-001 nltk-top-words 10 ""
 ls_scope   "$DS" embedding-001 umap-001 cluster-001 cluster-001-labels-001 \

--- a/examples/datasets/common-corpus-100k/build.sh
+++ b/examples/datasets/common-corpus-100k/build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Rebuild recipe: common-corpus-100k — 100k docs from PleIAs/common_corpus.
+#
+# SOURCE (verify/adjust): a 100k sample of PleIAs/common_corpus with a `text`
+# column. Land it at $INPUT (default: .../sources/common-corpus-100k.parquet).
+# Uses jina-embeddings-v3 (1024-dim, multilingual). nltk labels — no API key.
+set -euo pipefail
+source "$(dirname "$0")/../_lib.sh"
+
+DS="common-corpus-100k"
+INPUT="${INPUT:-$LATENT_SCOPE_DATA/../sources/common-corpus-100k.parquet}"
+require_input "$INPUT"
+
+ls_ingest  "$DS" --path "$INPUT" --text_column text
+ls_embed   "$DS" text transformers-jinaai___jina-embeddings-v3
+ls_umap    "$DS" embedding-001 25 0.1 --name "jina-v3 n25"
+ls_cluster "$DS" umap-001 25 5 0.0 --method evoc --name "evoc 25"
+ls_label   "$DS" text cluster-001 nltk-top-words 10 ""
+ls_scope   "$DS" embedding-001 umap-001 cluster-001 cluster-001-labels-001 \
+  "Common Corpus 100k" "100k documents from Common Corpus"
+
+echo "Done. Publish with:  ls-upload-dataset \$LATENT_SCOPE_DATA/$DS enjalot/ls-$DS"

--- a/examples/datasets/dadabase/build.sh
+++ b/examples/datasets/dadabase/build.sh
@@ -12,8 +12,8 @@ INPUT="${INPUT:-$LATENT_SCOPE_DATA/../sources/dadabase.csv}"
 require_input "$INPUT"
 
 ls_ingest  "$DS" --path "$INPUT" --text_column joke
-ls_embed   "$DS" joke transformers-nomic-ai___nomic-embed-text-v1.5 --prefix "clustering: "
-ls_umap    "$DS" embedding-001 100 0.1 --name "nomic n100"
+ls_embed   "$DS" joke transformers-jinaai___jina-embeddings-v5-text-nano-retrieval --prefix "Document: "
+ls_umap    "$DS" embedding-001 100 0.1 --name "jina-v5-nano n100"
 ls_cluster "$DS" umap-001 25 5 0.0 --method evoc --name "evoc 25"
 ls_label   "$DS" joke cluster-001 openai-gpt-4o 10 ""
 ls_scope   "$DS" embedding-001 umap-001 cluster-001 cluster-001-labels-001 \

--- a/examples/datasets/dadabase/build.sh
+++ b/examples/datasets/dadabase/build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Rebuild recipe: dadabase — 53k dad jokes. The fast text quickstart.
+#
+# SOURCE (verify/adjust): a CSV/parquet with a `joke` text column (~53k rows).
+#   Land it at $INPUT (default: $LATENT_SCOPE_DATA/../sources/dadabase.csv).
+# Needs OPENAI_API_KEY for the LLM label step (or swap the label model).
+set -euo pipefail
+source "$(dirname "$0")/../_lib.sh"
+
+DS="dadabase"
+INPUT="${INPUT:-$LATENT_SCOPE_DATA/../sources/dadabase.csv}"
+require_input "$INPUT"
+
+ls_ingest  "$DS" --path "$INPUT" --text_column joke
+ls_embed   "$DS" joke transformers-nomic-ai___nomic-embed-text-v1.5 --prefix "clustering: "
+ls_umap    "$DS" embedding-001 100 0.1 --name "nomic n100"
+ls_cluster "$DS" umap-001 25 5 0.0 --method evoc --name "evoc 25"
+ls_label   "$DS" joke cluster-001 openai-gpt-4o 10 ""
+ls_scope   "$DS" embedding-001 umap-001 cluster-001 cluster-001-labels-001 \
+  "Dadabase" "53k dad jokes"
+
+echo "Done. Publish with:  ls-upload-dataset \$LATENT_SCOPE_DATA/$DS enjalot/ls-$DS"

--- a/examples/datasets/dataisplural/build.sh
+++ b/examples/datasets/dataisplural/build.sh
@@ -12,8 +12,8 @@ INPUT="${INPUT:-$LATENT_SCOPE_DATA/../sources/dataisplural.csv}"
 require_input "$INPUT"
 
 ls_ingest  "$DS" --path "$INPUT" --text_column text
-ls_embed   "$DS" text transformers-nomic-ai___nomic-embed-text-v1.5
-ls_umap    "$DS" embedding-001 25 0.1 --name "nomic n25"
+ls_embed   "$DS" text transformers-jinaai___jina-embeddings-v5-text-nano-retrieval --prefix "Document: "
+ls_umap    "$DS" embedding-001 25 0.1 --name "jina-v5-nano n25"
 ls_cluster "$DS" umap-001 5 5 0.0 --method evoc --name "evoc 5"
 ls_label   "$DS" text cluster-001 openai-gpt-4o-mini 10 ""
 ls_scope   "$DS" embedding-001 umap-001 cluster-001 cluster-001-labels-001 \

--- a/examples/datasets/dataisplural/build.sh
+++ b/examples/datasets/dataisplural/build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Rebuild recipe: dataisplural — ~2k Data Is Plural newsletter entries.
+#
+# SOURCE (verify/adjust): the Data Is Plural archive as a CSV/parquet with a
+# `text` column (~2k rows). Land it at $INPUT (default: .../sources/dataisplural.csv).
+# Needs OPENAI_API_KEY for the label step (or swap the model).
+set -euo pipefail
+source "$(dirname "$0")/../_lib.sh"
+
+DS="dataisplural"
+INPUT="${INPUT:-$LATENT_SCOPE_DATA/../sources/dataisplural.csv}"
+require_input "$INPUT"
+
+ls_ingest  "$DS" --path "$INPUT" --text_column text
+ls_embed   "$DS" text transformers-nomic-ai___nomic-embed-text-v1.5
+ls_umap    "$DS" embedding-001 25 0.1 --name "nomic n25"
+ls_cluster "$DS" umap-001 5 5 0.0 --method evoc --name "evoc 5"
+ls_label   "$DS" text cluster-001 openai-gpt-4o-mini 10 ""
+ls_scope   "$DS" embedding-001 umap-001 cluster-001 cluster-001-labels-001 \
+  "Data Is Plural" "~2k Data Is Plural newsletter entries"
+
+echo "Done. Publish with:  ls-upload-dataset \$LATENT_SCOPE_DATA/$DS enjalot/ls-$DS"

--- a/examples/datasets/fineweb-edu-100k/build.sh
+++ b/examples/datasets/fineweb-edu-100k/build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Rebuild recipe: fineweb-edu-100k — 100k educational web docs.
+#
+# SOURCE (verify/adjust): a 100k sample of HuggingFaceFW/fineweb-edu with a
+# `text` column. Land it at $INPUT (default: .../sources/fineweb-edu-100k.parquet).
+# Labels use nltk-top-words (TF-IDF style) — no API key needed.
+set -euo pipefail
+source "$(dirname "$0")/../_lib.sh"
+
+DS="fineweb-edu-100k"
+INPUT="${INPUT:-$LATENT_SCOPE_DATA/../sources/fineweb-edu-100k.parquet}"
+require_input "$INPUT"
+
+ls_ingest  "$DS" --path "$INPUT" --text_column text
+ls_embed   "$DS" text transformers-nomic-ai___nomic-embed-text-v1.5 --prefix "clustering: "
+ls_umap    "$DS" embedding-001 25 0.1 --name "nomic n25"
+ls_cluster "$DS" umap-001 100 25 0.0 --method evoc --name "evoc 100"
+ls_label   "$DS" text cluster-001 nltk-top-words 10 ""
+ls_scope   "$DS" embedding-001 umap-001 cluster-001 cluster-001-labels-001 \
+  "Fineweb Edu 100k" "100k educational web documents"
+
+echo "Done. Publish with:  ls-upload-dataset \$LATENT_SCOPE_DATA/$DS enjalot/ls-$DS"

--- a/examples/datasets/fineweb-edu-100k/build.sh
+++ b/examples/datasets/fineweb-edu-100k/build.sh
@@ -12,8 +12,8 @@ INPUT="${INPUT:-$LATENT_SCOPE_DATA/../sources/fineweb-edu-100k.parquet}"
 require_input "$INPUT"
 
 ls_ingest  "$DS" --path "$INPUT" --text_column text
-ls_embed   "$DS" text transformers-nomic-ai___nomic-embed-text-v1.5 --prefix "clustering: "
-ls_umap    "$DS" embedding-001 25 0.1 --name "nomic n25"
+ls_embed   "$DS" text transformers-jinaai___jina-embeddings-v5-text-nano-retrieval --prefix "Document: "
+ls_umap    "$DS" embedding-001 25 0.1 --name "jina-v5-nano n25"
 ls_cluster "$DS" umap-001 100 25 0.0 --method evoc --name "evoc 100"
 ls_label   "$DS" text cluster-001 nltk-top-words 10 ""
 ls_scope   "$DS" embedding-001 umap-001 cluster-001 cluster-001-labels-001 \

--- a/examples/datasets/marqo-ge-sample/build.sh
+++ b/examples/datasets/marqo-ge-sample/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Rebuild recipe: marqo-ge-sample — 20k e-commerce products with IMAGES.
+# The 1.0 hero demo: image map (sprite atlas) + color-by (position/source).
+#
+# SOURCE (verify/adjust): a 20k sample of Marqo's general e-commerce / shopping
+# dataset (google_shopping + amazon_product). Columns: image (binary), title,
+# query, position (numeric), source (categorical), item_ID.
+#   Obtain a parquet/CSV with an `image` column + `title` and land it at:
+#     $INPUT  (default: $LATENT_SCOPE_DATA/../sources/marqo-ge-sample.parquet)
+#   e.g. from a Hugging Face dataset via `datasets.load_dataset(...).to_parquet()`.
+set -euo pipefail
+source "$(dirname "$0")/../_lib.sh"
+
+DS="marqo-ge-sample"
+INPUT="${INPUT:-$LATENT_SCOPE_DATA/../sources/marqo-ge-sample.parquet}"
+require_input "$INPUT"
+
+ls_ingest  "$DS" --path "$INPUT" --text_column title
+# CLIP embeds the auto-detected image column (multimodal). 512-dim.
+ls_embed   "$DS" title clip-openai___clip-vit-base-patch32
+ls_umap    "$DS" embedding-001 25 0.075 --name "CLIP images"
+ls_cluster "$DS" umap-001 30 5 0.0 --method evoc --name "evoc 30"
+# No LLM labels for the image demo — use the auto default labels.
+ls_scope   "$DS" embedding-001 umap-001 cluster-001 default \
+  "Marqo GE Sample (CLIP images)" "20k e-commerce products; image map + color-by"
+# Build the tiled representative-image atlas that powers the image map.
+ls_atlas   "$DS" scopes-001
+
+echo "Done. Publish with:  ls-upload-dataset \$LATENT_SCOPE_DATA/$DS enjalot/ls-$DS"

--- a/latentscope/models/embedding_models.json
+++ b/latentscope/models/embedding_models.json
@@ -1,5 +1,17 @@
 [
   {
+    "provider": "transformers",
+    "name": "jinaai/jina-embeddings-v5-text-nano-retrieval",
+    "id": "transformers-jinaai___jina-embeddings-v5-text-nano-retrieval",
+    "params": {
+      "max_tokens": 8192,
+      "dimensions": [
+        768
+      ],
+      "prefix": "Document: "
+    }
+  },
+  {
     "provider": "openai",
     "name": "text-embedding-3-small",
     "id": "openai-text-embedding-3-small",

--- a/latentscope/models/embedding_models.json
+++ b/latentscope/models/embedding_models.json
@@ -1,17 +1,5 @@
 [
   {
-    "provider": "transformers",
-    "name": "jinaai/jina-embeddings-v5-text-nano-retrieval",
-    "id": "transformers-jinaai___jina-embeddings-v5-text-nano-retrieval",
-    "params": {
-      "max_tokens": 8192,
-      "dimensions": [
-        768
-      ],
-      "prefix": "Document: "
-    }
-  },
-  {
     "provider": "openai",
     "name": "text-embedding-3-small",
     "id": "openai-text-embedding-3-small",

--- a/latentscope/scripts/download_dataset.py
+++ b/latentscope/scripts/download_dataset.py
@@ -13,7 +13,7 @@ from huggingface_hub import hf_hub_download, snapshot_download
 from latentscope.util import get_key
 
 
-def download_from_huggingface(dataset_repo, dataset_name,output_dir,token=None):
+def download_from_huggingface(dataset_repo, dataset_name, output_dir, token=None, revision=None):
     """
     Download a latentscope dataset from Hugging Face.
 
@@ -21,6 +21,9 @@ def download_from_huggingface(dataset_repo, dataset_name,output_dir,token=None):
         dataset_path (str): Path to the dataset on Hugging Face (e.g., 'username/dataset-name')
         output_dir (str): Local directory to save the downloaded files
         token (str, optional): Hugging Face API token
+        revision (str, optional): Git revision (tag/branch/commit) to pull. Use
+            this to pin a format-compatible version, e.g. ``v1.0``. Defaults to
+            the repo's default branch.
     """
     # Get token from .env if not provided
     if not token:
@@ -44,6 +47,7 @@ def download_from_huggingface(dataset_repo, dataset_name,output_dir,token=None):
             repo_type="dataset",
             local_dir=str(latentscope_path),
             token=token,
+            revision=revision,
             local_dir_use_symlinks=False
         )
 
@@ -104,10 +108,14 @@ def main():
     parser.add_argument('dataset_name', help='Name of the dataset')
     parser.add_argument('output_dir', help='Local directory to save the downloaded files')
     parser.add_argument('--token', help='Hugging Face API token', default=None)
+    parser.add_argument('--revision', default=None,
+                        help='Git revision (tag/branch/commit) to pull, e.g. v1.0 '
+                             '(default: the repo default branch)')
 
     args = parser.parse_args()
 
-    download_from_huggingface(args.dataset_repo, args.dataset_name, args.output_dir, args.token)
+    download_from_huggingface(args.dataset_repo, args.dataset_name, args.output_dir,
+                              args.token, revision=args.revision)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Reproducible example-dataset recipes + `--revision` (follow-up to 1.0)

Manages the rebuild of the published `enjalot/ls-*` demo datasets for 1.0. Kept **separate from #134** so 1.0.0 can be tagged independently; the actual re-bake/republish is a deliberate reviewed step (it overwrites public HF repos).

> **Base is `path-to-1.0`** (recipes use 1.0 CLIs: `--name`, `--method`, image atlas). GitHub will retarget this to `main` once #134 merges.

### What's here
- **`examples/datasets/<name>/build.sh`** — recorded provenance + the exact pipeline for each demo, with parameters **recovered from the current published datasets** (embedding model, umap/cluster settings, label model). Regenerates a demo in 1.0 format, ready for `ls-upload-dataset`.
  - `dadabase`, `fineweb-edu-100k`, `common-corpus-100k`, `dataisplural`, and a **new `marqo-ge-sample`** image showcase (20k e-commerce products → image map + color-by on `position`/`source`).
- **`examples/datasets/README.md`** — manifest (repo, size, features per dataset) + versioning guidance; **`_lib.sh`** — CLI resolution (pip or dev checkout) + shared env.
- **`ls-download-dataset --revision <tag>`** — pin a format-compatible version (e.g. `v1.0`) so old downloads keep working after a rebuild.

### Recommended rollout (not done here)
1. Verify each recipe's **SOURCE** (raw dataset origin is best-effort) and params.
2. Run recipes locally (cuML makes the 100k sets fast), spot-check the scopes.
3. `ls-upload-dataset` each, **tag `v1.0`** on the HF repo (keep old state as `v0.6`).
4. Point the 1.0 README/docs at `--revision v1.0`.

**Starter recommendation:** feature `marqo-ge-sample` as the hero (headline 1.0 features), keep `dadabase` as the 2-minute text quickstart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
