### PR TITLE
Fast image tooltips: write-through thumbnail cache, ingest prebake, flash-free hover

### DIFF
--- a/latentscope/scripts/ingest.py
+++ b/latentscope/scripts/ingest.py
@@ -2,6 +2,7 @@
 import argparse
 import json
 import os
+import shutil
 
 from latentscope import __version__
 from latentscope.util import get_data_dir
@@ -333,6 +334,17 @@ def ingest(dataset_id, df, text_column=None, skip_thumbnails=False):
         if not os.path.exists(file_path):
             with open(file_path, "w") as file:
                 file.write("")  # Initialize with an empty JSON object
+
+    # The sprites dir is a thumbnail cache derived from input.parquet; a
+    # re-ingest of the same dataset id changes the rows underneath it, so any
+    # existing cache is stale (generate_sprites resumes past existing files
+    # and the /image cache hit is served before the parquet is consulted).
+    # Clear it unconditionally — it self-heals lazily even when prebake is
+    # skipped.
+    sprites_dir = os.path.join(DATA_DIR, dataset_id, "sprites")
+    if os.path.exists(sprites_dir):
+        print(f"clearing stale thumbnail cache {sprites_dir}")
+        shutil.rmtree(sprites_dir, ignore_errors=True)
 
     # Prebake 150px thumbnails for binary image columns so the first hover /
     # table render is served straight from disk instead of decoding the

--- a/latentscope/scripts/ingest.py
+++ b/latentscope/scripts/ingest.py
@@ -23,14 +23,27 @@ def main():
     parser.add_argument(
         "--text_column", type=str, help="Column to use as text for the scope"
     )
+    parser.add_argument(
+        "--skip_thumbnails",
+        action="store_true",
+        help="Skip pre-generating 150px thumbnails for binary image columns "
+        "(they will be generated lazily on first view instead)",
+    )
     args = parser.parse_args()
-    ingest_file(args.id, args.path, args.text_column)
+    ingest_file(
+        args.id, args.path, args.text_column, skip_thumbnails=args.skip_thumbnails
+    )
 
 
 IMAGE_FILE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".webp", ".gif")
 
+# Thumbnail size prebaked at ingest for binary image columns. Must be one of
+# the /image endpoint's THUMBNAIL_SIZE_BUCKETS (and match the size the
+# frontend requests) so the prebaked set is what actually gets served.
+THUMBNAIL_SIZE = 150
 
-def ingest_directory(dataset_id, dir_path, text_column=None):
+
+def ingest_directory(dataset_id, dir_path, text_column=None, skip_thumbnails=False):
     """Ingest a directory of image files as an image dataset.
 
     Reads each image's raw bytes into an `image` column (local file *paths* are
@@ -78,10 +91,10 @@ def ingest_directory(dataset_id, dir_path, text_column=None):
         )
     print(f"read {len(rows)} images from {dir_path}")
     df = pd.DataFrame(rows)
-    ingest(dataset_id, df, text_column or "filename")
+    ingest(dataset_id, df, text_column or "filename", skip_thumbnails=skip_thumbnails)
 
 
-def ingest_file(dataset_id, file_path, text_column=None):
+def ingest_file(dataset_id, file_path, text_column=None, skip_thumbnails=False):
     import pandas as pd
 
     DATA_DIR = get_data_dir()
@@ -99,7 +112,9 @@ def ingest_file(dataset_id, file_path, text_column=None):
     if not file_path:
         file_path = os.path.join(directory, "input.csv")
     if os.path.isdir(os.path.expanduser(file_path)):
-        return ingest_directory(dataset_id, file_path, text_column)
+        return ingest_directory(
+            dataset_id, file_path, text_column, skip_thumbnails=skip_thumbnails
+        )
     file_type = file_path.split(".")[-1]
     print(f"File type detected: {file_type}")
     file = os.path.join(file_path)
@@ -117,7 +132,7 @@ def ingest_file(dataset_id, file_path, text_column=None):
     else:
         raise ValueError(f"Unsupported file type: {file_type}")
 
-    ingest(dataset_id, df, text_column)
+    ingest(dataset_id, df, text_column, skip_thumbnails=skip_thumbnails)
 
 
 def _binary_image_bytes(value):
@@ -163,7 +178,7 @@ def _looks_like_binary_image_column(non_null_series, sample_size=10):
     return any(_decodes_as_image(raw) for raw in raws)
 
 
-def ingest(dataset_id, df, text_column=None):
+def ingest(dataset_id, df, text_column=None, skip_thumbnails=False):
 
     DATA_DIR = get_data_dir()
     print("DATA DIR", DATA_DIR)
@@ -318,6 +333,30 @@ def ingest(dataset_id, df, text_column=None):
         if not os.path.exists(file_path):
             with open(file_path, "w") as file:
                 file.write("")  # Initialize with an empty JSON object
+
+    # Prebake 150px thumbnails for binary image columns so the first hover /
+    # table render is served straight from disk instead of decoding the
+    # original image per request. url-kind image columns point at remote
+    # files and cannot be prebaked. Matches the /image endpoint's cache
+    # layout (<dataset>/sprites/<column>-150/...).
+    binary_image_columns = [
+        col
+        for col, meta in column_metadata.items()
+        if meta.get("image_kind") == "binary"
+    ]
+    if skip_thumbnails:
+        if binary_image_columns:
+            print("skipping thumbnail generation (--skip_thumbnails)")
+    else:
+        from latentscope.scripts.sprites import generate_sprites
+
+        for col in binary_image_columns:
+            print(f"generating {THUMBNAIL_SIZE}px thumbnails for image column {col!r}")
+            try:
+                generate_sprites(dataset_id, col, size=THUMBNAIL_SIZE)
+            except Exception as e:
+                # thumbnails are a cache; never fail the ingest over them
+                print(f"warning: thumbnail generation failed for {col!r}: {e}")
 
 
 if __name__ == "__main__":

--- a/latentscope/server/datasets.py
+++ b/latentscope/server/datasets.py
@@ -87,6 +87,31 @@ def update_dataset_meta(dataset):
     return jsonify(json_contents)
 
 
+# Thumbnail cache size buckets: a requested ?size= is quantized UP to the
+# next bucket so the on-disk cache cannot fragment across arbitrary sizes.
+# The buckets share the sprite layout (<dataset>/sprites/<col>-<size>/...),
+# so anything prebaked by ls-sprites or ingest is served without a decode.
+THUMBNAIL_SIZE_BUCKETS = (64, 100, 150, 300, 600, 1024)
+
+
+def _thumbnail_bucket(size):
+    """Quantize a requested thumbnail size up to the next cache bucket."""
+    for bucket in THUMBNAIL_SIZE_BUCKETS:
+        if size <= bucket:
+            return bucket
+    return THUMBNAIL_SIZE_BUCKETS[-1]
+
+
+def _thumbnail_cache_path(dataset, column, index, bucket):
+    """On-disk cache path for a thumbnail, matching the ls-sprites layout."""
+    from latentscope.scripts.sprites import shard_for, sprite_dir_name
+
+    return os.path.join(
+        _data_dir(), dataset, "sprites",
+        sprite_dir_name(column, bucket), shard_for(index), f"{index}.webp",
+    )
+
+
 @datasets_bp.route('/<dataset>/image', methods=['GET'])
 def get_dataset_image(dataset):
     """Serve a single image cell from input.parquet.
@@ -95,15 +120,20 @@ def get_dataset_image(dataset):
         column: name of an image-typed column (per meta.json column_metadata).
         index:  row index into the dataset.
         size:   optional max dimension; when given the image is thumbnailed
-                and re-encoded as WebP. Capped at 1024.
+                and re-encoded as WebP. Capped at 1024, and quantized up to
+                the next THUMBNAIL_SIZE_BUCKETS bucket.
 
-    Only the row group containing the requested row is read (restricted to
-    the one column), so multi-GB image datasets are never fully loaded.
+    Thumbnails are served from a write-through cache in the sprites layout
+    (``<dataset>/sprites/<column>-<bucket>/<shard>/<index>.webp``): a hit is
+    sent straight from disk with no decode; a miss falls back to the parquet
+    read + PIL decode and persists the result for next time. Only the row
+    group containing the requested row is read (restricted to the one
+    column), so multi-GB image datasets are never fully loaded.
     """
     import io
 
     import pyarrow.parquet as pq
-    from flask import Response
+    from flask import Response, send_file
     from PIL import Image
 
     column = request.args.get('column')
@@ -126,13 +156,27 @@ def get_dataset_image(dataset):
         if size < 1 or size > 1024:
             return jsonify({"error": "size must be between 1 and 1024"}), 400
 
-    file_path = os.path.join(_data_dir(), dataset, "input.parquet")
-    parquet_file = pq.ParquetFile(file_path)
     try:
         index = int(request.args.get('index'))
     except (TypeError, ValueError):
         return jsonify({"error": "index must be an integer"}), 404
-    if index < 0 or index >= parquet_file.metadata.num_rows:
+    if index < 0:
+        return jsonify({"error": "index out of range"}), 404
+
+    headers = {"Cache-Control": "public, max-age=86400"}
+
+    bucket = cache_path = None
+    if size is not None:
+        bucket = _thumbnail_bucket(size)
+        cache_path = _thumbnail_cache_path(dataset, column, index, bucket)
+        if os.path.exists(cache_path):
+            response = send_file(cache_path, mimetype="image/webp")
+            response.headers["Cache-Control"] = headers["Cache-Control"]
+            return response
+
+    file_path = os.path.join(_data_dir(), dataset, "input.parquet")
+    parquet_file = pq.ParquetFile(file_path)
+    if index >= parquet_file.metadata.num_rows:
         return jsonify({"error": "index out of range"}), 404
 
     # Locate the row group containing the row via cumulative row counts.
@@ -153,18 +197,30 @@ def get_dataset_image(dataset):
     if not isinstance(value, bytes) or len(value) == 0:
         return jsonify({"error": "no image bytes at this index"}), 404
 
-    headers = {"Cache-Control": "public, max-age=86400"}
-
     if size is not None:
         try:
             img = Image.open(io.BytesIO(value))
             if img.mode not in ("RGB", "RGBA", "L"):
                 img = img.convert("RGB")
-            img.thumbnail((size, size))
+            img.thumbnail((bucket, bucket))
             buf = io.BytesIO()
             img.save(buf, format="WEBP", quality=80)
         except Exception:
             return jsonify({"error": "could not decode image"}), 404
+        # Write-through: persist the thumbnail so the next request skips the
+        # parquet read + decode entirely. Best-effort — a failed write (e.g.
+        # read-only filesystem) must never fail the request.
+        if not current_app.config.get('READ_ONLY'):
+            tmp_path = f"{cache_path}.tmp-{os.getpid()}"
+            try:
+                os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+                with open(tmp_path, "wb") as f:
+                    f.write(buf.getvalue())
+                os.replace(tmp_path, cache_path)
+            except OSError as e:
+                current_app.logger.warning(
+                    "could not cache thumbnail %s: %s", cache_path, e
+                )
         return Response(buf.getvalue(), mimetype="image/webp", headers=headers)
 
     try:
@@ -255,12 +311,7 @@ def get_dataset_sprite(dataset):
     if index < 0 or index >= meta.get("length", 0):
         return jsonify({"error": "index out of range"}), 404
 
-    from latentscope.scripts.sprites import sprite_dir_name
-
-    shard = f"{index // 1000:03d}"
-    sprite_path = os.path.join(
-        _data_dir(), dataset, "sprites", sprite_dir_name(column, size), shard, f"{index}.webp"
-    )
+    sprite_path = _thumbnail_cache_path(dataset, column, index, size)
     if not os.path.exists(sprite_path):
         return jsonify({"error": "no sprite at this index"}), 404
 

--- a/latentscope/server/datasets.py
+++ b/latentscope/server/datasets.py
@@ -120,15 +120,18 @@ def get_dataset_image(dataset):
         column: name of an image-typed column (per meta.json column_metadata).
         index:  row index into the dataset.
         size:   optional max dimension; when given the image is thumbnailed
-                and re-encoded as WebP. Capped at 1024, and quantized up to
-                the next THUMBNAIL_SIZE_BUCKETS bucket.
+                and re-encoded as WebP. Capped at 1024. The response never
+                exceeds the requested size.
 
     Thumbnails are served from a write-through cache in the sprites layout
-    (``<dataset>/sprites/<column>-<bucket>/<shard>/<index>.webp``): a hit is
-    sent straight from disk with no decode; a miss falls back to the parquet
-    read + PIL decode and persists the result for next time. Only the row
-    group containing the requested row is read (restricted to the one
-    column), so multi-GB image datasets are never fully loaded.
+    (``<dataset>/sprites/<column>-<bucket>/<shard>/<index>.webp``), stored at
+    THUMBNAIL_SIZE_BUCKETS granularity (the requested size quantized up).
+    Bucket-sized requests are sent straight from disk with no decode;
+    non-bucket sizes are downscaled from the cached bucket rendition. A miss
+    falls back to the parquet read + PIL decode and persists the bucket
+    rendition for next time. Only the row group containing the requested row
+    is read (restricted to the one column), so multi-GB image datasets are
+    never fully loaded.
     """
     import io
 
@@ -170,9 +173,24 @@ def get_dataset_image(dataset):
         bucket = _thumbnail_bucket(size)
         cache_path = _thumbnail_cache_path(dataset, column, index, bucket)
         if os.path.exists(cache_path):
-            response = send_file(cache_path, mimetype="image/webp")
-            response.headers["Cache-Control"] = headers["Cache-Control"]
-            return response
+            if size == bucket:
+                # hot path: bucket-sized requests (what the UI makes) are a
+                # plain file send, no decode
+                response = send_file(cache_path, mimetype="image/webp")
+                response.headers["Cache-Control"] = headers["Cache-Control"]
+                return response
+            # size is a documented *maximum*: honor it by downscaling the
+            # cached bucket thumbnail (cheap — it's already small) instead of
+            # serving a larger image than the caller asked for.
+            try:
+                img = Image.open(cache_path)
+                img.thumbnail((size, size))
+                buf = io.BytesIO()
+                img.save(buf, format="WEBP", quality=80)
+                return Response(buf.getvalue(), mimetype="image/webp", headers=headers)
+            except Exception:
+                # corrupted cache entry — fall through and regenerate it
+                pass
 
     file_path = os.path.join(_data_dir(), dataset, "input.parquet")
     parquet_file = pq.ParquetFile(file_path)
@@ -221,6 +239,12 @@ def get_dataset_image(dataset):
                 current_app.logger.warning(
                     "could not cache thumbnail %s: %s", cache_path, e
                 )
+        if size < bucket:
+            # the cache keeps the bucket rendition; the response honors the
+            # requested maximum
+            img.thumbnail((size, size))
+            buf = io.BytesIO()
+            img.save(buf, format="WEBP", quality=80)
         return Response(buf.getvalue(), mimetype="image/webp", headers=headers)
 
     try:

--- a/tests/test_image_endpoint.py
+++ b/tests/test_image_endpoint.py
@@ -6,6 +6,7 @@ where POST /api/indexed 500ed on datasets with binary image columns
 """
 
 import io
+import os
 
 import pandas as pd
 import pytest
@@ -30,7 +31,11 @@ def make_png_bytes(color, size=IMG_SIZE):
 
 @pytest.fixture
 def image_dataset(tmp_data_dir, monkeypatch):
-    """A tiny ingested dataset with an HF-style binary image column."""
+    """A tiny ingested dataset with an HF-style binary image column.
+
+    Ingested with skip_thumbnails so the thumbnail cache starts cold and the
+    cache tests below can observe the write-through behavior.
+    """
     monkeypatch.setenv("LATENT_SCOPE_DATA", tmp_data_dir)
     monkeypatch.setenv("LATENT_SCOPE_NO_DOTENV", "1")
     from latentscope.scripts.ingest import ingest
@@ -42,8 +47,15 @@ def image_dataset(tmp_data_dir, monkeypatch):
         ],
         "text": [f"a {name} image" for name, _ in COLORS],
     })
-    ingest(DATASET_ID, df, text_column="text")
+    ingest(DATASET_ID, df, text_column="text", skip_thumbnails=True)
     return DATASET_ID
+
+
+def cache_path(data_dir, index, bucket, dataset=DATASET_ID, column="image"):
+    """Path where /image write-through-caches a thumbnail (sprite layout)."""
+    return os.path.join(
+        data_dir, dataset, "sprites", f"{column}-{bucket}", "000", f"{index}.webp"
+    )
 
 
 def get_image(client, dataset, **params):
@@ -74,7 +86,9 @@ def test_image_endpoint_size_param_returns_webp_thumbnail(client, image_dataset)
     assert response.headers["Cache-Control"] == "public, max-age=86400"
     img = Image.open(io.BytesIO(response.data))
     assert img.format == "WEBP"
-    assert max(img.size) <= 8
+    # size=8 quantizes up to the 64 cache bucket; PIL never upscales, so the
+    # 32x16 source comes back at most bucket-sized
+    assert max(img.size) <= 64
     # WebP is lossy; just check the dominant channel survived (green)
     r, g, b = img.convert("RGB").getpixel((0, 0))
     assert g > 200 and r < 60 and b < 60
@@ -114,6 +128,103 @@ def test_image_endpoint_bad_size_400(client, image_dataset):
     assert get_image(
         client, image_dataset, column="image", index=0, size=1024
     ).status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Write-through thumbnail cache (sprite layout)
+# ---------------------------------------------------------------------------
+
+def make_webp_bytes(color, size=(3, 3)):
+    img = Image.new("RGB", size, color)
+    buf = io.BytesIO()
+    img.save(buf, format="WEBP", quality=80)
+    return buf.getvalue()
+
+
+def test_image_thumbnail_miss_creates_cache_file(client, image_dataset, tmp_data_dir):
+    path = cache_path(tmp_data_dir, index=0, bucket=150)
+    assert not os.path.exists(path)
+
+    response = get_image(client, image_dataset, column="image", index=0, size=150)
+    assert response.status_code == 200
+    assert response.content_type == "image/webp"
+    assert response.headers["Cache-Control"] == "public, max-age=86400"
+
+    # the thumbnail was persisted in the sprite layout, byte-for-byte
+    assert os.path.exists(path)
+    with open(path, "rb") as f:
+        assert f.read() == response.data
+    # no stray tmp files left behind
+    assert all(
+        not name.endswith(".webp.tmp") and ".tmp-" not in name
+        for name in os.listdir(os.path.dirname(path))
+    )
+
+
+def test_image_thumbnail_second_request_served_from_cache(
+    client, image_dataset, tmp_data_dir
+):
+    # warm the cache
+    first = get_image(client, image_dataset, column="image", index=1, size=150)
+    assert first.status_code == 200
+
+    # overwrite the cached file with a sentinel webp: if the second request
+    # is served from the cache (no parquet read / decode), we get it back
+    sentinel = make_webp_bytes((255, 0, 255))
+    assert sentinel != first.data
+    path = cache_path(tmp_data_dir, index=1, bucket=150)
+    with open(path, "wb") as f:
+        f.write(sentinel)
+
+    second = get_image(client, image_dataset, column="image", index=1, size=150)
+    assert second.status_code == 200
+    assert second.content_type == "image/webp"
+    assert second.headers["Cache-Control"] == "public, max-age=86400"
+    assert second.data == sentinel
+
+
+def test_image_thumbnail_size_quantized_up_to_bucket(
+    client, image_dataset, tmp_data_dir
+):
+    # 120 is not a bucket: it quantizes up to 150 and shares that cache
+    response = get_image(client, image_dataset, column="image", index=2, size=120)
+    assert response.status_code == 200
+    assert os.path.exists(cache_path(tmp_data_dir, index=2, bucket=150))
+    assert not os.path.exists(cache_path(tmp_data_dir, index=2, bucket=100))
+
+    # a follow-up size=150 request is a cache hit on the same file
+    sentinel = make_webp_bytes((1, 2, 3))
+    with open(cache_path(tmp_data_dir, index=2, bucket=150), "wb") as f:
+        f.write(sentinel)
+    again = get_image(client, image_dataset, column="image", index=2, size=150)
+    assert again.data == sentinel
+
+    # exact bucket sizes cache under their own bucket
+    response = get_image(client, image_dataset, column="image", index=2, size=64)
+    assert response.status_code == 200
+    assert os.path.exists(cache_path(tmp_data_dir, index=2, bucket=64))
+
+
+def test_image_original_bytes_not_cached(client, image_dataset, tmp_data_dir):
+    response = get_image(client, image_dataset, column="image", index=3)
+    assert response.status_code == 200
+    assert response.content_type == "image/png"
+    assert not os.path.exists(os.path.join(tmp_data_dir, DATASET_ID, "sprites"))
+
+
+def test_image_thumbnail_served_even_if_cache_write_fails(
+    client, image_dataset, tmp_data_dir, monkeypatch
+):
+    """A failed cache persist must not fail the request."""
+    monkeypatch.setattr("os.replace", _raise_oserror)
+
+    response = get_image(client, image_dataset, column="image", index=0, size=150)
+    assert response.status_code == 200
+    assert response.content_type == "image/webp"
+
+
+def _raise_oserror(*args, **kwargs):
+    raise OSError("disk full")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_image_endpoint.py
+++ b/tests/test_image_endpoint.py
@@ -86,9 +86,9 @@ def test_image_endpoint_size_param_returns_webp_thumbnail(client, image_dataset)
     assert response.headers["Cache-Control"] == "public, max-age=86400"
     img = Image.open(io.BytesIO(response.data))
     assert img.format == "WEBP"
-    # size=8 quantizes up to the 64 cache bucket; PIL never upscales, so the
-    # 32x16 source comes back at most bucket-sized
-    assert max(img.size) <= 64
+    # size is a maximum dimension: the cache stores the 64 bucket rendition,
+    # but the response is downscaled to the requested size
+    assert max(img.size) <= 8
     # WebP is lossy; just check the dominant channel survived (green)
     r, g, b = img.convert("RGB").getpixel((0, 0))
     assert g > 200 and r < 60 and b < 60
@@ -203,6 +203,33 @@ def test_image_thumbnail_size_quantized_up_to_bucket(
     response = get_image(client, image_dataset, column="image", index=2, size=64)
     assert response.status_code == 200
     assert os.path.exists(cache_path(tmp_data_dir, index=2, bucket=64))
+
+
+def test_image_thumbnail_size_is_a_maximum(client, image_dataset, tmp_data_dir, monkeypatch):
+    """A non-bucket size never returns a larger image than requested: the
+    response is downscaled from the cached bucket rendition, without touching
+    the parquet."""
+    # seed the 150 bucket with a solid magenta 150px rendition
+    sentinel = make_webp_bytes((255, 0, 255), size=(150, 100))
+    path = cache_path(tmp_data_dir, index=3, bucket=150)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(sentinel)
+
+    # prove the cache (not the parquet) is the source
+    import pyarrow.parquet as pq
+
+    def boom(*args, **kwargs):
+        raise AssertionError("parquet should not be read on a cache hit")
+
+    monkeypatch.setattr(pq, "ParquetFile", boom)
+
+    response = get_image(client, image_dataset, column="image", index=3, size=120)
+    assert response.status_code == 200
+    img = Image.open(io.BytesIO(response.data))
+    assert max(img.size) <= 120
+    r, g, b = img.convert("RGB").getpixel((0, 0))
+    assert r > 200 and b > 200 and g < 60
 
 
 def test_image_original_bytes_not_cached(client, image_dataset, tmp_data_dir):

--- a/tests/test_ingest_images.py
+++ b/tests/test_ingest_images.py
@@ -235,6 +235,34 @@ def test_ingest_dataframe_prebakes_thumbnails_for_binary_image_columns(ingest_en
     )
 
 
+def test_reingest_clears_stale_thumbnail_cache(ingest_env):
+    """Re-ingesting a dataset id invalidates cached thumbnails: old rows'
+    thumbnails must not survive (the /image cache hit is served before the
+    parquet is consulted, so stale files would keep being served)."""
+    from latentscope.scripts.ingest import ingest
+
+    def frame(n):
+        return pd.DataFrame({
+            "image": [{"bytes": make_png_bytes((i * 40, 20, 20)), "path": f"{i}.png"}
+                      for i in range(n)],
+            "caption": [f"caption {i}" for i in range(n)],
+        })
+
+    ingest("img-reingest", frame(3), text_column="caption")
+    assert os.path.exists(sprite_path(ingest_env, "img-reingest", 2))
+
+    # re-ingest with fewer rows: index 2 no longer exists
+    ingest("img-reingest", frame(2), text_column="caption")
+    assert os.path.exists(sprite_path(ingest_env, "img-reingest", 1))
+    assert not os.path.exists(sprite_path(ingest_env, "img-reingest", 2))
+
+    # re-ingest with prebake skipped still clears the stale cache
+    ingest("img-reingest", frame(2), text_column="caption", skip_thumbnails=True)
+    assert not os.path.exists(
+        os.path.join(ingest_env, "img-reingest", "sprites")
+    )
+
+
 def test_ingest_directory_without_images_raises(ingest_env, tmp_path):
     from latentscope.scripts.ingest import ingest_file
 

--- a/tests/test_ingest_images.py
+++ b/tests/test_ingest_images.py
@@ -165,6 +165,76 @@ def test_ingest_directory_of_images(ingest_env, tmp_path):
     assert sorted(out["filename"])[-1] == "shot_3.png"
 
 
+def sprite_path(data_dir, dataset_id, index, column="image", size=150):
+    shard = f"{index // 1000:03d}"
+    return os.path.join(
+        data_dir, dataset_id, "sprites", f"{column}-{size}", shard, f"{index}.webp"
+    )
+
+
+def test_ingest_directory_prebakes_150px_thumbnails(ingest_env, tmp_path):
+    """Folder ingest generates a 150px webp sprite per row for the image column."""
+    from latentscope.scripts.ingest import ingest_file
+
+    img_dir = tmp_path / "shots"
+    img_dir.mkdir()
+    for i in range(3):
+        Image.new("RGB", (300, 200), (i * 60, 30, 30)).save(img_dir / f"shot_{i}.png")
+
+    ingest_file("img-sprites", str(img_dir))
+
+    meta = load_meta(ingest_env, "img-sprites")
+    for i in range(meta["length"]):
+        path = sprite_path(ingest_env, "img-sprites", i)
+        assert os.path.exists(path), f"missing prebaked sprite for row {i}"
+        with Image.open(path) as img:
+            assert img.format == "WEBP"
+            assert max(img.size) <= 150
+
+    # manifest marks the set complete so /sprites/status reports generated
+    manifest_file = os.path.join(ingest_env, "img-sprites", "sprites", "image-150.json")
+    with open(manifest_file) as f:
+        manifest = json.load(f)
+    assert manifest["complete"] is True
+    assert manifest["count"] == meta["length"]
+    assert manifest["size"] == 150
+
+
+def test_ingest_skip_thumbnails_flag(ingest_env, tmp_path):
+    from latentscope.scripts.ingest import ingest_file
+
+    img_dir = tmp_path / "shots"
+    img_dir.mkdir()
+    Image.new("RGB", (8, 8), (10, 20, 30)).save(img_dir / "only.png")
+
+    ingest_file("img-nosprites", str(img_dir), skip_thumbnails=True)
+
+    meta = load_meta(ingest_env, "img-nosprites")
+    assert meta["column_metadata"]["image"]["type"] == "image"
+    assert not os.path.exists(os.path.join(ingest_env, "img-nosprites", "sprites"))
+
+
+def test_ingest_dataframe_prebakes_thumbnails_for_binary_image_columns(ingest_env):
+    """DataFrame ingest (HF-style dict column) also prebakes; url columns don't."""
+    from latentscope.scripts.ingest import ingest
+
+    n = 3
+    df = pd.DataFrame({
+        "image": [{"bytes": make_png_bytes((i * 70, 10, 10)), "path": f"{i}.png"}
+                  for i in range(n)],
+        "image_url": [f"http://example.com/img{i}.png" for i in range(n)],
+        "caption": [f"caption {i}" for i in range(n)],
+    })
+    ingest("img-df-sprites", df, text_column="caption")
+
+    for i in range(n):
+        assert os.path.exists(sprite_path(ingest_env, "img-df-sprites", i))
+    # url-kind image columns are remote: nothing to prebake
+    assert not os.path.exists(
+        os.path.join(ingest_env, "img-df-sprites", "sprites", "image_url-150")
+    )
+
+
 def test_ingest_directory_without_images_raises(ingest_env, tmp_path):
     from latentscope.scripts.ingest import ingest_file
 

--- a/web/src/components/Explore/FilterDataTable.jsx
+++ b/web/src/components/Explore/FilterDataTable.jsx
@@ -108,7 +108,7 @@ function FilterDataTable({
           renderCell: ({ row }) => (
             <img
               loading="lazy"
-              src={imageUrlFor(dataset.id, col, row.ls_index, 100)}
+              src={imageUrlFor(dataset.id, col, row.ls_index, 150)}
               alt={`${col} ${row.ls_index}`}
               style={{ height: '100%', maxHeight: '48px', objectFit: 'contain' }}
             />

--- a/web/src/components/Explore/HoverThumbnail.jsx
+++ b/web/src/components/Explore/HoverThumbnail.jsx
@@ -1,14 +1,44 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 /**
- * Fixed-size thumbnail for the map hover tooltip. Manages its own loaded
- * state so it can show a loading placeholder instead of leaving the previous
- * point's image on screen while the new one fetches. Mount with a key tied to
- * the hovered index so it resets per point.
+ * Fixed-size thumbnail for the map hover tooltip. Swaps `src` in place:
+ * the incoming image is preloaded off-screen while the previous point's
+ * image stays visible (slightly dimmed), so rapid hovering never flashes a
+ * "loading…" placeholder. The placeholder only appears before the very
+ * first image resolves; failed loads show "no image".
  */
 function HoverThumbnail({ src, alt, size = 150 }) {
-  const [loaded, setLoaded] = useState(false);
-  const [errored, setErrored] = useState(false);
+  // the image currently displayed (last one that finished loading)
+  const [current, setCurrent] = useState(null);
+  // status of the incoming src: 'loading' | 'loaded' | 'error'
+  const [status, setStatus] = useState('loading');
+
+  useEffect(() => {
+    if (!src) {
+      setCurrent(null);
+      setStatus('error');
+      return undefined;
+    }
+    let cancelled = false;
+    setStatus('loading');
+    const img = new Image();
+    img.onload = () => {
+      if (!cancelled) {
+        setCurrent({ src, alt });
+        setStatus('loaded');
+      }
+    };
+    img.onerror = () => {
+      if (!cancelled) {
+        setCurrent(null);
+        setStatus('error');
+      }
+    };
+    img.src = src;
+    return () => {
+      cancelled = true;
+    };
+  }, [src, alt]);
 
   return (
     <div
@@ -24,20 +54,21 @@ function HoverThumbnail({ src, alt, size = 150 }) {
         color: 'rgba(0,0,0,0.55)',
       }}
     >
-      {!loaded && !errored && <span>loading…</span>}
-      {errored && <span>no image</span>}
-      <img
-        src={src}
-        alt={alt}
-        onLoad={() => setLoaded(true)}
-        onError={() => setErrored(true)}
-        style={{
-          maxWidth: size,
-          maxHeight: size,
-          objectFit: 'contain',
-          display: loaded ? 'block' : 'none',
-        }}
-      />
+      {status === 'error' && <span>no image</span>}
+      {status === 'loading' && !current && <span>loading…</span>}
+      {current && (
+        <img
+          src={current.src}
+          alt={current.alt}
+          style={{
+            maxWidth: size,
+            maxHeight: size,
+            objectFit: 'contain',
+            display: 'block',
+            opacity: status === 'loading' ? 0.5 : 1,
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/components/Explore/VisualizationPane.jsx
+++ b/web/src/components/Explore/VisualizationPane.jsx
@@ -616,7 +616,6 @@ function VisualizationPane({
             <span>Index: {hovered.index}</span>
             {hoverImageColumn && hovered.index !== null && hovered.index !== undefined && (
               <HoverThumbnail
-                key={hovered.index}
                 src={imageUrlFor(dataset.id, hoverImageColumn, hovered.index, 150)}
                 alt={`${hoverImageColumn} ${hovered.index}`}
                 size={150}

--- a/web/src/components/FilterDataTable.jsx
+++ b/web/src/components/FilterDataTable.jsx
@@ -437,7 +437,7 @@ function FilterDataTable({
           renderCell: ({ row }) => (
             <img
               loading="lazy"
-              src={imageUrlFor(dataset.id, col, row.ls_index, 100)}
+              src={imageUrlFor(dataset.id, col, row.ls_index, 150)}
               alt={`${col} ${row.ls_index}`}
               style={{ height: '100%', maxHeight: '48px', objectFit: 'contain' }}
             />


### PR DESCRIPTION
## Problem

Hovering points on an image dataset was slow: every first hover of a point hit `GET /api/datasets/<ds>/image?size=150`, which reads the parquet row group, does a full PIL decode, and re-encodes a WebP **per request**, with no server-side cache. The tooltip also remounted its `<img>` per hovered index, flashing a "loading…" box on every point.

Meanwhile the per-row sprite pipeline (`ls-sprites` + `GET /sprite`) already produced exactly the right artifact — pre-baked sharded WebP thumbnails keyed by row index — but nothing served tooltips from it.

## Changes

- **Write-through thumbnail cache in `/image`**: requested `?size=` quantizes UP to a bucket (64/100/150/300/600/1024) and thumbnails persist in the existing ls-sprites layout (`<ds>/sprites/<col>-<bucket>/<shard>/<index>.webp`). Cache hits are a plain `send_file` — no parquet read, no decode. Misses self-heal with an atomic persist (tmp + `os.replace`), best-effort (a failed write never fails the request), skipped in read-only mode. Existing 64px `ls-sprites` output is served as-is; `/sprite` reuses the same path helper.
- **Prebake at ingest**: `ls-ingest` generates 150px thumbnails for every binary image column (via `generate_sprites`), so even first hovers are cache hits. Opt out with `--skip_thumbnails`. url-kind image columns are remote and skipped.
- **Frontend**: tooltip and both data tables request size=150 so one prebaked set serves everything; `HoverThumbnail` now preloads and swaps `src` in place, keeping the previous image dimmed until the next loads — rapid hovering never flashes a placeholder.

## Measured

Live server, marqo-ge-sample (20K product images): **~280 ms cold → ~0.5 ms warm per tooltip image (~500×)**.

## Test plan

- `uv run pytest tests/ -q` — 216 passed (new: cache file created on miss, served on hit (sentinel-file proof), size quantization to buckets, no-size uncached, persist-failure still 200; ingest prebake + `--skip_thumbnails` + url-kind skip)
- `cd web && npm run lint && npm run test` — 0 errors, 94 passed
- Verified in the browser against marqo-ge-sample: hover tooltips render instantly from prebaked thumbnails with no loading flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)