### PR TITLE
Fix nltk-top-words labeling on NLTK >= 3.9 (punkt_tab)

### DIFF
--- a/latentscope/models/providers/nltk.py
+++ b/latentscope/models/providers/nltk.py
@@ -19,6 +19,8 @@ class NLTKChatProvider(ChatModelProvider):
                 return " ".join(tokens)
 
         nltk.download('punkt')
+        # nltk >= 3.9 moved the pretrained tokenizer tables to punkt_tab
+        nltk.download('punkt_tab')
         nltk.download('stopwords')
         self.encoder = Encoder()
 


### PR DESCRIPTION
Hit while building the 1.0 demo datasets: `ls-label ... nltk-top-words` crashes with `LookupError: Resource 'punkt_tab' not found` on current NLTK, because 3.9 moved the pretrained tokenizer tables out of `punkt`. The provider now downloads `punkt_tab` alongside `punkt` and `stopwords`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)