### PR TITLE
Point detail drawer in Explore: click a point or table row to see the full row

### DIFF
--- a/web/src/components/Explore/FilterDataTable.jsx
+++ b/web/src/components/Explore/FilterDataTable.jsx
@@ -20,7 +20,7 @@ FilterDataTable.propTypes = {
   onClick: PropTypes.func,
 };
 
-function RowWithHover({ props, onHover }) {
+function RowWithHover({ props, onHover, onClick }) {
   const { row } = props;
   const { ls_index } = row;
   return (
@@ -32,6 +32,12 @@ function RowWithHover({ props, onHover }) {
       }}
       onMouseLeave={() => {
         onHover(null);
+      }}
+      onClick={(event) => {
+        // Ignore clicks on interactive cell content: links, buttons, and the
+        // SAE feature plot canvas (which opens its own modal).
+        if (event.target.closest('a, button, canvas')) return;
+        onClick(ls_index);
       }}
     />
   );
@@ -46,6 +52,7 @@ function FilterDataTable({
   feature = -1,
   features = [],
   onHover = () => {},
+  onClick = () => {},
 }) {
   const { dataTableRows, page, setPage, totalPages, loading } = useFilter();
 
@@ -230,9 +237,9 @@ function FilterDataTable({
 
   const renderRowWithHover = useCallback(
     (key, props) => {
-      return <RowWithHover key={key} props={props} onHover={onHover} />;
+      return <RowWithHover key={key} props={props} onHover={onHover} onClick={onClick} />;
     },
-    [onHover]
+    [onHover, onClick]
   );
 
   return (

--- a/web/src/components/Explore/MobileFilterDataTable.jsx
+++ b/web/src/components/Explore/MobileFilterDataTable.jsx
@@ -4,32 +4,46 @@ import styles from './MobileFilterDataTable.module.scss';
 import { useFilter } from '@/contexts/FilterContext';
 import { useScope } from '@/contexts/ScopeContext';
 import ClusterIcon from './Search/ClusterIcon';
+import PointDetailContent from './PointDetailContent';
 
-const DataRow = memo(function DataRow({ dataset, row, onHover, clusterMap, index }) {
+const DataRow = memo(function DataRow({ dataset, row, onHover, clusterMap, index, onExpanded }) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const expand = useCallback(() => setIsExpanded(!isExpanded), [isExpanded]);
+  const toggle = useCallback(() => {
+    setIsExpanded((prev) => {
+      const next = !prev;
+      if (next) onExpanded?.();
+      return next;
+    });
+  }, [onExpanded]);
 
   return (
     <div
       className={`${styles.dataRow} ${isExpanded ? styles.expanded : ''}`}
       onMouseEnter={() => onHover(row.ls_index)}
       onMouseLeave={() => onHover(null)}
-      onClick={expand}
     >
-      <div className={styles.rowIndex}>
-        <div className={styles.indexCircle}>{index + 1}</div>
-      </div>
-      <div className={styles.rowPreview}>
-        <div className={`${styles.rowText} ${isExpanded ? styles.expandedText : ''}`}>
-          {row[dataset.text_column]}
+      {/* Tap the header to expand/collapse; the detail body below is the
+          same per-datatype view as the desktop drawer. */}
+      <div className={styles.rowHeader} onClick={toggle}>
+        <div className={styles.rowIndex}>
+          <div className={styles.indexCircle}>{index + 1}</div>
         </div>
-        <div className={styles.rowCluster}>
-          <p className={styles.textPreview}>
-            <ClusterIcon cluster={row.ls_cluster} />
-            {clusterMap[row.ls_index]?.label}
-          </p>
+        <div className={styles.rowPreview}>
+          <div className={styles.rowText}>{row[dataset.text_column]}</div>
+          <div className={styles.rowCluster}>
+            <p className={styles.textPreview}>
+              <ClusterIcon cluster={row.ls_cluster} />
+              {clusterMap[row.ls_index]?.label}
+            </p>
+          </div>
         </div>
+        <div className={styles.rowChevron}>{isExpanded ? '▾' : '▸'}</div>
       </div>
+      {isExpanded && (
+        <div className={styles.rowDetail} onClick={(e) => e.stopPropagation()}>
+          <PointDetailContent row={row} index={row.ls_index} />
+        </div>
+      )}
     </div>
   );
 });
@@ -62,6 +76,12 @@ function MobileFilterDataTable({ dataset, onHover = () => {}, onClick }) {
   const handleTouchEnd = () => {
     setIsDragging(false);
   };
+
+  // When a row expands, make sure the sheet is tall enough to actually see
+  // the detail (images especially) without having to drag it up first.
+  const handleRowExpanded = useCallback(() => {
+    setContainerHeight((height) => Math.max(height, Math.min(520, window.innerHeight * 0.6)));
+  }, []);
 
   if (dataTableRows.length === 0) {
     return null;
@@ -106,6 +126,7 @@ function MobileFilterDataTable({ dataset, onHover = () => {}, onClick }) {
                 onClick={onClick}
                 dataset={dataset}
                 clusterMap={clusterMap}
+                onExpanded={handleRowExpanded}
               />
             ))}
           </div>

--- a/web/src/components/Explore/MobileFilterDataTable.module.scss
+++ b/web/src/components/Explore/MobileFilterDataTable.module.scss
@@ -65,9 +65,7 @@
   user-select: none;
   -webkit-touch-callout: none;
   display: flex;
-  flex-direction: row;
-  gap: 8px;
-  align-items: flex-start;
+  flex-direction: column;
   transition: all 0.2s ease-out;
 }
 
@@ -77,6 +75,33 @@
   border-bottom: 1px solid #eee;
 }
 
+.rowHeader {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  align-items: flex-start;
+  cursor: pointer;
+}
+
+.rowChevron {
+  margin-left: auto;
+  padding: 0 4px;
+  color: #888;
+  flex-shrink: 0;
+}
+
+// The expanded body reuses the desktop drawer's detail view (images with
+// lightbox, text block, per-type field list).
+.rowDetail {
+  padding: 8px 4px 4px 26px;
+  user-select: text;
+  -webkit-user-select: text;
+
+  img {
+    max-width: 100%;
+  }
+}
+
 .rowText {
   font-size: 16px;
   overflow: hidden;
@@ -84,14 +109,6 @@
   white-space: nowrap;
   transition: all 0.2s ease-out;
   max-width: calc(100vw - 80px);
-}
-
-.rowText.expandedText {
-  white-space: normal;
-  text-overflow: clip;
-  max-height: none;
-  line-height: 1.4;
-  padding: 4px 0;
 }
 
 .rowCluster {

--- a/web/src/components/Explore/PointDetail.jsx
+++ b/web/src/components/Explore/PointDetail.jsx
@@ -1,0 +1,220 @@
+import { useState, useEffect, useMemo, useRef } from 'react';
+import { Modal, Button } from 'react-element-forge';
+
+import { apiService } from '../../lib/apiService';
+import { imageUrlFor } from '../../lib/imageUrl';
+import { organizeDetailColumns, describeCellValue, formatDetailNumber } from '../../lib/pointDetail';
+import { useScope } from '../../contexts/ScopeContext';
+
+import styles from './PointDetail.module.scss';
+
+// Drawer width for inline images; the lightbox fetches the original.
+const DRAWER_IMAGE_SIZE = 600;
+
+function DetailValue({ cell }) {
+  if (cell.kind === 'empty') return <span className={styles.empty}>—</span>;
+  if (cell.kind === 'url') {
+    return (
+      <a href={cell.value} target="_blank" rel="noreferrer">
+        {cell.value}
+      </a>
+    );
+  }
+  if (cell.kind === 'array' || cell.kind === 'object') {
+    const summary =
+      cell.kind === 'array'
+        ? `${cell.value.length} item${cell.value.length === 1 ? '' : 's'}`
+        : 'object';
+    return (
+      <details className={styles.expandable}>
+        <summary>{summary}</summary>
+        <pre>{JSON.stringify(cell.value, null, 2)}</pre>
+      </details>
+    );
+  }
+  return <span>{cell.display}</span>;
+}
+
+/**
+ * Right-side drawer showing every column of a single clicked row: images
+ * large (with a click-to-original lightbox), the main text prominently, and
+ * the remaining columns as a definition list formatted per data type.
+ */
+function PointDetail({ selectedIndex, onClose }) {
+  const { dataset, sae, clusterMap } = useScope();
+
+  const [row, setRow] = useState(null);
+  const [loading, setLoading] = useState(false);
+  // { src, alt, href? } for the full-size image modal
+  const [lightbox, setLightbox] = useState(null);
+  // Guard against stale async responses when the selection changes quickly.
+  const latestIndexRef = useRef(null);
+
+  const isOpen = selectedIndex !== null && selectedIndex !== undefined;
+
+  useEffect(() => {
+    if (!isOpen || !dataset?.id) {
+      latestIndexRef.current = null;
+      setRow(null);
+      setLightbox(null);
+      return;
+    }
+    latestIndexRef.current = selectedIndex;
+    setLightbox(null);
+    setLoading(true);
+    apiService
+      .fetchDataFromIndices(dataset.id, [selectedIndex], sae?.id ?? null)
+      .then((rows) => {
+        if (latestIndexRef.current !== selectedIndex) return;
+        setRow(rows?.[0] ?? null);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (latestIndexRef.current !== selectedIndex) return;
+        setRow(null);
+        setLoading(false);
+      });
+  }, [isOpen, selectedIndex, dataset?.id, sae?.id]);
+
+  // Escape closes the lightbox first, then the drawer.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (event) => {
+      if (event.key !== 'Escape') return;
+      if (lightbox) {
+        setLightbox(null);
+      } else {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, lightbox, onClose]);
+
+  const { imageColumns, textColumn, listColumns } = useMemo(
+    () => organizeDetailColumns(dataset),
+    [dataset]
+  );
+
+  const cluster = isOpen ? clusterMap?.[selectedIndex] : null;
+  const metadata = dataset?.column_metadata || {};
+
+  return (
+    <div className={`${styles.drawer} ${isOpen ? styles.open : ''}`}>
+      <div className={styles.header}>
+        <div className={styles.headerText}>
+          <span className={styles.title}>Row {isOpen ? selectedIndex : ''}</span>
+          {cluster?.label && <span className={styles.cluster}>{cluster.label}</span>}
+        </div>
+        <Button
+          className={styles.closeButton}
+          onClick={onClose}
+          aria-label="Close point detail"
+          icon="x"
+          variant="outline"
+          size="small"
+        />
+      </div>
+
+      <div className={styles.content}>
+        {loading && <div className={styles.loading}>Loading…</div>}
+
+        {isOpen &&
+          imageColumns.map(({ column, kind }) => {
+            const src =
+              kind === 'binary'
+                ? imageUrlFor(dataset.id, column, selectedIndex, DRAWER_IMAGE_SIZE)
+                : row?.[column];
+            const fullSrc =
+              kind === 'binary' ? imageUrlFor(dataset.id, column, selectedIndex) : row?.[column];
+            if (!src) return null;
+            return (
+              <div key={column} className={styles.imageSection}>
+                <img
+                  className={styles.image}
+                  src={src}
+                  alt={`${column} ${selectedIndex}`}
+                  title="Click to view full size"
+                  onClick={() =>
+                    setLightbox({
+                      src: fullSrc,
+                      alt: `${column} ${selectedIndex}`,
+                      href: kind === 'url' ? fullSrc : null,
+                    })
+                  }
+                />
+                <div className={styles.imageCaption}>
+                  <span>{column}</span>
+                  {kind === 'url' && (
+                    <a href={row[column]} target="_blank" rel="noreferrer">
+                      open ↗
+                    </a>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+
+        {row && textColumn && row[textColumn] !== undefined && (
+          <div className={styles.textSection}>
+            <div className={styles.sectionLabel}>{textColumn}</div>
+            <div className={styles.text}>{row[textColumn]}</div>
+          </div>
+        )}
+
+        {row && (
+          <dl className={styles.fields}>
+            {row.ls_similarity !== undefined && row.ls_similarity !== null && (
+              <div className={styles.field}>
+                <dt>similarity</dt>
+                <dd>{formatDetailNumber(row.ls_similarity)}</dd>
+              </div>
+            )}
+            {listColumns.map((column) => (
+              <div key={column} className={styles.field}>
+                <dt>{column}</dt>
+                <dd>
+                  <DetailValue cell={describeCellValue(row[column], metadata[column])} />
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+      </div>
+
+      {lightbox && (
+        <Modal
+          className={styles.lightbox}
+          isVisible={!!lightbox}
+          onClose={() => setLightbox(null)}
+        >
+          <div className={styles.lightboxContent}>
+            <img
+              className={styles.lightboxImage}
+              src={lightbox.src}
+              alt={lightbox.alt}
+              onClick={() => setLightbox(null)}
+            />
+            <div className={styles.lightboxCaption}>
+              <span>{lightbox.alt}</span>
+              {lightbox.href && (
+                <a href={lightbox.href} target="_blank" rel="noreferrer">
+                  open original ↗
+                </a>
+              )}
+              <Button
+                onClick={() => setLightbox(null)}
+                aria-label="Close full size image"
+                icon="x"
+                variant="outline"
+                size="small"
+              />
+            </div>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+export default PointDetail;

--- a/web/src/components/Explore/PointDetail.jsx
+++ b/web/src/components/Explore/PointDetail.jsx
@@ -1,103 +1,64 @@
-import { useState, useEffect, useMemo, useRef } from 'react';
-import { Modal, Button } from 'react-element-forge';
+import { useState, useEffect, useRef } from 'react';
+import { Button } from 'react-element-forge';
 
 import { apiService } from '../../lib/apiService';
-import { imageUrlFor } from '../../lib/imageUrl';
-import { organizeDetailColumns, describeCellValue, formatDetailNumber } from '../../lib/pointDetail';
 import { useScope } from '../../contexts/ScopeContext';
+import PointDetailContent from './PointDetailContent';
 
 import styles from './PointDetail.module.scss';
 
-// Drawer width for inline images; the lightbox fetches the original.
-const DRAWER_IMAGE_SIZE = 600;
-
-function DetailValue({ cell }) {
-  if (cell.kind === 'empty') return <span className={styles.empty}>—</span>;
-  if (cell.kind === 'url') {
-    return (
-      <a href={cell.value} target="_blank" rel="noreferrer">
-        {cell.value}
-      </a>
-    );
-  }
-  if (cell.kind === 'array' || cell.kind === 'object') {
-    const summary =
-      cell.kind === 'array'
-        ? `${cell.value.length} item${cell.value.length === 1 ? '' : 's'}`
-        : 'object';
-    return (
-      <details className={styles.expandable}>
-        <summary>{summary}</summary>
-        <pre>{JSON.stringify(cell.value, null, 2)}</pre>
-      </details>
-    );
-  }
-  return <span>{cell.display}</span>;
-}
-
 /**
- * Right-side drawer showing every column of a single clicked row: images
- * large (with a click-to-original lightbox), the main text prominently, and
- * the remaining columns as a definition list formatted per data type.
+ * Right-side drawer showing every column of a single clicked row; the body
+ * (images with lightbox, text, typed field list) is PointDetailContent,
+ * shared with the mobile table's expanded rows.
  */
 function PointDetail({ selectedIndex, onClose }) {
   const { dataset, sae, clusterMap } = useScope();
 
   const [row, setRow] = useState(null);
   const [loading, setLoading] = useState(false);
-  // { src, alt, href? } for the full-size image modal
-  const [lightbox, setLightbox] = useState(null);
-  // Guard against stale async responses when the selection changes quickly.
-  const latestIndexRef = useRef(null);
+  // Guard against stale async responses when the selection, dataset, or sae
+  // changes while a fetch is in flight — the key identifies the request, not
+  // just the row index (the same index can exist in another dataset).
+  const latestRequestRef = useRef(null);
 
   const isOpen = selectedIndex !== null && selectedIndex !== undefined;
 
   useEffect(() => {
     if (!isOpen || !dataset?.id) {
-      latestIndexRef.current = null;
+      latestRequestRef.current = null;
       setRow(null);
-      setLightbox(null);
       return;
     }
-    latestIndexRef.current = selectedIndex;
-    setLightbox(null);
+    const requestKey = `${dataset.id}:${sae?.id ?? ''}:${selectedIndex}`;
+    latestRequestRef.current = requestKey;
     setLoading(true);
     apiService
       .fetchDataFromIndices(dataset.id, [selectedIndex], sae?.id ?? null)
       .then((rows) => {
-        if (latestIndexRef.current !== selectedIndex) return;
+        if (latestRequestRef.current !== requestKey) return;
         setRow(rows?.[0] ?? null);
         setLoading(false);
       })
       .catch(() => {
-        if (latestIndexRef.current !== selectedIndex) return;
+        if (latestRequestRef.current !== requestKey) return;
         setRow(null);
         setLoading(false);
       });
   }, [isOpen, selectedIndex, dataset?.id, sae?.id]);
 
-  // Escape closes the lightbox first, then the drawer.
+  // Escape closes the drawer (PointDetailContent intercepts Escape first
+  // while its lightbox is open).
   useEffect(() => {
     if (!isOpen) return;
     const handleKeyDown = (event) => {
-      if (event.key !== 'Escape') return;
-      if (lightbox) {
-        setLightbox(null);
-      } else {
-        onClose();
-      }
+      if (event.key === 'Escape') onClose();
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, lightbox, onClose]);
-
-  const { imageColumns, textColumn, listColumns } = useMemo(
-    () => organizeDetailColumns(dataset),
-    [dataset]
-  );
+  }, [isOpen, onClose]);
 
   const cluster = isOpen ? clusterMap?.[selectedIndex] : null;
-  const metadata = dataset?.column_metadata || {};
 
   return (
     <div className={`${styles.drawer} ${isOpen ? styles.open : ''}`}>
@@ -118,101 +79,8 @@ function PointDetail({ selectedIndex, onClose }) {
 
       <div className={styles.content}>
         {loading && <div className={styles.loading}>Loading…</div>}
-
-        {isOpen &&
-          imageColumns.map(({ column, kind }) => {
-            const src =
-              kind === 'binary'
-                ? imageUrlFor(dataset.id, column, selectedIndex, DRAWER_IMAGE_SIZE)
-                : row?.[column];
-            const fullSrc =
-              kind === 'binary' ? imageUrlFor(dataset.id, column, selectedIndex) : row?.[column];
-            if (!src) return null;
-            return (
-              <div key={column} className={styles.imageSection}>
-                <img
-                  className={styles.image}
-                  src={src}
-                  alt={`${column} ${selectedIndex}`}
-                  title="Click to view full size"
-                  onClick={() =>
-                    setLightbox({
-                      src: fullSrc,
-                      alt: `${column} ${selectedIndex}`,
-                      href: kind === 'url' ? fullSrc : null,
-                    })
-                  }
-                />
-                <div className={styles.imageCaption}>
-                  <span>{column}</span>
-                  {kind === 'url' && (
-                    <a href={row[column]} target="_blank" rel="noreferrer">
-                      open ↗
-                    </a>
-                  )}
-                </div>
-              </div>
-            );
-          })}
-
-        {row && textColumn && row[textColumn] !== undefined && (
-          <div className={styles.textSection}>
-            <div className={styles.sectionLabel}>{textColumn}</div>
-            <div className={styles.text}>{row[textColumn]}</div>
-          </div>
-        )}
-
-        {row && (
-          <dl className={styles.fields}>
-            {row.ls_similarity !== undefined && row.ls_similarity !== null && (
-              <div className={styles.field}>
-                <dt>similarity</dt>
-                <dd>{formatDetailNumber(row.ls_similarity)}</dd>
-              </div>
-            )}
-            {listColumns.map((column) => (
-              <div key={column} className={styles.field}>
-                <dt>{column}</dt>
-                <dd>
-                  <DetailValue cell={describeCellValue(row[column], metadata[column])} />
-                </dd>
-              </div>
-            ))}
-          </dl>
-        )}
+        {isOpen && <PointDetailContent row={row} index={selectedIndex} />}
       </div>
-
-      {lightbox && (
-        <Modal
-          className={styles.lightbox}
-          isVisible={!!lightbox}
-          onClose={() => setLightbox(null)}
-        >
-          <div className={styles.lightboxContent}>
-            <img
-              className={styles.lightboxImage}
-              src={lightbox.src}
-              alt={lightbox.alt}
-              onClick={() => setLightbox(null)}
-            />
-            <div className={styles.lightboxCaption}>
-              <span>{lightbox.alt}</span>
-              {lightbox.href && (
-                <a href={lightbox.href} target="_blank" rel="noreferrer">
-                  open original ↗
-                </a>
-              )}
-              <Button
-                onClick={() => setLightbox(null)}
-                aria-label="Close full size image"
-                icon="x"
-                variant="outline"
-                size="small"
-              />
-            </div>
-          </div>
-        </Modal>
-      )}
     </div>
   );
 }

--- a/web/src/components/Explore/PointDetail.module.scss
+++ b/web/src/components/Explore/PointDetail.module.scss
@@ -1,0 +1,207 @@
+.drawer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 400px;
+  max-width: 85%;
+  display: flex;
+  flex-direction: column;
+  background: var(--neutrals-color-neutral-0, #ffffff);
+  border-left: 1px solid var(--borders-color-border-1, #e6e6e6);
+  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.15);
+  z-index: 999;
+  transform: translateX(105%);
+  visibility: hidden;
+  transition:
+    transform 0.25s ease,
+    visibility 0.25s;
+
+  &.open {
+    transform: translateX(0);
+    visibility: visible;
+  }
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--borders-color-border-1, #e6e6e6);
+  flex-shrink: 0;
+}
+
+.headerText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-color-text-main, #262a30);
+}
+
+.cluster {
+  font-size: 12px;
+  color: var(--text-color-text-subtle, #757575);
+  overflow-wrap: anywhere;
+}
+
+.closeButton {
+  flex-shrink: 0;
+}
+
+.content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px 24px;
+}
+
+.loading {
+  font-size: 13px;
+  color: var(--text-color-text-subtle, #757575);
+  padding: 8px 0;
+}
+
+.imageSection {
+  margin-bottom: 16px;
+}
+
+.image {
+  display: block;
+  width: 100%;
+  max-height: 400px;
+  object-fit: contain;
+  background: var(--neutrals-color-neutral-1, #f4f2f0);
+  border: 1px solid var(--borders-color-border-1, #e6e6e6);
+  border-radius: 4px;
+  cursor: zoom-in;
+}
+
+.imageCaption {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--text-color-text-subtle, #757575);
+
+  a {
+    color: var(--text-color-text-primary, #a36022);
+  }
+}
+
+.sectionLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-color-text-subtle, #757575);
+  margin-bottom: 4px;
+}
+
+.textSection {
+  margin-bottom: 16px;
+}
+
+.text {
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text-color-text-main, #262a30);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  max-width: 60ch;
+}
+
+.fields {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.field {
+  dt {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-color-text-subtle, #757575);
+    margin-bottom: 2px;
+  }
+
+  dd {
+    margin: 0;
+    font-size: 13px;
+    color: var(--text-color-text-main, #262a30);
+    overflow-wrap: anywhere;
+
+    a {
+      color: var(--text-color-text-primary, #a36022);
+    }
+  }
+}
+
+.empty {
+  color: var(--text-color-text-subtle, #757575);
+}
+
+.expandable {
+  summary {
+    cursor: pointer;
+    color: var(--text-color-text-subtle, #757575);
+  }
+
+  pre {
+    margin: 4px 0 0;
+    padding: 8px;
+    font-size: 12px;
+    background: var(--neutrals-color-neutral-1, #f4f2f0);
+    border: 1px solid var(--borders-color-border-1, #e6e6e6);
+    border-radius: 4px;
+    overflow-x: auto;
+    max-height: 300px;
+    overflow-y: auto;
+  }
+}
+
+// Full-size image lightbox (rendered in the react-element-forge modal portal).
+.lightbox {
+  background: transparent !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  max-width: none !important;
+}
+
+.lightboxContent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.lightboxImage {
+  max-width: 90vw;
+  max-height: 85vh;
+  object-fit: contain;
+  cursor: zoom-out;
+  border-radius: 4px;
+  background: var(--neutrals-color-neutral-0, #ffffff);
+}
+
+.lightboxCaption {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 10px;
+  font-size: 13px;
+  color: var(--text-color-text-main, #262a30);
+  background: var(--neutrals-color-neutral-0, #ffffff);
+  border: 1px solid var(--borders-color-border-1, #e6e6e6);
+  border-radius: 4px;
+
+  a {
+    color: var(--text-color-text-primary, #a36022);
+  }
+}

--- a/web/src/components/Explore/PointDetailContent.jsx
+++ b/web/src/components/Explore/PointDetailContent.jsx
@@ -1,0 +1,171 @@
+import { useState, useEffect } from 'react';
+import { Modal, Button } from 'react-element-forge';
+
+import { imageUrlFor } from '../../lib/imageUrl';
+import {
+  organizeDetailColumns,
+  describeCellValue,
+  formatDetailNumber,
+} from '../../lib/pointDetail';
+import { useScope } from '../../contexts/ScopeContext';
+
+import styles from './PointDetail.module.scss';
+
+// Default inline image width; the lightbox fetches the original.
+const DEFAULT_IMAGE_SIZE = 600;
+
+function DetailValue({ cell }) {
+  if (cell.kind === 'empty') return <span className={styles.empty}>—</span>;
+  if (cell.kind === 'url') {
+    return (
+      <a href={cell.value} target="_blank" rel="noreferrer">
+        {cell.value}
+      </a>
+    );
+  }
+  if (cell.kind === 'array' || cell.kind === 'object') {
+    const summary =
+      cell.kind === 'array'
+        ? `${cell.value.length} item${cell.value.length === 1 ? '' : 's'}`
+        : 'object';
+    return (
+      <details className={styles.expandable}>
+        <summary>{summary}</summary>
+        <pre>{JSON.stringify(cell.value, null, 2)}</pre>
+      </details>
+    );
+  }
+  return <span>{cell.display}</span>;
+}
+
+/**
+ * The body of a single row's detail view: images large (with a
+ * click-to-original lightbox), the main text prominently, and the remaining
+ * columns as a definition list formatted per data type. Shared between the
+ * desktop drawer (PointDetail) and the mobile table's expanded rows.
+ *
+ * `row` may be null while it loads — binary images only need the index, so
+ * they render immediately.
+ */
+function PointDetailContent({ row, index, imageSize = DEFAULT_IMAGE_SIZE }) {
+  const { dataset } = useScope();
+
+  // { src, alt, href? } for the full-size image modal
+  const [lightbox, setLightbox] = useState(null);
+
+  // Close the lightbox when the row changes under us.
+  useEffect(() => {
+    setLightbox(null);
+  }, [index, dataset?.id]);
+
+  // While the lightbox is open, Escape closes it and stops there (capture
+  // phase, so an enclosing drawer's own Escape handler doesn't also fire).
+  useEffect(() => {
+    if (!lightbox) return;
+    const handleKeyDown = (event) => {
+      if (event.key !== 'Escape') return;
+      event.stopPropagation();
+      setLightbox(null);
+    };
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, [lightbox]);
+
+  const { imageColumns, textColumn, listColumns } = organizeDetailColumns(dataset);
+  const metadata = dataset?.column_metadata || {};
+  const hasIndex = index !== null && index !== undefined;
+
+  return (
+    <>
+      {hasIndex &&
+        imageColumns.map(({ column, kind }) => {
+          const src =
+            kind === 'binary' ? imageUrlFor(dataset.id, column, index, imageSize) : row?.[column];
+          const fullSrc =
+            kind === 'binary' ? imageUrlFor(dataset.id, column, index) : row?.[column];
+          if (!src) return null;
+          return (
+            <div key={column} className={styles.imageSection}>
+              <img
+                className={styles.image}
+                src={src}
+                alt={`${column} ${index}`}
+                title="Click to view full size"
+                onClick={() =>
+                  setLightbox({
+                    src: fullSrc,
+                    alt: `${column} ${index}`,
+                    href: kind === 'url' ? fullSrc : null,
+                  })
+                }
+              />
+              <div className={styles.imageCaption}>
+                <span>{column}</span>
+                {kind === 'url' && (
+                  <a href={row[column]} target="_blank" rel="noreferrer">
+                    open ↗
+                  </a>
+                )}
+              </div>
+            </div>
+          );
+        })}
+
+      {row && textColumn && row[textColumn] !== undefined && (
+        <div className={styles.textSection}>
+          <div className={styles.sectionLabel}>{textColumn}</div>
+          <div className={styles.text}>{row[textColumn]}</div>
+        </div>
+      )}
+
+      {row && (
+        <dl className={styles.fields}>
+          {row.ls_similarity !== undefined && row.ls_similarity !== null && (
+            <div className={styles.field}>
+              <dt>similarity</dt>
+              <dd>{formatDetailNumber(row.ls_similarity)}</dd>
+            </div>
+          )}
+          {listColumns.map((column) => (
+            <div key={column} className={styles.field}>
+              <dt>{column}</dt>
+              <dd>
+                <DetailValue cell={describeCellValue(row[column], metadata[column])} />
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+
+      {lightbox && (
+        <Modal className={styles.lightbox} isVisible={!!lightbox} onClose={() => setLightbox(null)}>
+          <div className={styles.lightboxContent}>
+            <img
+              className={styles.lightboxImage}
+              src={lightbox.src}
+              alt={lightbox.alt}
+              onClick={() => setLightbox(null)}
+            />
+            <div className={styles.lightboxCaption}>
+              <span>{lightbox.alt}</span>
+              {lightbox.href && (
+                <a href={lightbox.href} target="_blank" rel="noreferrer">
+                  open original ↗
+                </a>
+              )}
+              <Button
+                onClick={() => setLightbox(null)}
+                aria-label="Close full size image"
+                icon="x"
+                variant="outline"
+                size="small"
+              />
+            </div>
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+}
+
+export default PointDetailContent;

--- a/web/src/components/Explore/ScatterGL.jsx
+++ b/web/src/components/Explore/ScatterGL.jsx
@@ -565,6 +565,10 @@ function ScatterGL({
       const nearestPoint = findNearestPoint(x, y);
       if (nearestPoint !== -1) {
         onSelect([nearestPoint]);
+      } else {
+        // Clicking empty space clears the selection (e.g. closes the
+        // point detail drawer).
+        onSelect([]);
       }
     },
     [points, onSelect, findNearestPoint]

--- a/web/src/lib/pointDetail.js
+++ b/web/src/lib/pointDetail.js
@@ -1,0 +1,81 @@
+/**
+ * Pure helpers for the point detail drawer (PointDetail.jsx): decide how a
+ * dataset's columns are organized for display and how individual cell values
+ * are rendered. Kept free of React so the logic is unit-testable.
+ */
+
+// Columns that are internal bookkeeping and shouldn't appear in the
+// detail list (the row index is already shown in the drawer header).
+const INTERNAL_COLUMNS = new Set(['ls_index', 'index', 'idx', 'sae_indices', 'sae_acts']);
+
+/**
+ * Organize a dataset's columns for the detail view.
+ *
+ * Returns:
+ * - imageColumns: [{ column, kind }] where kind is "binary" (fetched from the
+ *   backend image endpoint) or "url" (the row value is the image URL)
+ * - textColumn: the dataset's main text column (shown prominently)
+ * - listColumns: everything else, in dataset column order
+ */
+export function organizeDetailColumns(dataset) {
+  if (!dataset) return { imageColumns: [], textColumn: null, listColumns: [] };
+  const metadata = dataset.column_metadata || {};
+  const columns = dataset.columns || [];
+  const textColumn = dataset.text_column || null;
+
+  const imageColumns = [];
+  const listColumns = [];
+  columns.forEach((column) => {
+    if (INTERNAL_COLUMNS.has(column)) return;
+    const meta = metadata[column];
+    if (meta?.type === 'image') {
+      imageColumns.push({ column, kind: 'binary' });
+    } else if (meta?.image) {
+      imageColumns.push({ column, kind: 'url' });
+    } else if (column !== textColumn) {
+      listColumns.push(column);
+    }
+  });
+  return { imageColumns, textColumn, listColumns };
+}
+
+/** Format a number compactly: integers with locale separators, floats trimmed. */
+export function formatDetailNumber(value) {
+  const num = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(num)) return String(value);
+  if (Number.isInteger(num)) return num.toLocaleString();
+  // Trim float noise but keep small values legible.
+  return String(parseFloat(num.toPrecision(6)));
+}
+
+/** Format a date-ish value; fall back to the raw string when unparseable. */
+export function formatDetailDate(value) {
+  const date = value instanceof Date ? value : new Date(value);
+  if (isNaN(date.getTime())) return String(value);
+  return date.toLocaleString();
+}
+
+const URL_REGEX = /^https?:\/\//;
+
+/**
+ * Classify a cell value (given its column metadata) for rendering.
+ *
+ * Returns one of:
+ * - { kind: "empty" }
+ * - { kind: "url", value }
+ * - { kind: "array", value }        (render as expandable JSON)
+ * - { kind: "object", value }      (render as expandable JSON)
+ * - { kind: "text", display }      (numbers/dates arrive pre-formatted)
+ */
+export function describeCellValue(value, meta) {
+  if (value === null || value === undefined || value === '') return { kind: 'empty' };
+  if (Array.isArray(value)) return { kind: 'array', value };
+  if (meta?.url && typeof value === 'string') return { kind: 'url', value };
+  if (meta?.type === 'date') return { kind: 'text', display: formatDetailDate(value) };
+  if (meta?.type === 'number' || typeof value === 'number') {
+    return { kind: 'text', display: formatDetailNumber(value) };
+  }
+  if (typeof value === 'object') return { kind: 'object', value };
+  if (typeof value === 'string' && URL_REGEX.test(value)) return { kind: 'url', value };
+  return { kind: 'text', display: String(value) };
+}

--- a/web/src/lib/pointDetail.test.js
+++ b/web/src/lib/pointDetail.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { organizeDetailColumns, describeCellValue, formatDetailNumber } from './pointDetail';
+
+describe('organizeDetailColumns', () => {
+  const dataset = {
+    text_column: 'text',
+    columns: ['text', 'photo', 'thumb_url', 'link', 'score', 'tokens', 'ls_index'],
+    column_metadata: {
+      photo: { type: 'image', image_kind: 'binary' },
+      thumb_url: { image: true, image_kind: 'url' },
+      link: { url: true },
+      score: { type: 'number', extent: [0, 1] },
+      tokens: { type: 'array' },
+    },
+  };
+
+  it('splits image columns by kind and keeps the rest in order', () => {
+    const { imageColumns, textColumn, listColumns } = organizeDetailColumns(dataset);
+    expect(imageColumns).toEqual([
+      { column: 'photo', kind: 'binary' },
+      { column: 'thumb_url', kind: 'url' },
+    ]);
+    expect(textColumn).toBe('text');
+    expect(listColumns).toEqual(['link', 'score', 'tokens']);
+  });
+
+  it('excludes the text column and internal ls_index from the list', () => {
+    const { listColumns } = organizeDetailColumns(dataset);
+    expect(listColumns).not.toContain('text');
+    expect(listColumns).not.toContain('ls_index');
+  });
+
+  it('handles a missing dataset and missing metadata', () => {
+    expect(organizeDetailColumns(null)).toEqual({
+      imageColumns: [],
+      textColumn: null,
+      listColumns: [],
+    });
+    const bare = organizeDetailColumns({ text_column: 't', columns: ['t', 'a'] });
+    expect(bare.imageColumns).toEqual([]);
+    expect(bare.listColumns).toEqual(['a']);
+  });
+});
+
+describe('describeCellValue', () => {
+  it('classifies empty values', () => {
+    expect(describeCellValue(null, null).kind).toBe('empty');
+    expect(describeCellValue(undefined, null).kind).toBe('empty');
+    expect(describeCellValue('', null).kind).toBe('empty');
+  });
+
+  it('classifies urls from metadata and from value shape', () => {
+    expect(describeCellValue('https://a.com', { url: true })).toEqual({
+      kind: 'url',
+      value: 'https://a.com',
+    });
+    expect(describeCellValue('http://b.org/x', null).kind).toBe('url');
+    expect(describeCellValue('not a url', { url: true }).kind).toBe('url');
+  });
+
+  it('classifies arrays and objects for expandable JSON', () => {
+    expect(describeCellValue([1, 2, 3], { type: 'array' }).kind).toBe('array');
+    expect(describeCellValue([1], null).kind).toBe('array');
+    expect(describeCellValue({ a: 1 }, null).kind).toBe('object');
+  });
+
+  it('formats numbers and dates as display text', () => {
+    expect(describeCellValue(1234567, { type: 'number' })).toEqual({
+      kind: 'text',
+      display: (1234567).toLocaleString(),
+    });
+    expect(describeCellValue(0.123456789, { type: 'number' }).display).toBe('0.123457');
+    const date = describeCellValue('2024-01-15T00:00:00Z', { type: 'date' });
+    expect(date.kind).toBe('text');
+    expect(date.display).not.toBe('2024-01-15T00:00:00Z'); // formatted
+  });
+
+  it('falls back to raw strings for unparseable dates and plain text', () => {
+    expect(describeCellValue('not a date', { type: 'date' })).toEqual({
+      kind: 'text',
+      display: 'not a date',
+    });
+    expect(describeCellValue('hello', null)).toEqual({ kind: 'text', display: 'hello' });
+  });
+});
+
+describe('formatDetailNumber', () => {
+  it('keeps integers exact and trims float noise', () => {
+    expect(formatDetailNumber(42)).toBe('42');
+    expect(formatDetailNumber(0.30000000000000004)).toBe('0.3');
+    expect(formatDetailNumber('nope')).toBe('nope');
+  });
+});

--- a/web/src/pages/FullScreenExplore.jsx
+++ b/web/src/pages/FullScreenExplore.jsx
@@ -10,6 +10,7 @@ import LeftPane from '../components/Explore/LeftPane';
 import VisualizationPane from '../components/Explore/VisualizationPane';
 import FilterDataTable from '../components/Explore/FilterDataTable';
 import ClusterLabelsPanel from '../components/Explore/ClusterLabelsPanel';
+import PointDetail from '../components/Explore/PointDetail';
 
 import { ScopeProvider, useScope } from '../contexts/ScopeContext';
 import { FilterProvider, useFilter } from '../contexts/FilterContext';
@@ -78,10 +79,19 @@ function ExploreContent() {
   const [hovered, setHovered] = useState(null);
   const [hoveredCluster, setHoveredCluster] = useState(null);
   const [hoverAnnotations, setHoverAnnotations] = useState([]);
-  // Note: these currently have no setters wired up; they exist to satisfy
-  // VisualizationPane's props with stable empty values.
+  // Note: this currently has no setter wired up; it exists to satisfy
+  // VisualizationPane's props with a stable empty value.
   const [dataTableRows] = useState([]);
-  const [selectedAnnotations] = useState([]);
+  // Index of the point whose detail drawer is open (null = closed).
+  const [selectedIndex, setSelectedIndex] = useState(null);
+
+  // Highlight the selected point on the map (same [x, y] annotation shape as
+  // the hover annotations).
+  const selectedAnnotations = useMemo(() => {
+    if (selectedIndex === null || selectedIndex === undefined) return [];
+    const sr = scopeRows?.[selectedIndex];
+    return sr ? [[sr.x, sr.y]] : [];
+  }, [selectedIndex, scopeRows]);
 
   // Add a ref to track the latest requested index
   const latestHoverIndexRef = useRef(null);
@@ -144,8 +154,31 @@ function ExploreContent() {
 
   const [showClusters, setShowClusters] = useState(false);
 
-  // Handlers for responding to individual data points
-  const handleClicked = useCallback(() => {}, []);
+  // Handlers for responding to individual data points.
+  // Clicking a table row opens the detail drawer for that row.
+  const handleClicked = useCallback(
+    (index) => {
+      if (index === null || index === undefined || deletedIndicesSet.has(index)) return;
+      setSelectedIndex(index);
+    },
+    [deletedIndicesSet]
+  );
+
+  // Clicking a point on the map opens the detail drawer; clicking empty
+  // space (ScatterGL sends an empty selection) closes it.
+  const handleSelected = useCallback(
+    (indices) => {
+      const index = indices?.[0];
+      if (index === undefined || index === -1 || deletedIndicesSet.has(index)) {
+        setSelectedIndex(null);
+        return;
+      }
+      setSelectedIndex(index);
+    },
+    [deletedIndicesSet]
+  );
+
+  const handleDetailClose = useCallback(() => setSelectedIndex(null), []);
 
   const handleHover = useCallback(
     (index) => {
@@ -362,13 +395,14 @@ function ExploreContent() {
                 hovered={hovered}
                 hoveredIndex={hoveredIndex}
                 onHover={handleHover}
-                onSelect={() => {}}
+                onSelect={handleSelected}
                 hoverAnnotations={hoverAnnotations}
                 selectedAnnotations={selectedAnnotations}
                 hoveredCluster={hoveredCluster}
                 dataTableRows={dataTableRows}
               />
             ) : null}
+            <PointDetail selectedIndex={selectedIndex} onClose={handleDetailClose} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What

Clicking a point in the Explore scatterplot (or a row in the filter table) now opens a right-side detail drawer inside the visualization pane showing the full row, rendered per data type:

- **binary image columns** render drawer-width (via the image endpoint at size=600) with a click-to-original **lightbox** — Escape closes the lightbox first, then the drawer
- **url-kind image columns** use the row value as `src` and link out
- the dataset **text column** gets a prominent pre-wrap block
- remaining columns render as a definition list: urls as anchors, numbers/dates formatted, arrays/objects as expandable pretty-JSON `<details>`
- header shows the row index + cluster label; the selected point is highlighted on the map via the existing `selectedAnnotations` path

Wiring details: `ScatterGL` now emits `onSelect([])` on empty-space clicks so clicking the background closes the drawer; `FilterDataTable` threads its previously-unused row `onClick` (ignoring clicks on links/buttons/the SAE feature-plot canvas, which opens its own modal). Row fetches go through `fetchDataFromIndices` with a stale-response guard. Pure column-organization/formatting logic lives in `lib/pointDetail.js`.

Known v1 limitation: the drawer overlays the right 400px of the map, so a selected point in that strip sits under it.

## Test plan

- `cd web && npm run lint` — 0 errors; `npm run test` — 103 passed (9 new for `pointDetail.js`)
- Driven headless (Playwright) against a production build on both an image dataset (marqo-ge-sample: drawer with large product image, lightbox with original, Escape cascade) and a text dataset (dadabase: joke text, clickable URL, formatted score/date, cluster label); empty-canvas click closes, table row click opens the right row, dark mode verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)