### PR TITLE
e2e polish batch (supersedes #136)

### DIFF
--- a/examples/datasets/README.md
+++ b/examples/datasets/README.md
@@ -61,10 +61,11 @@ recipe documents where the raw input comes from — verify/adjust it, since some
 original source ids are best-effort.
 
 **Text embedder:** all text demos share
-`jinaai/jina-embeddings-v5-text-nano-retrieval` (768-dim, multilingual, embedded
-with the `Document: ` task prefix) — the same model the SAE work targets, so the
-demos, the SAEs, and the taxonomy line up on one embedding space. (This replaces
-the previous per-dataset mix of nomic-embed-text-v1.5 / jina-embeddings-v3.) The
+`jinaai/jina-embeddings-v5-text-nano-retrieval` (768-dim, multilingual) — the
+same model the SAE work targets, so the demos, the SAEs, and the taxonomy line
+up on one embedding space. (This replaces the previous per-dataset mix of
+nomic-embed-text-v1.5 / jina-embeddings-v3.) No manual prefix is needed: the
+`transformers` provider auto-applies the model's `document` task prompt. The
 `marqo-ge-sample` image demo uses CLIP.
 
 > **Note:** these recipes are scaffolding for a follow-up to the 1.0 release.

--- a/examples/datasets/common-corpus-100k/build.sh
+++ b/examples/datasets/common-corpus-100k/build.sh
@@ -12,7 +12,7 @@ INPUT="${INPUT:-$LATENT_SCOPE_DATA/../sources/common-corpus-100k.parquet}"
 require_input "$INPUT"
 
 ls_ingest  "$DS" --path "$INPUT" --text_column text
-ls_embed   "$DS" text transformers-jinaai___jina-embeddings-v5-text-nano-retrieval --prefix "Document: "
+ls_embed   "$DS" text huggingface-jinaai___jina-embeddings-v5-text-nano-retrieval
 ls_umap    "$DS" embedding-001 25 0.1 --name "jina-v5-nano n25"
 ls_cluster "$DS" umap-001 25 5 0.0 --method evoc --name "evoc 25"
 ls_label   "$DS" text cluster-001 nltk-top-words 10 ""

--- a/examples/datasets/dadabase/build.sh
+++ b/examples/datasets/dadabase/build.sh
@@ -12,7 +12,7 @@ INPUT="${INPUT:-$LATENT_SCOPE_DATA/../sources/dadabase.csv}"
 require_input "$INPUT"
 
 ls_ingest  "$DS" --path "$INPUT" --text_column joke
-ls_embed   "$DS" joke transformers-jinaai___jina-embeddings-v5-text-nano-retrieval --prefix "Document: "
+ls_embed   "$DS" joke huggingface-jinaai___jina-embeddings-v5-text-nano-retrieval
 ls_umap    "$DS" embedding-001 100 0.1 --name "jina-v5-nano n100"
 ls_cluster "$DS" umap-001 25 5 0.0 --method evoc --name "evoc 25"
 ls_label   "$DS" joke cluster-001 openai-gpt-4o 10 ""

--- a/examples/datasets/dataisplural/build.sh
+++ b/examples/datasets/dataisplural/build.sh
@@ -12,7 +12,7 @@ INPUT="${INPUT:-$LATENT_SCOPE_DATA/../sources/dataisplural.csv}"
 require_input "$INPUT"
 
 ls_ingest  "$DS" --path "$INPUT" --text_column text
-ls_embed   "$DS" text transformers-jinaai___jina-embeddings-v5-text-nano-retrieval --prefix "Document: "
+ls_embed   "$DS" text huggingface-jinaai___jina-embeddings-v5-text-nano-retrieval
 ls_umap    "$DS" embedding-001 25 0.1 --name "jina-v5-nano n25"
 ls_cluster "$DS" umap-001 5 5 0.0 --method evoc --name "evoc 5"
 ls_label   "$DS" text cluster-001 openai-gpt-4o-mini 10 ""

--- a/examples/datasets/fineweb-edu-100k/build.sh
+++ b/examples/datasets/fineweb-edu-100k/build.sh
@@ -12,7 +12,7 @@ INPUT="${INPUT:-$LATENT_SCOPE_DATA/../sources/fineweb-edu-100k.parquet}"
 require_input "$INPUT"
 
 ls_ingest  "$DS" --path "$INPUT" --text_column text
-ls_embed   "$DS" text transformers-jinaai___jina-embeddings-v5-text-nano-retrieval --prefix "Document: "
+ls_embed   "$DS" text huggingface-jinaai___jina-embeddings-v5-text-nano-retrieval
 ls_umap    "$DS" embedding-001 25 0.1 --name "jina-v5-nano n25"
 ls_cluster "$DS" umap-001 100 25 0.0 --method evoc --name "evoc 100"
 ls_label   "$DS" text cluster-001 nltk-top-words 10 ""

--- a/examples/datasets/marqo-ge-sample/build.sh
+++ b/examples/datasets/marqo-ge-sample/build.sh
@@ -16,14 +16,17 @@ INPUT="${INPUT:-$LATENT_SCOPE_DATA/../sources/marqo-ge-sample.parquet}"
 require_input "$INPUT"
 
 ls_ingest  "$DS" --path "$INPUT" --text_column title
-# CLIP embeds the auto-detected image column (multimodal). 512-dim.
-ls_embed   "$DS" title clip-openai___clip-vit-base-patch32
+# Embed the IMAGE column with CLIP's image encoder (embed() picks image vs text
+# mode from the column metadata) so the map is an image-embedding map, not CLIP
+# text features of the titles. 512-dim.
+ls_embed   "$DS" image clip-openai___clip-vit-base-patch32
 ls_umap    "$DS" embedding-001 25 0.075 --name "CLIP images"
 ls_cluster "$DS" umap-001 30 5 0.0 --method evoc --name "evoc 30"
 # No LLM labels for the image demo — use the auto default labels.
 ls_scope   "$DS" embedding-001 umap-001 cluster-001 default \
   "Marqo GE Sample (CLIP images)" "20k e-commerce products; image map + color-by"
 # Build the tiled representative-image atlas that powers the image map.
-ls_atlas   "$DS" scopes-001
+# ls-sprite-atlas takes: <dataset> <scope> <image_column>.
+ls_atlas   "$DS" scopes-001 image
 
 echo "Done. Publish with:  ls-upload-dataset \$LATENT_SCOPE_DATA/$DS enjalot/ls-$DS"

--- a/latentscope/models/providers/base.py
+++ b/latentscope/models/providers/base.py
@@ -9,6 +9,12 @@ class EmbedModelProvider:
     def embed(self, text):
         raise NotImplementedError("This method should be implemented by subclasses.")
 
+    def embed_query(self, inputs, dimensions=None):
+        """Embed a search query. Defaults to plain embed(); providers whose
+        models use distinct query/document prompts (e.g. transformers/jina)
+        override this to apply the query prompt."""
+        return self.embed(inputs, dimensions=dimensions)
+
 class ChatModelProvider:
     def __init__(self, name, params, base_url=None):
         self.name = name

--- a/latentscope/models/providers/transformers.py
+++ b/latentscope/models/providers/transformers.py
@@ -13,6 +13,28 @@ class TransformersEmbedProvider(EmbedModelProvider):
         from sentence_transformers import SentenceTransformer
         self.model = SentenceTransformer(self.name, trust_remote_code=True, device=self.device)#, backend="onnx")
         self.tokenizer = self.model.tokenizer
+        # Task-conditioned models (e.g. jina-v3/v5) advertise `config.task_names`
+        # and refuse to encode until a task is selected (they swap a LoRA adapter
+        # per task). Select the requested task, else a sensible default, so these
+        # models work without the caller needing a task-specialised checkpoint.
+        try:
+            module = self.model[0]
+            task_names = list(getattr(getattr(module, "config", None), "task_names", None) or [])
+            self.task_names = task_names
+            if task_names and getattr(module, "default_task", None) is None:
+                requested = getattr(self, "task", None) or (self.params or {}).get("task")
+                if requested and requested in task_names:
+                    chosen = requested
+                elif "retrieval" in task_names:
+                    chosen = "retrieval"
+                else:
+                    chosen = task_names[0]
+                module.default_task = chosen
+                self.task = chosen
+                print(f"transformers: model is task-conditioned {task_names}; "
+                      f"using task '{chosen}'")
+        except Exception as e:
+            print(f"transformers: task auto-detect skipped ({e})")
         # If the model defines task prompts (e.g. jina-v5's {query, document})
         # but no default, apply the document/passage prompt automatically so
         # embedding a corpus gets the retrieval "document" representation without

--- a/latentscope/models/providers/transformers.py
+++ b/latentscope/models/providers/transformers.py
@@ -13,6 +13,23 @@ class TransformersEmbedProvider(EmbedModelProvider):
         from sentence_transformers import SentenceTransformer
         self.model = SentenceTransformer(self.name, trust_remote_code=True, device=self.device)#, backend="onnx")
         self.tokenizer = self.model.tokenizer
+        # If the model defines task prompts (e.g. jina-v5's {query, document})
+        # but no default, apply the document/passage prompt automatically so
+        # embedding a corpus gets the retrieval "document" representation without
+        # the user having to know the right --prefix. A manual --prefix still
+        # stacks on top if provided, so leave it empty for prompt-aware models.
+        try:
+            prompts = getattr(self.model, "prompts", None) or {}
+            has_default = getattr(self.model, "default_prompt_name", None)
+            if prompts and not has_default:
+                for key in ("document", "passage", "corpus", "doc", "text"):
+                    if key in prompts:
+                        self.model.default_prompt_name = key
+                        print(f"transformers: auto-applying '{key}' prompt "
+                              f"({prompts[key]!r}) for {self.name}")
+                        break
+        except Exception as e:
+            print(f"transformers: prompt auto-detect skipped ({e})")
 
     def embed(self, inputs, dimensions=None):
         embeddings = self.model.encode(inputs, convert_to_tensor=True)

--- a/latentscope/models/providers/transformers.py
+++ b/latentscope/models/providers/transformers.py
@@ -43,6 +43,9 @@ class TransformersEmbedProvider(EmbedModelProvider):
         try:
             prompts = getattr(self.model, "prompts", None) or {}
             has_default = getattr(self.model, "default_prompt_name", None)
+            # Remember the query-side prompt so embed_query() can encode search
+            # queries with it instead of the document default.
+            self.query_prompt_name = next((k for k in ("query", "question") if k in prompts), None)
             if prompts and not has_default:
                 for key in ("document", "passage", "corpus", "doc", "text"):
                     if key in prompts:
@@ -53,16 +56,31 @@ class TransformersEmbedProvider(EmbedModelProvider):
         except Exception as e:
             print(f"transformers: prompt auto-detect skipped ({e})")
 
-    def embed(self, inputs, dimensions=None):
-        embeddings = self.model.encode(inputs, convert_to_tensor=True)
+    def _finalize(self, embeddings, dimensions):
         # Support Matroyshka embeddings
         if dimensions is not None and dimensions > 0:
             embeddings = self.torch.nn.functional.layer_norm(embeddings, normalized_shape=(embeddings.shape[1],))
             embeddings = embeddings[:, :dimensions]
-
         # Normalize embeddings
         normalized_embeddings = self.torch.nn.functional.normalize(embeddings, p=2, dim=1)
         return normalized_embeddings.tolist()
+
+    def embed(self, inputs, dimensions=None):
+        # Corpus embedding: uses the model's default prompt (the document/passage
+        # prompt auto-applied in load_model, if the model advertises one).
+        return self._finalize(self.model.encode(inputs, convert_to_tensor=True), dimensions)
+
+    def embed_query(self, inputs, dimensions=None):
+        # Query embedding for nearest-neighbor search: override the document
+        # default with the model's *query* prompt when it has one, so searches
+        # aren't encoded with the document/passage prompt (which would make
+        # retrieval inconsistent for prompt-aware models like jina-v5).
+        prompt_name = getattr(self, "query_prompt_name", None)
+        if prompt_name:
+            embeddings = self.model.encode(inputs, convert_to_tensor=True, prompt_name=prompt_name)
+        else:
+            embeddings = self.model.encode(inputs, convert_to_tensor=True)
+        return self._finalize(embeddings, dimensions)
 
 
 class TransformersChatProvider(ChatModelProvider):

--- a/latentscope/scripts/embed.py
+++ b/latentscope/scripts/embed.py
@@ -207,6 +207,16 @@ def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_si
 
     if prefix is None:
         prefix = ""
+    # Avoid double-applying a task prompt: if the transformers provider already
+    # auto-applies the model's own document prompt (default_prompt_name, e.g.
+    # jina-v5), a manual --prefix would stack on top of it ("Document: Document:
+    # ..."). Prefer the model's prompt and drop the redundant manual prefix.
+    if prefix and isinstance(model, TransformersEmbedProvider):
+        auto_prompt = getattr(getattr(model, "model", None), "default_prompt_name", None)
+        if auto_prompt:
+            print(f"Model auto-applies its '{auto_prompt}' prompt; ignoring the "
+                  f"manual prefix {prefix!r} to avoid double-prompting.")
+            prefix = ""
     if input_type == "image":
         if not getattr(model, "supports_images", False):
             print(f"Error: column '{text_column}' is an image column but model "

--- a/latentscope/scripts/embed.py
+++ b/latentscope/scripts/embed.py
@@ -94,10 +94,13 @@ def main():
     parser.add_argument('--rerun', type=str, help='Rerun the given embedding from last completed batch')
     parser.add_argument('--batch_size', type=int, help='Set the batch size (number of sentences to embed in one call)', default=100)
     parser.add_argument('--max_seq_length', type=int, help='Set the max sequence length for the model', default=None)
+    parser.add_argument('--task', type=str, default=None,
+                        help='Task for task-conditioned models (e.g. jina-v3/v5): '
+                             'retrieval, clustering, classification, text-matching')
 
     # Parse arguments
     args = parser.parse_args()
-    embed(args.dataset_id, args.text_column, args.model_id, args.prefix, args.rerun, args.dimensions, args.batch_size, args.max_seq_length)
+    embed(args.dataset_id, args.text_column, args.model_id, args.prefix, args.rerun, args.dimensions, args.batch_size, args.max_seq_length, task=args.task)
 
 def _make_token_counter(model):
     """Best-effort per-text token counter using a tokenizer the embedding
@@ -121,7 +124,7 @@ def _make_token_counter(model):
     return count
 
 
-def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_size=100, max_seq_length=None):
+def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_size=100, max_seq_length=None, task=None):
     import numpy as np
     import pandas as pd
 
@@ -189,6 +192,10 @@ def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_si
     print("RUNNING:", embedding_id)
     print("MODEL ID", model_id)
     model = get_embedding_model(model_id)
+    # Requested task for task-conditioned models (jina-v3/v5); the provider reads
+    # this in load_model and falls back to a sensible default when unset.
+    if task:
+        model.task = task
     print("MODEL", model)
     print("loading", model.name)
     model.load_model()
@@ -207,16 +214,19 @@ def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_si
 
     if prefix is None:
         prefix = ""
-    # Avoid double-applying a task prompt: if the transformers provider already
-    # auto-applies the model's own document prompt (default_prompt_name, e.g.
-    # jina-v5), a manual --prefix would stack on top of it ("Document: Document:
-    # ..."). Prefer the model's prompt and drop the redundant manual prefix.
-    if prefix and isinstance(model, TransformersEmbedProvider):
-        auto_prompt = getattr(getattr(model, "model", None), "default_prompt_name", None)
-        if auto_prompt:
-            print(f"Model auto-applies its '{auto_prompt}' prompt; ignoring the "
-                  f"manual prefix {prefix!r} to avoid double-prompting.")
-            prefix = ""
+    # Prompt precedence: an explicit --prefix (user intent) wins over a model's
+    # auto-applied prompt. Some sentence-transformers models set a default prompt
+    # (default_prompt_name) so a corpus is embedded with the model's own document
+    # prompt when the user gives no prefix. If the user DID specify a prefix,
+    # honor it and disable the auto prompt so the two don't stack. This is
+    # model-agnostic — it keys off whether the model advertises a default prompt.
+    if isinstance(model, TransformersEmbedProvider):
+        st = getattr(model, "model", None)
+        auto_prompt = getattr(st, "default_prompt_name", None)
+        if auto_prompt and prefix:
+            print(f"Using the specified prefix {prefix!r}; disabling the model's "
+                  f"auto-applied '{auto_prompt}' prompt so they don't stack.")
+            st.default_prompt_name = None
     if input_type == "image":
         if not getattr(model, "supports_images", False):
             print(f"Error: column '{text_column}' is an image column but model "
@@ -367,6 +377,7 @@ def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_si
         "dimensions": stats["dimensions"],
         "max_seq_length": max_seq_length,
         "prefix": prefix,
+        "task": getattr(model, "task", None),
         "late_interaction": is_late_interaction,
         "min_values": stats["min_values"],
         "max_values": stats["max_values"],

--- a/latentscope/server/jobs.py
+++ b/latentscope/server/jobs.py
@@ -322,6 +322,8 @@ def run_embed():
     dimensions = request.values.get('dimensions')
     batch_size = request.values.get('batch_size')
     max_seq_length = request.values.get('max_seq_length')
+    # Task for task-conditioned models (jina-v3/v5). Consumed by ls-embed.
+    task = request.values.get('task')
 
     err = _require_params(dataset=dataset, text_column=text_column, model_id=model_id,
                           prefix=prefix, batch_size=batch_size)
@@ -335,6 +337,8 @@ def run_embed():
         command.append(f'--dimensions={dimensions}')
     if max_seq_length is not None:
         command.append(f'--max_seq_length={max_seq_length}')
+    if task:
+        command.append(f'--task={task}')
     threading.Thread(target=run_job, args=(data_dir, dataset, job_id, command)).start()
     return jsonify({"job_id": job_id})
 

--- a/latentscope/server/jobs.py
+++ b/latentscope/server/jobs.py
@@ -54,6 +54,18 @@ def _require_params(**params):
     return None
 
 
+def _atomic_write_json(path, obj):
+    """Write JSON atomically: serialize to a temp file in the same directory,
+    then os.replace() (an atomic rename on the same filesystem). A concurrent
+    reader always sees a complete file — the old one or the new one — never a
+    truncated/partial write mid-``json.dump`` (which caused intermittent
+    JSONDecodeErrors when polling / killing a running job)."""
+    tmp = f"{path}.{os.getpid()}.tmp"
+    with open(tmp, 'w') as f:
+        json.dump(obj, f)
+    os.replace(tmp, path)
+
+
 def run_job(data_dir, dataset, job_id, command):
     """Execute a CLI command in a subprocess and write progress to a JSON file.
 
@@ -91,8 +103,7 @@ def run_job(data_dir, dataset, job_id, command):
     def write_job():
         job["progress"] = list(progress)
         job["times"] = list(times)
-        with open(progress_file, 'w') as f:
-            json.dump(job, f)
+        _atomic_write_json(progress_file, job)
 
     write_job()
 
@@ -214,8 +225,7 @@ def reconcile_stale_jobs(data_dir):
         job["times"] = times
         job["last_update"] = _now()
         try:
-            with open(path, 'w') as f:
-                json.dump(job, f)
+            _atomic_write_json(path, job)
         except Exception:
             continue
 
@@ -425,8 +435,7 @@ def kill_job():
         job["status"] = "dead"
         job["cause_of_death"] = "process not found, presumed dead"
     job["last_update"] = _now()
-    with open(progress_file, 'w') as f:
-        json.dump(job, f)
+    _atomic_write_json(progress_file, job)
     return jsonify(job)
 
 
@@ -850,5 +859,4 @@ def _write_completed_job(data_dir, dataset, job_id, description):
         "progress": [],
         "times": [],
     }
-    with open(os.path.join(job_dir, f"{job_id}.json"), 'w') as f:
-        json.dump(job, f)
+    _atomic_write_json(os.path.join(job_dir, f"{job_id}.json"), job)

--- a/latentscope/server/jobs.py
+++ b/latentscope/server/jobs.py
@@ -4,6 +4,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
 import threading
 import time
 import uuid
@@ -97,6 +98,14 @@ def run_job(data_dir, dataset, job_id, command):
 
     env = os.environ.copy()
     env['PYTHONUNBUFFERED'] = '1'
+    # Resolve the CLI entry point robustly. subprocess searches PATH, but a
+    # server launched from a venv whose bin dir is not on PATH (e.g. started by
+    # absolute python path) would fail to find ls-embed/ls-umap/... Fall back to
+    # the same bin dir as the running interpreter before giving up.
+    if command and shutil.which(command[0]) is None:
+        candidate = os.path.join(os.path.dirname(sys.executable), command[0])
+        if os.path.exists(candidate):
+            command = [candidate, *command[1:]]
     try:
         process = subprocess.Popen(
             command,

--- a/latentscope/server/search.py
+++ b/latentscope/server/search.py
@@ -82,7 +82,7 @@ def nn():
     except Exception:
         count = 0
     if count > 0:
-        embedding = np.array(model.embed([query], dimensions=dimensions))
+        embedding = np.array(model.embed_query([query], dimensions=dimensions))
         query_vec = embedding[0] if embedding.ndim > 1 else embedding
         indices, distances = search_nn(
             DATA_DIR, dataset, embedding_id, query_vec, limit=150
@@ -108,7 +108,7 @@ def nn():
         nne.fit(embeddings)
         NN_CACHE[nn_key] = nne
 
-    embedding = np.array(model.embed([query], dimensions=dimensions))
+    embedding = np.array(model.embed_query([query], dimensions=dimensions))
     distances, indices = nne.kneighbors(embedding)
     return jsonify(
         indices=indices[0].tolist(),
@@ -121,7 +121,7 @@ def nn_lance(data_dir, dataset, scope_id, model, query, dimensions):
     import lancedb
     db = lancedb.connect(os.path.join(data_dir, dataset, "lancedb"))
     table = db.open_table(scope_id)
-    embedding = model.embed([query], dimensions=dimensions)
+    embedding = model.embed_query([query], dimensions=dimensions)
     results = table.search(embedding).metric("cosine").select(["index"]).limit(100).to_list()
     indices = [result["index"] for result in results]
     distances = [result["_distance"] for result in results]
@@ -235,7 +235,7 @@ def features():
         NN_CACHE[nn_key] = nne
 
     query = request.args.get('query')
-    embedding = np.array(model.embed([query], dimensions=dimensions))
+    embedding = np.array(model.embed_query([query], dimensions=dimensions))
     distances, indices = nne.kneighbors(embedding)
     return jsonify(
         indices=indices[0].tolist(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
     "torch>=2.1,<3",
     "transformers>=4.40,<6",
     "sentence-transformers>=3.0,<6",
+    # peft is required by some models' custom code loaded via trust_remote_code
+    # (e.g. jina-embeddings-v5, which uses LoRA task adapters).
+    "peft>=0.10,<1",
     # Server
     "Flask>=3.0,<4",
     "Flask-Cors>=4.0,<7",

--- a/tests/test_search_late_interaction.py
+++ b/tests/test_search_late_interaction.py
@@ -32,6 +32,10 @@ class FakeLIProvider:
         means, _ = self.embed_multi(inputs, dimensions)
         return means.tolist()
 
+    def embed_query(self, inputs, dimensions=None):
+        # Mirror the base provider: query embedding defaults to embed().
+        return self.embed(inputs, dimensions=dimensions)
+
 
 @pytest.fixture
 def li_dataset(tmp_data_dir):

--- a/uv.lock
+++ b/uv.lock
@@ -2959,6 +2959,7 @@ dependencies = [
     { name = "openai" },
     { name = "outlines" },
     { name = "pandas" },
+    { name = "peft" },
     { name = "pillow" },
     { name = "pylance" },
     { name = "pylate" },
@@ -3015,6 +3016,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.12,<3" },
     { name = "outlines", specifier = ">=0.1,<2" },
     { name = "pandas", specifier = ">=2.0,<3" },
+    { name = "peft", specifier = ">=0.10,<1" },
     { name = "pillow", specifier = ">=10,<14" },
     { name = "pylance", specifier = ">=0.39,<0.40" },
     { name = "pylate", specifier = ">=1.6.0" },
@@ -4584,6 +4586,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b2/3a/3f06f34820a31257ddcabdfafc2672c5816be79c7e353b02c1f318daa7d4/partd-1.4.2.tar.gz", hash = "sha256:d022c33afbdc8405c226621b015e8067888173d85f7f5ecebb3cafed9a20f02c", size = 21029, upload-time = "2024-05-06T19:51:41.945Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl", hash = "sha256:978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f", size = 18905, upload-time = "2024-05-06T19:51:39.271Z" },
+]
+
+[[package]]
+name = "peft"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accelerate" },
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/cf/037f1e3d5186496c05513a6754639e2dab3038a05f384284d49a9bd06a2d/peft-0.19.1.tar.gz", hash = "sha256:0d97542fe96dcdaa20d3b81c06f26f988618f416a73544ab23c3618ccb674a40", size = 763738, upload-time = "2026-04-16T15:46:45.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/b6/f54d676ed93cc2dd2234c3b172ea9c8c3d7d29361e66b1b23dec57a67465/peft-0.19.1-py3-none-any.whl", hash = "sha256:2113f72a81621b5913ef28f9022204c742df111890c5f49d812716a4a301e356", size = 680692, upload-time = "2026-04-16T15:46:42.886Z" },
 ]
 
 [[package]]

--- a/web/src/components/Job/Progress.css
+++ b/web/src/components/Job/Progress.css
@@ -15,3 +15,21 @@
   color: springgreen;
   padding: 6px;
 }
+/* Job log: collapsed shows just the latest line; expanded scrolls. */
+.job-progress pre.log-collapsed {
+  max-height: 2.4em;
+  overflow: hidden;
+}
+.job-progress pre.log-expanded {
+  max-height: 16em;
+  overflow-y: auto;
+}
+.job-progress .log-toggle {
+  font-size: 0.8em;
+  padding: 1px 6px;
+  margin: 2px 0 4px;
+  cursor: pointer;
+  background: none;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+}

--- a/web/src/components/Job/Progress.jsx
+++ b/web/src/components/Job/Progress.jsx
@@ -47,7 +47,18 @@ function JobProgress({
           Running <b>{job.job_name}</b>
           <br />
           <code>{Array.isArray(job.command) ? job.command.join(' ') : job.command}</code>
-          <pre ref={preRef}>{onlyLast ? history[history.length - 1] : history.join('\n')}</pre>
+          <pre ref={preRef} className={onlyLast ? 'log-collapsed' : 'log-expanded'}>
+            {onlyLast ? history[history.length - 1] : history.join('\n')}
+          </pre>
+          {history.length > 1 && !allwaysOnlyLast ? (
+            <button
+              type="button"
+              className="log-toggle"
+              onClick={() => setOnlyLast((v) => !v)}
+            >
+              {onlyLast ? `▸ Show full log (${history.length} lines)` : '▾ Show latest only'}
+            </button>
+          ) : null}
           {isError ? (
             <div className="job-progress-error" style={{ color: '#b00020' }}>
               <b>Job failed{job.error ? `: ${job.error}` : ''}</b>

--- a/web/src/components/Job/Progress.jsx
+++ b/web/src/components/Job/Progress.jsx
@@ -46,7 +46,7 @@ function JobProgress({
         <div className="job-progress">
           Running <b>{job.job_name}</b>
           <br />
-          <code>{job.command}</code>
+          <code>{Array.isArray(job.command) ? job.command.join(' ') : job.command}</code>
           <pre ref={preRef}>{onlyLast ? history[history.length - 1] : history.join('\n')}</pre>
           {isError ? (
             <div className="job-progress-error" style={{ color: '#b00020' }}>

--- a/web/src/components/Job/Progress.jsx
+++ b/web/src/components/Job/Progress.jsx
@@ -66,10 +66,13 @@ function JobProgress({
             </div>
           ) : null}
           {clearJob && job.status == 'completed' ? (
-            <button onClick={clearJob}>👍 Dismiss</button>
+            <button type="button" onClick={clearJob}>
+              👍 Dismiss
+            </button>
           ) : null}
           {killJob && job.status == 'running' ? (
             <button
+              type="button"
               onClick={() => {
                 killJob(job);
               }}
@@ -79,8 +82,16 @@ function JobProgress({
           ) : null}
           {isError ? (
             <div className="error-choices">
-              {clearJob ? <button onClick={clearJob}>🤬 Dismiss</button> : null}
-              {rerunJob ? <button onClick={() => rerunJob(job)}>🔁 Rerun</button> : null}
+              {clearJob ? (
+                <button type="button" onClick={clearJob}>
+                  🤬 Dismiss
+                </button>
+              ) : null}
+              {rerunJob ? (
+                <button type="button" onClick={() => rerunJob(job)}>
+                  🔁 Rerun
+                </button>
+              ) : null}
             </div>
           ) : null}
           <span className="timer">

--- a/web/src/components/ModelSelect.jsx
+++ b/web/src/components/ModelSelect.jsx
@@ -81,7 +81,11 @@ function ModelSelect({
   const formatGroupLabel = useCallback((option) => {
     return (
       <div style={groupStyles}>
-        {option.label == '🤗' ? <span>🤗 Local Models</span> : <span>{option.label}</span>}
+        {option.label == 'huggingface' ? (
+          <span>🤗 Local Models</span>
+        ) : (
+          <span>{option.label}</span>
+        )}
         {option.options.length ? (
           <span style={groupBadgeStyles}>{option.options.length}</span>
         ) : null}

--- a/web/src/components/Setup/Cluster.jsx
+++ b/web/src/components/Setup/Cluster.jsx
@@ -382,7 +382,11 @@ function Cluster() {
             />
           </form>
 
-          <JobProgress job={clusterJob} clearJob={() => setClusterJob(null)} />
+          <JobProgress
+            job={clusterJob}
+            clearJob={() => setClusterJob(null)}
+            killJob={(job) => apiService.killJob(dataset.id, job.id).then(setClusterJob).catch(console.error)}
+          />
         </div>
 
         <div className={styles['cluster-list']}>

--- a/web/src/components/Setup/Embedding.jsx
+++ b/web/src/components/Setup/Embedding.jsx
@@ -245,6 +245,35 @@ function Embedding() {
 
   const [batchSize, setBatchSize] = useState(100);
   const [maxSeqLength, setMaxSeqLength] = useState(512);
+  // Task-conditioned models (e.g. jina-v3/v5) advertise `task_names` in their HF
+  // config and must have a task selected. Detect them and offer a picker so the
+  // popular base checkpoints work without needing a task-specialised variant.
+  const [taskNames, setTaskNames] = useState([]);
+  const [task, setTask] = useState(null);
+
+  useEffect(() => {
+    setTaskNames([]);
+    setTask(null);
+    const m = allModels.find((mm) => mm.id === modelId);
+    const isHF =
+      m && m.name && (m.provider === 'huggingface' || String(m.id || '').startsWith('huggingface-'));
+    if (!isHF) return;
+    let cancelled = false;
+    fetch(`https://huggingface.co/${m.name}/resolve/main/config.json`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((cfg) => {
+        if (cancelled || !cfg) return;
+        const tn = cfg.task_names;
+        if (Array.isArray(tn) && tn.length) {
+          setTaskNames(tn);
+          setTask(tn.includes('retrieval') ? 'retrieval' : tn[0]);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [modelId, allModels]);
 
   // Estimation state
   const [embedEstimate, setEmbedEstimate] = useState(null);
@@ -358,9 +387,10 @@ function Embedding() {
         max_seq_length: maxSeqLength,
       };
       if (dimensions) job.dimensions = dimensions;
+      if (task && taskNames.length) job.task = task;
       startEmbeddingsJob(job);
     },
-    [startEmbeddingsJob, textColumn, dimensions, batchSize, modelId, maxSeqLength, imageColumn]
+    [startEmbeddingsJob, textColumn, dimensions, batchSize, modelId, maxSeqLength, imageColumn, task, taskNames]
   );
 
   const handleRerunEmbedding = (job) => {
@@ -510,6 +540,23 @@ function Embedding() {
           {/* The form for creating a new embedding */}
           <form onSubmit={handleNewEmbedding}>
             <div className={styles.step}>
+              {/* Task picker for task-conditioned models (jina-v3/v5). */}
+              {!imageColumn && taskNames.length > 0 && (
+                <label className={styles.taskSelect}>
+                  Task:{' '}
+                  <select
+                    value={task || ''}
+                    onChange={(e) => setTask(e.target.value)}
+                    disabled={!!embeddingsJob}
+                  >
+                    {taskNames.map((t) => (
+                      <option key={t} value={t}>
+                        {t}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
               {/* prefix doesn't apply to image columns */}
               {!imageColumn && (
                 <textarea
@@ -607,6 +654,9 @@ function Embedding() {
               clearJob={() => {
                 setEmbeddingsJob(null);
               }}
+              killJob={(job) =>
+                apiService.killJob(dataset.id, job.id).then(setEmbeddingsJob).catch(console.error)
+              }
               rerunJob={handleRerunEmbedding}
             />
             {/* 

--- a/web/src/components/Setup/Embedding.jsx
+++ b/web/src/components/Setup/Embedding.jsx
@@ -15,7 +15,7 @@ import {
   modelSupportsImages,
   filterModelsForColumn,
 } from '../../lib/embeddingColumns';
-import { saeAvailable } from '../../lib/SAE';
+import { getSaeForModel } from '../../lib/SAE';
 import { debounce } from '../../utils';
 import SettingsModal from '../SettingsModal';
 
@@ -784,8 +784,8 @@ function Embedding() {
                       <br />
                     )}
 
-                    {saeAvailable[emb.model_id] ? (
-                      <Sae embedding={emb} model={saeAvailable[emb.model_id]} onSAE={handleSAE} />
+                    {getSaeForModel(emb.model_id) ? (
+                      <Sae embedding={emb} model={getSaeForModel(emb.model_id)} onSAE={handleSAE} />
                     ) : null}
                   </span>
                 </label>

--- a/web/src/components/Setup/Embedding.jsx
+++ b/web/src/components/Setup/Embedding.jsx
@@ -377,8 +377,10 @@ function Embedding() {
       const form = e.target;
       const data = new FormData(form);
       // const model = allModels.find(model => model.id === data.get('modelName'));
-      // prefix doesn't apply to image columns (the textarea is hidden)
-      const prefix = imageColumn ? '' : data.get('prefix');
+      // prefix doesn't apply to image columns (the textarea is hidden).
+      // Coerce a missing/empty value to "" so it never serializes to the string
+      // "null"/"undefined" (which would then be prepended to every document).
+      const prefix = imageColumn ? '' : (data.get('prefix') ?? '');
       let job = {
         text_column: textColumn,
         model_id: modelId,

--- a/web/src/components/Setup/Embedding.module.scss
+++ b/web/src/components/Setup/Embedding.module.scss
@@ -137,3 +137,9 @@
   cursor: wait;
 }
 
+
+.taskSelect {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 0.9em;
+}

--- a/web/src/components/Setup/Sae.jsx
+++ b/web/src/components/Setup/Sae.jsx
@@ -180,6 +180,7 @@ function Sae({ embedding, model, onSAE = () => {} }) {
         clearJob={() => {
           setSaeJob(null);
         }}
+        killJob={(job) => apiService.killJob(dataset.id, job.id).then(setSaeJob).catch(console.error)}
         rerunJob={handleRerunSae}
       />
       {/* 

--- a/web/src/components/Setup/Scope.jsx
+++ b/web/src/components/Setup/Scope.jsx
@@ -279,6 +279,9 @@ function Scope() {
               clearJob={() => {
                 setScopeJob(null);
               }}
+              killJob={(job) =>
+                apiService.killJob(dataset.id, job.id).then(setScopeJob).catch(console.error)
+              }
             />
 
             {(savedScope && !scopeJob && isDifferent) || newVersion ? (

--- a/web/src/components/Setup/SpriteAtlas.jsx
+++ b/web/src/components/Setup/SpriteAtlas.jsx
@@ -8,7 +8,7 @@ import { Link } from 'react-router-dom';
 import { Button } from 'react-element-forge';
 import { useStartJobPolling } from '../Job/Run';
 import JobProgress from '../Job/Progress';
-import { apiUrl } from '../../lib/apiService';
+import { apiService, apiUrl } from '../../lib/apiService';
 import { fetchAtlasStatus, fetchAtlasPlan } from '../../lib/atlasUrl';
 import { useSetup } from '../../contexts/SetupContext';
 import AtlasPlanPreview from './AtlasPlanPreview';
@@ -254,7 +254,11 @@ function SpriteAtlas() {
         />
       </div>
 
-      <JobProgress job={atlasJob} clearJob={() => setAtlasJob(null)} />
+      <JobProgress
+        job={atlasJob}
+        clearJob={() => setAtlasJob(null)}
+        killJob={(job) => apiService.killJob(dataset.id, job.id).then(setAtlasJob).catch(console.error)}
+      />
 
       {status.generated && (
         <div className={styles.summary}>

--- a/web/src/components/Setup/Umap.jsx
+++ b/web/src/components/Setup/Umap.jsx
@@ -327,7 +327,11 @@ function Umap() {
               text="New UMAP"
             ></Button>
 
-            <JobProgress job={umapJob} clearJob={() => setUmapJob(null)} />
+            <JobProgress
+              job={umapJob}
+              clearJob={() => setUmapJob(null)}
+              killJob={(job) => apiService.killJob(dataset.id, job.id).then(setUmapJob).catch(console.error)}
+            />
           </form>
         </div>
         {/* The list of available UMAPS */}

--- a/web/src/lib/SAE.js
+++ b/web/src/lib/SAE.js
@@ -9,3 +9,18 @@ export const saeAvailable = {
   // "🤗-sentence-transformers___all-MiniLM-L6-v2": {
   // }
 }
+
+// Strip the provider prefix from an embedding model id so lookups are
+// prefix-agnostic: the canonical "huggingface-" and the legacy "🤗-" /
+// "transformers-" ids all resolve to the same HF model name.
+const stripHFPrefix = (id) => (id || '').replace(/^(huggingface-|🤗-|transformers-)/, '');
+
+// Look up the pretrained SAE for an embedding model id, tolerant of which HF
+// prefix the id carries (the SAE map is keyed by the legacy emoji id).
+export function getSaeForModel(modelId) {
+  const norm = stripHFPrefix(modelId);
+  for (const [key, sae] of Object.entries(saeAvailable)) {
+    if (stripHFPrefix(key) === norm) return sae;
+  }
+  return null;
+}

--- a/web/src/lib/apiService.js
+++ b/web/src/lib/apiService.js
@@ -138,9 +138,9 @@ export const apiService = {
       // convert the HF data format to ours
       const hfm = data.map((d) => {
         return {
-          id: '🤗-' + d.id.replace('/', '___'),
+          id: 'huggingface-' + d.id.replace('/', '___'),
           name: d.id,
-          provider: '🤗',
+          provider: 'huggingface',
           downloads: d.downloads,
           params: {},
         };
@@ -160,9 +160,9 @@ export const apiService = {
         .filter((d) => d.tags.includes('conversational') && !d.tags.includes('gguf'))
         .map((d) => {
           return {
-            id: '🤗-' + d.id.replace('/', '___'),
+            id: 'huggingface-' + d.id.replace('/', '___'),
             name: d.id,
-            provider: '🤗',
+            provider: 'huggingface',
             downloads: d.downloads,
             params: {},
           };


### PR DESCRIPTION
## e2e polish batch (supersedes #136)

#136 was auto-closed when its base branch `example-datasets` was deleted during the #135 merge, and GitHub won't reopen a PR whose base is gone. Same commits, re-targeted at `main`.

Contains all the e2e-polish work verified while running the demo pipeline manually:
- Canonical `huggingface-` model ids from HF search; auto document-prompt with explicit-prefix precedence; **query prompt for search** (`embed_query`); `peft` dep; **task-conditioned model support** (jina-v3/v5) + UI task picker so the base checkpoints work.
- Kill button on every Setup step (+ `type=button` so it doesn't submit the form); robust CLI spawn; command-display spaces; atomic job-progress writes (fixes the flaky `TestKillJob`); expandable job logs.
- Codex review addressed: query-vs-document prompt, prefix-agnostic SAE lookup, marqo recipe (embed `image` column + atlas `image_column`).

Local suite: **203 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
