### PR TITLE
Incremental UMAP for growing datasets: --transform-from, growing --align, --register-to

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ tiny dataset, embeds it on CPU, runs the whole pipeline, and verifies search.
 | --- | --- | --- |
 | ingest | `ls-ingest <ds> --path <file-or-image-dir> --text_column <col>` (or a DataFrame via the library API) | `input.parquet`, `meta.json` (column detection) |
 | embed | `ls-embed <ds> <col> <model_id> [--task] [--prefix] [--dimensions] [--batch_size] [--max_seq_length]` | `embeddings/embedding-NNN.*` (LanceDB) |
-| umap | `ls-umap <ds> <embedding_id> <neighbors> <min_dist> [--name --description]` | `umaps/umap-NNN.*` (x,y in [-1,1]) |
+| umap | `ls-umap <ds> <embedding_id> <neighbors> <min_dist> [--save --transform-from --align --register-to --name --description]` (growing datasets: docs/umap.md) | `umaps/umap-NNN.*` (x,y in [-1,1]) |
 | cluster | `ls-cluster <ds> <umap_id> <samples> <min_samples> <epsilon> [--method] [--cluster_on] [--name]` | `clusters/cluster-NNN.*` + `…-labels-default.parquet` |
 | label | `ls-label <ds> <text_col> <cluster_id> <chat_model_id> <samples> <context>` | `clusters/<cluster>-labels-NNN.parquet` |
 | scope | `ls-scope <ds> <embedding_id> <umap_id> <cluster_id> <labels_id> "<label>" "<desc>"` | `scopes/scopes-NNN.*` + per-scope LanceDB |

--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -1,6 +1,6 @@
 # Clustering methods
 
-After projecting embeddings with `ls-umap`, the `ls-cluster` step assigns every
+After projecting embeddings with [`ls-umap`](umap.md), the `ls-cluster` step assigns every
 point a cluster id. Latent Scope 1.0 supports four clustering methods and lets
 you choose whether to cluster on the 2D UMAP projection or the original
 high-dimensional embedding ([issue #41](https://github.com/enjalot/latent-scope/issues/41)).

--- a/docs/umap.md
+++ b/docs/umap.md
@@ -1,0 +1,90 @@
+# UMAP projections
+
+`ls-umap` projects an embedding down to 2D and writes `umaps/umap-NNN.parquet`
+(columns `x,y`, normalized to `[-1, 1]`), a preview PNG, and a meta JSON.
+
+```bash
+# ls-umap <dataset_id> <embedding_id> [neighbors] [min_dist] [options]
+ls-umap mydataset embedding-001 25 0.1
+```
+
+## Flag reference
+
+| flag | what it does |
+| --- | --- |
+| `--save` | Pickle the fitted reducer to `umaps/umap-NNN.pkl` so new rows can later be projected through it. Forces the CPU (umap-learn) code path. |
+| `--transform-from <umap-id>` | Project rows appended since `<umap-id>` through its saved reducer; old points keep their exact published positions. Writes a new umap-NNN. |
+| `--align <emb1,emb2,…>` | AlignedUMAP across several embeddings of the same dataset. Embeddings may have different lengths as long as they share an index prefix (append-only growth): the relations map the shared prefix of each consecutive pair. Writes one umap-NNN per embedding. |
+| `--register-to <umap-id>` | After fitting (plain or `--align`), register the new layout onto an existing umap with a 2D similarity transform (rotation + uniform scale + translation, reflection allowed) fit on the shared row prefix, so the refit lands in the published frame. |
+| `--init <umap-id>` | Warm-start the fit from an existing layout (CPU only). |
+| `--seed N` | Fix `random_state` for reproducibility (see note below). `-1` means unseeded. |
+| `--sae_id`, `--name`, `--description` | Project SAE features instead / attach human-friendly metadata. |
+
+`--transform-from` cannot be combined with `--align`, `--init`, `--save`,
+`--sae_id`, or `--register-to`; the `neighbors`/`min_dist` positionals are
+ignored in that mode (the saved reducer already encodes them) and may be
+omitted entirely.
+
+## Growing datasets: keeping a published map stable
+
+When a dataset grows daily but the published map must stay visually stable,
+use a two-cadence recipe:
+
+**Once — fit and save the reducer:**
+
+```bash
+ls-umap mydataset embedding-001 25 0.1 --save    # -> umap-001 (+ umap-001.pkl)
+```
+
+**Daily — project only the new rows through the saved reducer:**
+
+```bash
+# after re-embedding the grown dataset into the same embedding id
+ls-umap mydataset embedding-001 --transform-from umap-001   # -> umap-002
+ls-umap mydataset embedding-001 --transform-from umap-002   # next day -> umap-003
+...
+```
+
+Old rows are copied verbatim from the source parquet (pixel-stable); new rows
+are transformed and mapped into the source's `[-1, 1]` frame using its stored
+min/max. New points can land slightly outside `[-1, 1]` — they are left there
+(the count is printed) rather than rescaling the old points. The meta records
+`transformed_from` and `reducer_id`; the pickle itself is not copied, so a
+chain of daily transforms keeps resolving back to the original saved reducer.
+
+**Periodically — refit so accumulated new rows get a proper embedding, and
+register the refit onto the published layout:**
+
+```bash
+# AlignedUMAP across the old (shorter) and current (longer) embedding windows,
+# anchored to the published umap so the layout doesn't rotate/flip/drift:
+ls-umap mydataset embedding-002 25 0.1 --align embedding-001 --register-to umap-001 --save
+```
+
+Registration computes a least-squares similarity transform on the rows shared
+with the target umap (the index prefix) and applies it to the whole layout, so
+the refit is expressed in the published frame. The meta records
+`registered_to` plus the `registration` transform — a later `--transform-from`
+of a registered umap reuses that transform for its new points, so the daily
+cadence can continue from the registered refit.
+
+## Reproducibility note
+
+Passing `--seed` (i.e. setting `random_state`) forces umap-learn into a
+single-threaded fit, which is substantially slower on large datasets. Leaving
+it unseeded is faster but non-deterministic — with the workflow above that's
+usually fine, because `--register-to` re-anchors each refit onto the published
+layout anyway. Also note `--save` (and `--align`/`--init`) disable the cuML
+GPU path, since only CPU umap-learn reducers can be pickled and transformed.
+
+## Reducer pickle size
+
+Saved reducers embed the training data and its nearest-neighbor search index,
+so the `.pkl` files are large — on the order of 100–200 MB for a few tens of
+thousands of rows, growing with the dataset. Only the most recent saved
+reducer in a `--transform-from` chain is needed; older pickles can be deleted
+once superseded by a new `--save` fit.
+
+## Next step
+
+Cluster the projection with [`ls-cluster`](clustering.md).

--- a/latentscope/scripts/registration.py
+++ b/latentscope/scripts/registration.py
@@ -1,0 +1,117 @@
+"""Pure-numpy helpers for incremental and aligned UMAP workflows (issue #142).
+
+These functions have no dependency beyond numpy so they can be unit tested
+without running any real UMAP fits:
+
+- ``umeyama_2d`` / ``apply_similarity`` — least-squares 2D similarity
+  registration (rotation + uniform scale + translation, reflection allowed),
+  used by ``ls-umap --register-to`` to anchor a refit layout onto a
+  previously published one.
+- ``register_layout`` — register a new layout onto a target layout via their
+  shared index prefix.
+- ``prefix_relations`` — AlignedUMAP relations for growing (append-only)
+  embedding windows.
+- ``apply_normalization`` — map raw UMAP coordinates into the [-1, 1] frame
+  defined by a previous fit's min/max values, used by
+  ``ls-umap --transform-from``.
+"""
+import numpy as np
+
+
+def umeyama_2d(src, dst):
+    """Least-squares similarity transform mapping ``src`` points onto ``dst``.
+
+    Solves for scale ``c``, orthogonal matrix ``R`` (rotation, reflection
+    allowed) and translation ``t`` minimizing ``||(c * src @ R.T + t) - dst||``
+    (Umeyama 1991, without the det(R)=+1 constraint so reflections are
+    recovered too).
+
+    Parameters
+    ----------
+    src, dst : array-like of shape (n, 2), n >= 2, rows in correspondence.
+
+    Returns
+    -------
+    (c, R, t) : float, (2, 2) ndarray, (2,) ndarray
+        such that ``dst ≈ c * src @ R.T + t``.
+    """
+    src = np.asarray(src, dtype=np.float64)
+    dst = np.asarray(dst, dtype=np.float64)
+    if src.shape != dst.shape or src.ndim != 2 or src.shape[1] != 2:
+        raise ValueError(f"expected matching (n, 2) arrays, got {src.shape} and {dst.shape}")
+    if src.shape[0] < 2:
+        raise ValueError("need at least 2 shared points to compute a similarity transform")
+
+    mu_src = src.mean(axis=0)
+    mu_dst = dst.mean(axis=0)
+    src_c = src - mu_src
+    dst_c = dst - mu_dst
+
+    var_src = (src_c ** 2).sum() / src.shape[0]
+    if var_src == 0:
+        raise ValueError("source points are all identical; similarity transform is undefined")
+
+    cov = dst_c.T @ src_c / src.shape[0]
+    U, D, Vt = np.linalg.svd(cov)
+    R = U @ Vt  # unconstrained orthogonal: reflections allowed
+    c = D.sum() / var_src
+    t = mu_dst - c * (R @ mu_src)
+    return c, R, t
+
+
+def apply_similarity(points, c, R, t):
+    """Apply a similarity transform ``(c, R, t)`` to an (n, 2) point array."""
+    points = np.asarray(points, dtype=np.float64)
+    return c * points @ np.asarray(R, dtype=np.float64).T + np.asarray(t, dtype=np.float64)
+
+
+def register_layout(new_layout, target_layout):
+    """Register ``new_layout`` onto ``target_layout`` via their shared prefix.
+
+    Rows are assumed aligned by index (append-only datasets), so the shared
+    rows are ``range(min(len(target), len(new)))``. The similarity transform is
+    fit on that prefix and applied to ALL points of ``new_layout``.
+
+    Returns
+    -------
+    (registered, (c, R, t)) : the transformed copy of ``new_layout`` (float64)
+        and the transform parameters that produced it.
+    """
+    new_layout = np.asarray(new_layout)
+    target_layout = np.asarray(target_layout)
+    n_shared = min(new_layout.shape[0], target_layout.shape[0])
+    c, R, t = umeyama_2d(new_layout[:n_shared], target_layout[:n_shared])
+    return apply_similarity(new_layout, c, R, t), (c, R, t)
+
+
+def prefix_relations(lengths):
+    """AlignedUMAP relations for a growing (append-only) series of windows.
+
+    Relation i -> i+1 maps the shared index prefix
+    ``{j: j for j in range(min(lengths[i], lengths[i+1]))}``. For equal-length
+    windows this is identical to the old identity relations.
+    """
+    return [
+        {j: j for j in range(min(lengths[i], lengths[i + 1]))}
+        for i in range(len(lengths) - 1)
+    ]
+
+
+def apply_normalization(coords, min_values, max_values):
+    """Map raw UMAP coords into the [-1, 1] frame of a previous fit.
+
+    Uses the same per-axis formula the umapper applies at fit time, but with
+    the SOURCE fit's stored min/max so new points land in the same frame as
+    the old ones (they may fall slightly outside [-1, 1]).
+    """
+    coords = np.asarray(coords, dtype=np.float64)
+    min_values = np.asarray(min_values, dtype=np.float64)
+    max_values = np.asarray(max_values, dtype=np.float64)
+    scaled = (coords - min_values) / (max_values - min_values)
+    return 2 * scaled - 1
+
+
+def count_out_of_frame(coords, lo=-1.0, hi=1.0):
+    """Number of points with any coordinate outside [lo, hi]."""
+    coords = np.asarray(coords)
+    return int(np.any((coords < lo) | (coords > hi), axis=1).sum())

--- a/latentscope/scripts/umapper.py
+++ b/latentscope/scripts/umapper.py
@@ -18,6 +18,12 @@ def main():
     parser.add_argument('--init', type=str, help='Initialize with UMAP', default=None)
     parser.add_argument('--align', type=str, help='Align UMAP with multiple embeddings', default=None)
     parser.add_argument('--save', action='store_true', help='Save the UMAP model')
+    parser.add_argument('--transform-from', dest='transform_from', type=str, default=None,
+                        help='Project rows appended since an existing umap through its saved '
+                             '(--save) reducer; old points keep their published positions')
+    parser.add_argument('--register-to', dest='register_to', type=str, default=None,
+                        help='Register the new layout onto an existing umap with a similarity '
+                             'transform fit on the shared row prefix')
     parser.add_argument('--seed', type=int, help='Random seed', default=None)
     parser.add_argument('--sae_id', type=str, help='SAE to project instead of embedding', default=None)
     parser.add_argument('--name', type=str, help='Human-friendly name for this umap', default=None)
@@ -31,14 +37,24 @@ def main():
     if seed == -1:
         seed = None
 
-    if args.sae_id:
+    if args.transform_from:
+        if args.align or args.init or args.save or args.sae_id or args.register_to:
+            parser.error("--transform-from cannot be combined with "
+                         "--align/--init/--save/--sae_id/--register-to")
+        # neighbors/min_dist are ignored in this mode (the saved reducer already
+        # encodes them); the source umap's values are inherited for provenance.
+        transform_umap(args.dataset_id, args.embedding_id, args.transform_from,
+                       name=args.name, description=args.description)
+    elif args.sae_id:
+        if args.register_to:
+            parser.error("--register-to is not supported with --sae_id")
         sparse_umapper(args.dataset_id, args.embedding_id, args.sae_id, args.neighbors, args.min_dist,
                        save=args.save, init=args.init, seed=seed, name=args.name,
                        description=args.description)
     else:
         umapper(args.dataset_id, args.embedding_id, args.neighbors, args.min_dist, save=args.save,
-                init=args.init, align=args.align, seed=seed, name=args.name,
-                description=args.description)
+                init=args.init, align=args.align, seed=seed, register_to=args.register_to,
+                name=args.name, description=args.description)
 
 
 # TODO move this into shared space
@@ -161,8 +177,171 @@ def _reduce_umap(embeddings, neighbors, min_dist, seed, use_cuml, init_array=Non
     return umap_embeddings, reducer
 
 
+def _next_umap_id(umap_dir):
+    """Allocate the next umap-NNN id from the json files already in umap_dir."""
+    umap_files = [f for f in os.listdir(umap_dir) if re.match(r"umap-\d+\.json", f)]
+    if len(umap_files) > 0:
+        last_umap = sorted(umap_files)[-1]
+        last_umap_number = int(last_umap.split("-")[1].split(".")[0])
+        next_umap_number = last_umap_number + 1
+    else:
+        next_umap_number = 1
+    return f"umap-{next_umap_number:03d}"
+
+
+def _read_umap_meta(umap_dir, umap_id):
+    meta_path = os.path.join(umap_dir, f"{umap_id}.json")
+    if not os.path.exists(meta_path):
+        raise ValueError(f"umap meta not found: {meta_path}")
+    with open(meta_path) as f:
+        return json.load(f)
+
+
+def _resolve_reducer_id(umap_dir, umap_id):
+    """Follow the reducer_id chain from umap_id to a umap with a saved .pkl.
+
+    A umap made with --save has its own pickle; a umap made with
+    --transform-from records the reducer_id whose pickle produced it (pickles
+    are large so they are never copied). Returns the id whose .pkl exists, or
+    None if the chain dead-ends.
+    """
+    current = umap_id
+    seen = set()
+    while current and current not in seen:
+        seen.add(current)
+        if os.path.exists(os.path.join(umap_dir, f"{current}.pkl")):
+            return current
+        meta_path = os.path.join(umap_dir, f"{current}.json")
+        if not os.path.exists(meta_path):
+            return None
+        with open(meta_path) as f:
+            current = json.load(f).get("reducer_id")
+    return None
+
+
+def transform_umap(dataset_id, embedding_id, transform_from, name=None, description=None):
+    """Project rows appended since `transform_from` through its saved reducer.
+
+    The daily half of the growing-dataset workflow (issue #142): old rows are
+    copied verbatim from the source umap's parquet so the published map stays
+    pixel-stable; only the new rows (embedding rows beyond the source umap's
+    length) are transformed, then mapped into the source's [-1, 1] frame using
+    its stored min/max (or its registration transform if the source was made
+    with --register-to). New points may land slightly outside [-1, 1]; they
+    are left there rather than rescaling the old points.
+
+    Returns the new umap id, or None if there were no new rows.
+    """
+    DATA_DIR = get_data_dir()
+    umap_dir = os.path.join(DATA_DIR, dataset_id, "umaps")
+
+    import pickle
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+    import pandas as pd
+
+    from latentscope.scripts.registration import (
+        apply_normalization,
+        apply_similarity,
+        count_out_of_frame,
+    )
+
+    source_meta = _read_umap_meta(umap_dir, transform_from)
+    source_embedding_id = source_meta.get("embedding_id")
+    if source_embedding_id != embedding_id:
+        raise ValueError(
+            f"{transform_from} was fit on embedding {source_embedding_id!r}, not "
+            f"{embedding_id!r}; transforming through a reducer fit on a different "
+            "embedding is not meaningful")
+
+    reducer_id = _resolve_reducer_id(umap_dir, transform_from)
+    if reducer_id is None:
+        raise ValueError(
+            f"no saved reducer (.pkl) found for {transform_from} (or its reducer_id "
+            "chain); re-run the source umap with --save to enable --transform-from")
+    with open(os.path.join(umap_dir, f"{reducer_id}.pkl"), 'rb') as f:
+        reducer = pickle.load(f)
+
+    source_df = pd.read_parquet(os.path.join(umap_dir, f"{transform_from}.parquet"))
+    n_old = len(source_df)
+
+    print("loading embeddings")
+    embeddings = load_embeddings(dataset_id, embedding_id)
+    n_total = embeddings.shape[0]
+    if n_total < n_old:
+        raise ValueError(
+            f"embedding {embedding_id} has {n_total} rows but source umap "
+            f"{transform_from} has {n_old}; the dataset should only grow")
+    if n_total == n_old:
+        print(f"no new rows: {embedding_id} and {transform_from} both have {n_total} rows")
+        return None
+
+    umap_id = _next_umap_id(umap_dir)
+    print("RUNNING:", umap_id)
+    print(f"transforming {n_total - n_old} new rows through {reducer_id}")
+    new_raw = reducer.transform(embeddings[n_old:])
+
+    min_values = np.array(source_meta["min_values"])
+    max_values = np.array(source_meta["max_values"])
+    registration = source_meta.get("registration")
+    if registration is not None:
+        # the source's parquet frame came from a similarity registration, not
+        # from min/max normalization; reuse the same transform for new points
+        new_coords = apply_similarity(new_raw, registration["scale"],
+                                      np.array(registration["rotation"]),
+                                      np.array(registration["translation"]))
+    else:
+        new_coords = apply_normalization(new_raw, min_values, max_values)
+    outside = count_out_of_frame(new_coords)
+    if outside > 0:
+        print(f"{outside} new points fall outside [-1, 1]; leaving them "
+              "(old points stay fixed)")
+
+    # old rows verbatim, new rows appended in the same dtype
+    coord_dtype = source_df["x"].dtype
+    new_df = pd.DataFrame(new_coords.astype(coord_dtype), columns=['x', 'y'])
+    df = pd.concat([source_df[['x', 'y']], new_df], ignore_index=True)
+    output_file = os.path.join(umap_dir, f"{umap_id}.parquet")
+    df.to_parquet(output_file)
+    print("wrote", output_file)
+
+    fig, ax = plt.subplots(figsize=(14.22, 14.22))  # 1024px by 1024px at 72 dpi
+    point_size = calculate_point_size(len(df))
+    print("POINT SIZE", point_size, "for", len(df), "points")
+    plt.scatter(df['x'], df['y'], s=point_size, alpha=0.5)
+    plt.axis('off')  # remove axis
+    plt.gca().set_position([0, 0, 1, 1])  # remove margins
+    plt.savefig(os.path.join(umap_dir, f"{umap_id}.png"))
+
+    with open(os.path.join(umap_dir, f'{umap_id}.json'), 'w') as f:
+        meta = {
+            "id": umap_id,
+            "embedding_id": embedding_id,
+            # inherited from the source for provenance; the pickled reducer
+            # already encodes them
+            "neighbors": source_meta.get("neighbors"),
+            "min_dist": source_meta.get("min_dist"),
+            # the source's frame is this umap's frame
+            "min_values": min_values.tolist(),
+            "max_values": max_values.tolist(),
+            "transformed_from": transform_from,
+            "reducer_id": reducer_id,
+        }
+        if registration is not None:
+            meta["registration"] = registration
+        if name is not None:
+            meta["name"] = name
+        if description is not None:
+            meta["description"] = description
+        json.dump(meta, f, indent=2)
+
+    print("done with", umap_id)
+    return umap_id
+
+
 def umapper(dataset_id, embedding_id, neighbors=25, min_dist=0.1, save=False, init=None, align=None,
-            seed=None, name=None, description=None):
+            seed=None, register_to=None, name=None, description=None):
     DATA_DIR = get_data_dir()
     # read in the embeddings
 
@@ -172,16 +351,8 @@ def umapper(dataset_id, embedding_id, neighbors=25, min_dist=0.1, save=False, in
 
     # determine the index of the last umap run by looking in the dataset directory
     # for files named umap-<number>.json
-    umap_files = [f for f in os.listdir(umap_dir) if re.match(r"umap-\d+\.json", f)]
-    if len(umap_files) > 0:
-        last_umap = sorted(umap_files)[-1]
-        last_umap_number = int(last_umap.split("-")[1].split(".")[0])
-        next_umap_number = last_umap_number + 1
-    else:
-        next_umap_number = 1
-
-    # make the umap name from the number, zero padded to 3 digits
-    umap_id = f"umap-{next_umap_number:03d}"
+    umap_id = _next_umap_id(umap_dir)
+    next_umap_number = int(umap_id.split("-")[1])
     print("RUNNING:", umap_id)
 
     import pickle
@@ -192,6 +363,12 @@ def umapper(dataset_id, embedding_id, neighbors=25, min_dist=0.1, save=False, in
     import pandas as pd
     import umap
 
+    from latentscope.scripts.registration import (
+        count_out_of_frame,
+        prefix_relations,
+        register_layout,
+    )
+
     print("loading embeddings")
     # embedding_path = os.path.join(DATA_DIR, dataset_id, "embeddings", f"{embedding_id}.h5")
     # with h5py.File(embedding_path, 'r') as f:
@@ -199,15 +376,51 @@ def umapper(dataset_id, embedding_id, neighbors=25, min_dist=0.1, save=False, in
     #     embeddings = np.array(dataset)
     embeddings = load_embeddings(dataset_id, embedding_id)
 
+    # --register-to: load the published layout the new one should be anchored to
+    register_target = None
+    if register_to is not None and register_to != "":
+        print("registering onto", register_to)
+        target_meta = _read_umap_meta(umap_dir, register_to)
+        target_df = pd.read_parquet(os.path.join(umap_dir, f"{register_to}.parquet"))
+        register_target = {
+            "umap_id": register_to,
+            "coords": target_df[['x', 'y']].to_numpy(),
+            # after registration the coords are already in the target's [-1, 1]
+            # frame, so the target's frame values carry over (identity fallback
+            # for old metas without them)
+            "min_values": target_meta.get("min_values", [-1.0, -1.0]),
+            "max_values": target_meta.get("max_values", [1.0, 1.0]),
+        }
+
     def process_umap_embeddings(umap_id, umap_embeddings, emb_id, align_id=None):
-        min_values = np.min(umap_embeddings, axis=0)
-        max_values = np.max(umap_embeddings, axis=0)
+        registration = None
+        if register_target is not None:
+            # similarity-register (rotation + uniform scale + translation) onto
+            # the target via the shared row prefix; the result is already in the
+            # target's [-1, 1] frame so min/max renormalization is skipped
+            umap_embeddings, (r_scale, r_rot, r_trans) = register_layout(
+                umap_embeddings, register_target["coords"])
+            umap_embeddings = umap_embeddings.astype(np.float32)
+            registration = {
+                "scale": float(r_scale),
+                "rotation": r_rot.tolist(),
+                "translation": r_trans.tolist(),
+            }
+            min_values = np.array(register_target["min_values"])
+            max_values = np.array(register_target["max_values"])
+            outside = count_out_of_frame(umap_embeddings)
+            if outside > 0:
+                print(f"{umap_id}: {outside} registered points fall outside [-1, 1]; "
+                      "not rescaling")
+        else:
+            min_values = np.min(umap_embeddings, axis=0)
+            max_values = np.max(umap_embeddings, axis=0)
 
-        # Scale the embeddings to the range [0, 1]
-        umap_embeddings = (umap_embeddings - min_values) / (max_values - min_values)
+            # Scale the embeddings to the range [0, 1]
+            umap_embeddings = (umap_embeddings - min_values) / (max_values - min_values)
 
-        # Scale the embeddings to the range [-1, 1]
-        umap_embeddings = 2 * umap_embeddings - 1
+            # Scale the embeddings to the range [-1, 1]
+            umap_embeddings = 2 * umap_embeddings - 1
 
         print("writing normalized umap", umap_id)
         # save umap embeddings to a parquet file with columns x,y
@@ -262,6 +475,9 @@ def umapper(dataset_id, embedding_id, neighbors=25, min_dist=0.1, save=False, in
             if align is not None and align != "":
                 meta["align"] = f"{embedding_id},{align}"
                 meta["align_id"] = align_id
+            if register_target is not None:
+                meta["registered_to"] = register_target["umap_id"]
+                meta["registration"] = registration
             if name is not None:
                 meta["name"] = name
             if description is not None:
@@ -305,9 +521,14 @@ def umapper(dataset_id, embedding_id, neighbors=25, min_dist=0.1, save=False, in
             n_components=2,
             verbose=True,
         )
-        print("a_embeddings", len(a_embeddings), a_embeddings[0].shape[0])
-        relations = [{j: j for j in range(a_embeddings[i].shape[0])} for i in range(len(a_embeddings)-1)]
-        print("relations", len(relations))
+        # shared-prefix relations: for growing (append-only) windows the shared
+        # rows between window i and i+1 are the index prefix of the shorter one;
+        # identical to the old identity relations when lengths are equal
+        lengths = [a_emb.shape[0] for a_emb in a_embeddings]
+        print("a_embeddings", len(a_embeddings), "lengths", lengths)
+        relations = prefix_relations(lengths)
+        for i, rel in enumerate(relations):
+            print(f"relation {i} -> {i + 1}: {len(rel)} shared rows")
         aligned = reducer.fit_transform(a_embeddings, relations=relations)
         print("ALIGNED", aligned)
         for i,emb in enumerate(a_embedding_ids):
@@ -354,16 +575,7 @@ def sparse_umapper(dataset_id, embedding_id, sae_id, neighbors=25, min_dist=0.1,
 
     # determine the index of the last umap run by looking in the dataset directory
     # for files named umap-<number>.json
-    umap_files = [f for f in os.listdir(umap_dir) if re.match(r"umap-\d+\.json", f)]
-    if len(umap_files) > 0:
-        last_umap = sorted(umap_files)[-1]
-        last_umap_number = int(last_umap.split("-")[1].split(".")[0])
-        next_umap_number = last_umap_number + 1
-    else:
-        next_umap_number = 1
-
-    # make the umap name from the number, zero padded to 3 digits
-    umap_id = f"umap-{next_umap_number:03d}"
+    umap_id = _next_umap_id(umap_dir)
     print("RUNNING:", umap_id)
 
     import pickle

--- a/latentscope/scripts/umapper.py
+++ b/latentscope/scripts/umapper.py
@@ -531,9 +531,28 @@ def umapper(dataset_id, embedding_id, neighbors=25, min_dist=0.1, save=False, in
             print(f"relation {i} -> {i + 1}: {len(rel)} shared rows")
         aligned = reducer.fit_transform(a_embeddings, relations=relations)
         print("ALIGNED", aligned)
+        import pickle
+        mappers = getattr(reducer, "mappers_", None)
         for i,emb in enumerate(a_embedding_ids):
+            aligned_umap_id = f"umap-{next_umap_number+i:03d}"
             print("processing", emb, "umap", next_umap_number+i)
-            process_umap_embeddings(f"umap-{next_umap_number+i:03d}", aligned[i], emb, umap_id)
+            process_umap_embeddings(aligned_umap_id, aligned[i], emb, umap_id)
+            if save and mappers is not None:
+                # Each slice's mapper is a full fitted UMAP, but its internal
+                # embedding_ lives in the mapper's OWN frame, not the aligned
+                # frame that was just written (alignment happens outside the
+                # mappers). UMAP.transform embeds new points relative to
+                # embedding_, so swap in the slice's aligned coordinates
+                # before pickling — a later --transform-from then projects
+                # newly appended rows into this slice's raw aligned frame,
+                # and the meta's min/max (or registration transform) carries
+                # them into the published frame.
+                mapper = mappers[i]
+                mapper.embedding_ = np.ascontiguousarray(
+                    np.asarray(aligned[i]), dtype=np.float32)
+                with open(os.path.join(umap_dir, f"{aligned_umap_id}.pkl"), "wb") as f:
+                    pickle.dump(mapper, f)
+                print(f"saved aligned reducer to {aligned_umap_id}.pkl")
 
         print("done with aligned umap")
         return

--- a/latentscope/server/jobs.py
+++ b/latentscope/server/jobs.py
@@ -490,18 +490,32 @@ def run_umap():
     align = request.values.get('align')
     save = request.values.get('save')
     seed = request.values.get('seed')
+    # Incremental / registered umaps (issue #142)
+    transform_from = request.values.get('transform_from')
+    register_to = request.values.get('register_to')
     # Optional named-step metadata (issue: experiment gallery + named steps).
     # Consumed by ls-umap (WP-A) and written into umap-NNN.json.
     name = request.values.get('name')
     description = request.values.get('description')
 
-    err = _require_params(dataset=dataset, embedding_id=embedding_id,
-                          neighbors=neighbors, min_dist=min_dist)
+    if transform_from:
+        # neighbors/min_dist are ignored by the transform path (the saved
+        # reducer already encodes them)
+        err = _require_params(dataset=dataset, embedding_id=embedding_id)
+    else:
+        err = _require_params(dataset=dataset, embedding_id=embedding_id,
+                              neighbors=neighbors, min_dist=min_dist)
     if err:
         return err
 
     job_id = str(uuid.uuid4())
-    command = ['ls-umap', dataset, embedding_id, neighbors, min_dist]
+    command = ['ls-umap', dataset, embedding_id]
+    if neighbors is not None and min_dist is not None:
+        command += [neighbors, min_dist]
+    if transform_from:
+        command.append(f'--transform-from={transform_from}')
+    if register_to:
+        command.append(f'--register-to={register_to}')
     if init:
         command.append(f'--init={init}')
     if align:

--- a/tests/test_umap_incremental.py
+++ b/tests/test_umap_incremental.py
@@ -1,0 +1,287 @@
+"""Incremental / aligned UMAP workflows (issue #142).
+
+Covers the pure helpers in latentscope/scripts/registration.py (umeyama
+similarity registration, growing-window AlignedUMAP relations, source-frame
+normalization) and the ``ls-umap --transform-from`` flow driven through a fake
+pickled reducer — no real UMAP/AlignedUMAP fits are run here.
+"""
+import json
+import os
+import pickle
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from latentscope.scripts.registration import (
+    apply_normalization,
+    apply_similarity,
+    count_out_of_frame,
+    prefix_relations,
+    register_layout,
+    umeyama_2d,
+)
+from tests.test_pipeline_e2e import FakeEmbedProvider, make_input_df
+
+N_ROWS = 120  # make_input_df(): 3 topics x 40 rows
+
+
+# ---------------------------------------------------------------------------
+# umeyama similarity registration (pure)
+# ---------------------------------------------------------------------------
+
+def _rotation(theta):
+    return np.array([[np.cos(theta), -np.sin(theta)],
+                     [np.sin(theta), np.cos(theta)]])
+
+
+def test_umeyama_recovers_similarity_transform():
+    rng = np.random.default_rng(0)
+    src = rng.normal(size=(50, 2))
+    c, R, t = 2.5, _rotation(0.7), np.array([3.0, -1.0])
+    dst = c * src @ R.T + t
+
+    c_hat, R_hat, t_hat = umeyama_2d(src, dst)
+    assert abs(c_hat - c) < 1e-6
+    assert np.allclose(R_hat, R, atol=1e-6)
+    assert np.allclose(t_hat, t, atol=1e-6)
+    assert np.allclose(apply_similarity(src, c_hat, R_hat, t_hat), dst, atol=1e-6)
+
+
+def test_umeyama_recovers_reflection():
+    rng = np.random.default_rng(1)
+    src = rng.normal(size=(40, 2))
+    reflect = np.array([[1.0, 0.0], [0.0, -1.0]])
+    R = _rotation(-0.3) @ reflect  # improper: det = -1
+    c, t = 0.4, np.array([-2.0, 5.0])
+    dst = c * src @ R.T + t
+
+    c_hat, R_hat, t_hat = umeyama_2d(src, dst)
+    assert abs(np.linalg.det(R_hat) + 1.0) < 1e-6  # reflection preserved
+    assert np.allclose(apply_similarity(src, c_hat, R_hat, t_hat), dst, atol=1e-6)
+
+
+def test_umeyama_rejects_degenerate_input():
+    with pytest.raises(ValueError):
+        umeyama_2d(np.zeros((1, 2)), np.zeros((1, 2)))
+    with pytest.raises(ValueError):
+        umeyama_2d(np.ones((5, 2)), np.random.default_rng(2).normal(size=(5, 2)))
+    with pytest.raises(ValueError):
+        umeyama_2d(np.zeros((5, 2)), np.zeros((4, 2)))
+
+
+def test_register_layout_uses_shared_prefix():
+    rng = np.random.default_rng(3)
+    new_layout = rng.normal(size=(30, 2))
+    c, R, t = 1.7, _rotation(1.1), np.array([0.5, 0.25])
+    # target only covers the first 20 rows (the published, smaller layout)
+    target = c * new_layout[:20] @ R.T + t
+
+    registered, (c_hat, R_hat, t_hat) = register_layout(new_layout, target)
+    assert registered.shape == (30, 2)
+    # shared prefix lands exactly on the target; the tail gets the same transform
+    assert np.allclose(registered[:20], target, atol=1e-6)
+    assert np.allclose(registered, apply_similarity(new_layout, c_hat, R_hat, t_hat))
+    assert abs(c_hat - c) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# growing-window relations (pure)
+# ---------------------------------------------------------------------------
+
+def test_prefix_relations_unequal_lengths():
+    relations = prefix_relations([5, 8, 3])
+    assert len(relations) == 2
+    assert relations[0] == {j: j for j in range(5)}  # min(5, 8)
+    assert relations[1] == {j: j for j in range(3)}  # min(8, 3)
+
+
+def test_prefix_relations_equal_lengths_match_identity():
+    relations = prefix_relations([4, 4])
+    assert relations == [{0: 0, 1: 1, 2: 2, 3: 3}]
+
+
+# ---------------------------------------------------------------------------
+# source-frame normalization (pure)
+# ---------------------------------------------------------------------------
+
+def test_apply_normalization_matches_fit_time_formula():
+    min_values, max_values = np.array([-10.0, 0.0]), np.array([10.0, 4.0])
+    coords = np.array([[-10.0, 0.0], [10.0, 4.0], [0.0, 2.0]])
+    normalized = apply_normalization(coords, min_values, max_values)
+    assert np.allclose(normalized, [[-1.0, -1.0], [1.0, 1.0], [0.0, 0.0]])
+
+
+def test_apply_normalization_allows_out_of_frame_points():
+    normalized = apply_normalization([[15.0, 2.0]], [-10.0, 0.0], [10.0, 4.0])
+    assert normalized[0, 0] > 1.0
+    assert count_out_of_frame(normalized) == 1
+    assert count_out_of_frame([[0.0, 0.0], [-1.0, 1.0]]) == 0
+
+
+# ---------------------------------------------------------------------------
+# --transform-from flow (fake pickled reducer; no real UMAP fit)
+# ---------------------------------------------------------------------------
+
+class FakeReducer:
+    """Picklable stand-in for a fitted CPU umap reducer."""
+
+    def transform(self, X):
+        X = np.asarray(X)
+        return np.stack([X[:, 0] * 10.0, X[:, 1] * 10.0], axis=1).astype(np.float32)
+
+
+@pytest.fixture
+def embedded_dataset(tmp_data_dir, monkeypatch):
+    monkeypatch.setenv("LATENT_SCOPE_DATA", tmp_data_dir)
+    monkeypatch.setenv("LATENT_SCOPE_NO_DOTENV", "1")
+
+    import latentscope.scripts.embed as embed_mod
+    monkeypatch.setattr(embed_mod, "get_embedding_model",
+                        lambda model_id: FakeEmbedProvider())
+
+    from latentscope.scripts.embed import embed
+    from latentscope.scripts.ingest import ingest
+
+    dataset_id = "incremental"
+    ingest(dataset_id, make_input_df(), text_column="text")
+    embed(dataset_id, "text", "fake-test-model", prefix=None, rerun=None,
+          dimensions=None, batch_size=50)
+    return tmp_data_dir, dataset_id
+
+
+def _make_source_umap(data_dir, dataset_id, n_old, umap_id="umap-001",
+                      embedding_id="embedding-001", with_pkl=True, extra_meta=None):
+    """Fabricate a previously published umap (parquet + meta + optional pickle)."""
+    umap_dir = os.path.join(data_dir, dataset_id, "umaps")
+    os.makedirs(umap_dir, exist_ok=True)
+
+    rng = np.random.default_rng(7)
+    coords = rng.uniform(-1, 1, size=(n_old, 2)).astype(np.float32)
+    pd.DataFrame(coords, columns=["x", "y"]).to_parquet(
+        os.path.join(umap_dir, f"{umap_id}.parquet"))
+
+    meta = {
+        "id": umap_id,
+        "embedding_id": embedding_id,
+        "neighbors": 25,
+        "min_dist": 0.1,
+        "min_values": [-12.0, -12.0],
+        "max_values": [12.0, 12.0],
+    }
+    if extra_meta:
+        meta.update(extra_meta)
+    with open(os.path.join(umap_dir, f"{umap_id}.json"), "w") as f:
+        json.dump(meta, f)
+
+    if with_pkl:
+        with open(os.path.join(umap_dir, f"{umap_id}.pkl"), "wb") as f:
+            pickle.dump(FakeReducer(), f)
+    return umap_dir
+
+
+def test_transform_from_appends_new_rows(embedded_dataset):
+    data_dir, dataset_id = embedded_dataset
+    from latentscope.scripts.umapper import transform_umap
+    umap_dir = _make_source_umap(data_dir, dataset_id, n_old=100)
+
+    new_id = transform_umap(dataset_id, "embedding-001", "umap-001")
+    assert new_id == "umap-002"
+
+    old = pd.read_parquet(os.path.join(umap_dir, "umap-001.parquet"))
+    combined = pd.read_parquet(os.path.join(umap_dir, "umap-002.parquet"))
+    assert len(combined) == N_ROWS
+    # old rows are copied verbatim (published positions stay pixel-stable)
+    assert np.array_equal(old[["x", "y"]].to_numpy(),
+                          combined.iloc[:100][["x", "y"]].to_numpy())
+
+    # new rows are the reducer output mapped into the SOURCE's [-1, 1] frame
+    from latentscope.util.embedding_store import load_embeddings
+    embeddings = load_embeddings(data_dir, dataset_id, "embedding-001")
+    expected = apply_normalization(FakeReducer().transform(embeddings[100:]),
+                                   [-12.0, -12.0], [12.0, 12.0])
+    assert np.allclose(combined.iloc[100:][["x", "y"]].to_numpy(), expected, atol=1e-5)
+
+    with open(os.path.join(umap_dir, "umap-002.json")) as f:
+        meta = json.load(f)
+    assert meta["transformed_from"] == "umap-001"
+    assert meta["reducer_id"] == "umap-001"
+    assert meta["embedding_id"] == "embedding-001"
+    # the source's frame carries over
+    assert meta["min_values"] == [-12.0, -12.0]
+    assert meta["max_values"] == [12.0, 12.0]
+    # the reducer pickle is NOT copied (they are large); the chain resolves it
+    assert not os.path.exists(os.path.join(umap_dir, "umap-002.pkl"))
+    assert os.path.exists(os.path.join(umap_dir, "umap-002.png"))
+
+
+def test_transform_from_resolves_reducer_chain(embedded_dataset):
+    data_dir, dataset_id = embedded_dataset
+    from latentscope.scripts.umapper import transform_umap
+    umap_dir = _make_source_umap(data_dir, dataset_id, n_old=90, umap_id="umap-001")
+    # umap-002 was itself a transform output: no pickle of its own, but its meta
+    # points back to the umap whose reducer produced it
+    _make_source_umap(data_dir, dataset_id, n_old=100, umap_id="umap-002",
+                      with_pkl=False,
+                      extra_meta={"transformed_from": "umap-001",
+                                  "reducer_id": "umap-001"})
+
+    new_id = transform_umap(dataset_id, "embedding-001", "umap-002")
+    assert new_id == "umap-003"
+    combined = pd.read_parquet(os.path.join(umap_dir, "umap-003.parquet"))
+    assert len(combined) == N_ROWS
+
+    with open(os.path.join(umap_dir, "umap-003.json")) as f:
+        meta = json.load(f)
+    assert meta["transformed_from"] == "umap-002"
+    assert meta["reducer_id"] == "umap-001"
+
+
+def test_transform_from_registered_source_uses_similarity(embedded_dataset):
+    data_dir, dataset_id = embedded_dataset
+    from latentscope.scripts.umapper import transform_umap
+    registration = {"scale": 0.05,
+                    "rotation": [[0.0, -1.0], [1.0, 0.0]],
+                    "translation": [0.1, -0.2]}
+    umap_dir = _make_source_umap(data_dir, dataset_id, n_old=100,
+                                 extra_meta={"registered_to": "umap-000",
+                                             "registration": registration})
+
+    new_id = transform_umap(dataset_id, "embedding-001", "umap-001")
+    combined = pd.read_parquet(os.path.join(umap_dir, f"{new_id}.parquet"))
+
+    from latentscope.util.embedding_store import load_embeddings
+    embeddings = load_embeddings(data_dir, dataset_id, "embedding-001")
+    expected = apply_similarity(FakeReducer().transform(embeddings[100:]),
+                                registration["scale"],
+                                np.array(registration["rotation"]),
+                                np.array(registration["translation"]))
+    assert np.allclose(combined.iloc[100:][["x", "y"]].to_numpy(), expected, atol=1e-5)
+
+
+def test_transform_from_errors_without_saved_reducer(embedded_dataset):
+    data_dir, dataset_id = embedded_dataset
+    from latentscope.scripts.umapper import transform_umap
+    _make_source_umap(data_dir, dataset_id, n_old=100, with_pkl=False)
+
+    with pytest.raises(ValueError, match="--save"):
+        transform_umap(dataset_id, "embedding-001", "umap-001")
+
+
+def test_transform_from_errors_on_mismatched_embedding(embedded_dataset):
+    data_dir, dataset_id = embedded_dataset
+    from latentscope.scripts.umapper import transform_umap
+    _make_source_umap(data_dir, dataset_id, n_old=100)
+
+    with pytest.raises(ValueError, match="embedding"):
+        transform_umap(dataset_id, "embedding-002", "umap-001")
+
+
+def test_transform_from_no_new_rows_is_a_noop(embedded_dataset):
+    data_dir, dataset_id = embedded_dataset
+    from latentscope.scripts.umapper import transform_umap
+    umap_dir = _make_source_umap(data_dir, dataset_id, n_old=N_ROWS)
+
+    assert transform_umap(dataset_id, "embedding-001", "umap-001") is None
+    assert not os.path.exists(os.path.join(umap_dir, "umap-002.json"))
+    assert not os.path.exists(os.path.join(umap_dir, "umap-002.parquet"))

--- a/tests/test_umap_incremental.py
+++ b/tests/test_umap_incremental.py
@@ -180,6 +180,48 @@ def _make_source_umap(data_dir, dataset_id, n_old, umap_id="umap-001",
     return umap_dir
 
 
+class FakeAlignedUMAP:
+    """Stand-in for umap.AlignedUMAP exposing fit_transform + mappers_."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def fit_transform(self, embeddings, relations=None):
+        self.mappers_ = [FakeReducer() for _ in embeddings]
+        return [np.asarray(e)[:, :2].astype(np.float32) for e in embeddings]
+
+
+def test_align_save_persists_per_slice_reducers(embedded_dataset, monkeypatch):
+    """--align --save writes a .pkl per aligned output, so the documented
+    periodic-refit -> daily --transform-from cadence actually works (the align
+    branch used to return before the save path, leaving the refit with no
+    reducer)."""
+    data_dir, dataset_id = embedded_dataset
+    import umap
+    monkeypatch.setattr(umap, "AlignedUMAP", FakeAlignedUMAP)
+    from latentscope.scripts.umapper import transform_umap, umapper
+
+    # align the embedding with itself: two equal windows, two aligned outputs
+    umapper(dataset_id, "embedding-001", neighbors=5, min_dist=0.1,
+            align="embedding-001", save=True)
+
+    umap_dir = os.path.join(data_dir, dataset_id, "umaps")
+    for uid in ("umap-001", "umap-002"):
+        pkl_path = os.path.join(umap_dir, f"{uid}.pkl")
+        assert os.path.exists(pkl_path), f"{uid} missing its saved reducer"
+        with open(pkl_path, "rb") as f:
+            saved = pickle.load(f)
+        assert hasattr(saved, "transform")
+        # the pickled mapper's embedding_ must be the slice's ALIGNED frame
+        # (mappers' own frames differ from the aligned outputs), so that
+        # transform() of new rows lands in the frame the parquet was built from
+        assert saved.embedding_.shape == (N_ROWS, 2)
+
+    # the daily cadence resolves the aligned output's reducer: resolution and
+    # pickle.load happen BEFORE the no-new-rows noop, so None means success
+    assert transform_umap(dataset_id, "embedding-001", "umap-002") is None
+
+
 def test_transform_from_appends_new_rows(embedded_dataset):
     data_dir, dataset_id = embedded_dataset
     from latentscope.scripts.umapper import transform_umap


### PR DESCRIPTION
Closes #142.

A daily-growing dataset can now keep a visually stable published map:

- **`ls-umap <ds> <emb> --transform-from <umap-id>`** — loads the source umap's saved (`--save`) reducer pickle (following the `reducer_id` chain when the source was itself a transform output), projects only the rows appended since the source, and maps them into the source's `[-1,1]` frame via its stored min/max — or via its registration transform if the source was registered, so the daily cadence keeps working after a registered refit. Old rows are copied verbatim (byte-identical) so published positions never move; out-of-frame new points are left in place and counted. Pickles are never copied.
- **Growing-window `--align`** — identity relations replaced by shared-prefix relations `{j: j for j in range(min(len_i, len_i+1))}`; identical to old behavior for equal lengths, supports append-only windows.
- **`--register-to <umap-id>`** — registers a plain or aligned fit onto an existing umap with a least-squares 2D similarity transform (Umeyama; rotation + uniform scale + translation, reflections allowed) fit on the shared row prefix. Output is already in the target's frame (no renormalization); meta records `registered_to` + the transform.
- **`docs/umap.md`** — the daily/periodic recipe, plus the `--seed`→single-threaded-fit caveat and reducer-pickle size/pruning notes from the issue.

Both new flags are forwarded by the server job route. Pure numpy pieces live in `latentscope/scripts/registration.py`.

Recipe:
```bash
ls-umap mydata embedding-001 25 0.1 --save                       # once: fit + save reducer
ls-umap mydata embedding-001 --transform-from umap-001           # daily: project new rows
ls-umap mydata embedding-002 25 0.1 --align embedding-001 --register-to umap-001 --save  # periodic refit
```

## Test plan

- `uv run pytest tests/ -q` — 233 passed (14 new: umeyama recovery incl. reflection/degenerate cases, prefix relations for unequal windows, normalization, and the full transform flow via a fake pickled reducer — success, chain resolution, registered source, missing pkl, mismatched embedding, no-new-rows)
- Verified end-to-end with real UMAP/AlignedUMAP fits on a 120-row dataset: daily transform kept 100 old rows byte-stable and appended 20; growing align (100→120) + register wrote both slices anchored to the published frame
- Behavior with none of the new flags is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)