### PR TITLE
Clustering/embedding frictions: honest noise by default, EVoC knobs, MPS OOM preflight, debug cleanup

### DIFF
--- a/.claude/skills/latent-scope/SKILL.md
+++ b/.claude/skills/latent-scope/SKILL.md
@@ -23,7 +23,9 @@ uv run ls-cluster mydata umap-001 25 5 0.0 --method hdbscan
 uv run ls-scope   mydata embedding-001 umap-001 cluster-001 default "My scope" "desc"
 uv run ls-serve   $LATENT_SCOPE_DATA          # http://localhost:5001 — show the user
 ```
-(`ls-cluster` auto-writes `default` labels, so no LLM is required for a first map.)
+(`ls-cluster` auto-writes `default` labels, so no LLM is required for a first map.
+HDBSCAN/EVoC noise becomes an explicit "Unclustered" cluster — that's expected,
+not a bug; `--assign-noise` restores nearest-centroid reassignment.)
 
 ## Fast path — images (point at a folder)
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ tiny dataset, embeds it on CPU, runs the whole pipeline, and verifies search.
 | ingest | `ls-ingest <ds> --path <file-or-image-dir> --text_column <col>` (or a DataFrame via the library API) | `input.parquet`, `meta.json` (column detection) |
 | embed | `ls-embed <ds> <col> <model_id> [--task] [--prefix] [--dimensions] [--batch_size] [--max_seq_length]` | `embeddings/embedding-NNN.*` (LanceDB) |
 | umap | `ls-umap <ds> <embedding_id> <neighbors> <min_dist> [--name --description]` | `umaps/umap-NNN.*` (x,y in [-1,1]) |
-| cluster | `ls-cluster <ds> <umap_id> <samples> <min_samples> <epsilon> [--method] [--cluster_on] [--name]` | `clusters/cluster-NNN.*` + `…-labels-default.parquet` |
+| cluster | `ls-cluster <ds> <umap_id> <samples> <min_samples> <epsilon> [--method] [--cluster_on] [--assign-noise] [--seed] [--name]` | `clusters/cluster-NNN.*` + `…-labels-default.parquet` (noise → an "Unclustered" cluster unless `--assign-noise`) |
 | label | `ls-label <ds> <text_col> <cluster_id> <chat_model_id> <samples> <context>` | `clusters/<cluster>-labels-NNN.parquet` |
 | scope | `ls-scope <ds> <embedding_id> <umap_id> <cluster_id> <labels_id> "<label>" "<desc>"` | `scopes/scopes-NNN.*` + per-scope LanceDB |
 | atlas | `ls-sprite-atlas <ds> <scope_id> <image_column>` (image datasets only) | tiled image pyramid for the image map |
@@ -176,6 +176,16 @@ the auto prompt (they don't stack), for models that use raw instruction prefixes
 input space with `--cluster_on {umap,embedding}` — cluster on the 2D projection
 (spatially coherent) or the high-dim embeddings (semantically tighter). EVoC and
 HDBSCAN find the cluster count for you; kmeans/gmm need it.
+
+**Noise is honest by default**: HDBSCAN/EVoC noise points land in an explicit
+**"Unclustered"** cluster (empty hull, excluded from LLM labeling) instead of
+being silently reassigned to the nearest centroid — expect one when a run
+prints a `NOISE: N points (P%)` line. Pass `--assign-noise` for the old
+reassignment behavior. Steering: `--seed` (reproducible evoc/kmeans/gmm),
+`--approx_n_clusters` / `--base_n_clusters` (evoc granularity targets), and
+note HDBSCAN's `min_cluster_size` has **cliff behavior** (a small bump can
+collapse dozens of clusters into a few) while `min_samples 1` reduces noise
+without collapsing — see `docs/clustering.md`.
 
 ---
 

--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -8,7 +8,9 @@ high-dimensional embedding ([issue #41](https://github.com/enjalot/latent-scope/
 ```bash
 # ls-cluster <dataset_id> <umap_id> <samples> <min_samples> <cluster_selection_epsilon> [column]
 #            [--method {evoc,hdbscan,kmeans,gmm}] [--cluster_on {umap,embedding}]
-#            [--n_neighbors N] [--noise_level F] [--name ...] [--description ...]
+#            [--n_neighbors N] [--noise_level F] [--approx_n_clusters N]
+#            [--base_n_clusters N] [--seed N] [--assign-noise]
+#            [--name ...] [--description ...]
 ls-cluster mydataset umap-001 5 3 0.0 --method hdbscan
 ```
 
@@ -28,8 +30,15 @@ are only meaningful for HDBSCAN but must still be supplied for the other methods
 | `gmm` | scikit-learn (`GaussianMixture`) | **number of clusters (components)** | no |
 
 - **EVoC** and **HDBSCAN** are density-based: `samples` is the minimum cluster
-  size, and points that don't fit a cluster are marked as noise (`-1`) and then
-  reassigned to their nearest cluster centroid.
+  size, and points that don't fit a cluster are marked as noise (`-1`). By
+  default the noise points are kept as an explicit extra cluster labeled
+  **"Unclustered"** (with no hull drawn around it), so the map stays honest
+  about what the algorithm couldn't place. Pass `--assign-noise` to instead
+  reassign every noise point to its nearest cluster centroid (the pre-1.0
+  behavior). Either way the run prints the noise count and percentage, the
+  original `-1` labels are preserved in the `raw_cluster` column, and the run
+  metadata records `n_noise`, `assign_noise`, and (when present) the id of the
+  `unclustered_cluster`.
 - **KMeans** and **GMM** are partitional: `samples` is the target **number of
   clusters**, and every point is always assigned (no noise). `min_samples` and
   `cluster_selection_epsilon` are ignored for these methods but still positional:
@@ -40,8 +49,25 @@ are only meaningful for HDBSCAN but must still be supplied for the other methods
   ls-cluster mydataset umap-001 15 3 0.0 --method gmm
   ```
 
-EVoC-only tuning flags: `--n_neighbors` (kNN graph, default 15) and
-`--noise_level` (0.0–1.0, default 0.5).
+EVoC-only tuning flags: `--n_neighbors` (kNN graph, default 15),
+`--noise_level` (0.0–1.0, default 0.5), `--approx_n_clusters` (aim for roughly
+this many clusters in the final output), and `--base_n_clusters` (target
+exactly this many clusters at the finest layer of the hierarchy). The
+`min_samples` positional is forwarded to EVoC as well as HDBSCAN. `--seed`
+makes `evoc`, `kmeans`, and `gmm` runs reproducible (HDBSCAN is deterministic
+for a fixed input).
+
+### HDBSCAN parameter sensitivity
+
+`min_cluster_size` (the `samples` positional) has **cliff behavior**: small
+changes can collapse the clustering. On one real dataset, moving
+`min_cluster_size` from 150 to 160 dropped the result from 53 clusters to 3,
+and on another from 110 to 120 dropped it from 55 to 5. Where the cliff sits is
+specific to each embedding, so sweep the value in small steps around your
+current setting rather than jumping by large factors. Separately,
+`min_samples=1` is an effective lever for reducing the noise fraction — in the
+same report it cut noise from 33% to ~25% of the dataset — without collapsing
+the clustering the way a larger `min_cluster_size` can.
 
 ---
 

--- a/latentscope/scripts/cluster.py
+++ b/latentscope/scripts/cluster.py
@@ -329,7 +329,12 @@ def clusterer(dataset_id, umap_id, samples, min_samples, cluster_selection_epsil
             # All-noise runs (non_noise_labels empty) also land here — even
             # with --assign-noise there are no centroids to reassign to, so
             # everything becomes one big Unclustered cluster with id 0.
-            unclustered_cluster = int(non_noise_labels.shape[0])
+            # max+1 (not len) so a non-dense label set (e.g. the `column`
+            # path supplying labels {1, 2}) can never collide with a real
+            # cluster id; for dense 0..n-1 output the two are identical.
+            unclustered_cluster = (
+                int(non_noise_labels.max()) + 1 if non_noise_labels.shape[0] > 0 else 0
+            )
             cluster_labels[cluster_labels == -1] = unclustered_cluster
             if assign_noise:
                 hint = ("--assign-noise had no effect: there are no non-noise "

--- a/latentscope/scripts/cluster.py
+++ b/latentscope/scripts/cluster.py
@@ -58,6 +58,16 @@ def main():
     parser.add_argument('--approx_n_clusters', type=int, default=None,
                         help='EVoC: aim for approximately this many clusters '
                              '(picks the closest cluster layer)')
+    parser.add_argument('--base_n_clusters', type=int, default=None,
+                        help='EVoC: target exactly this many clusters at the '
+                             'base (finest) layer of the hierarchy')
+    parser.add_argument('--seed', type=int, default=None,
+                        help='Random seed for evoc/kmeans/gmm (reproducible runs)')
+    parser.add_argument('--assign-noise', dest='assign_noise', action='store_true',
+                        help='Reassign HDBSCAN/EVoC noise points (-1) to their '
+                             'nearest cluster centroid (pre-1.0 behavior). By '
+                             'default noise points are kept as a separate '
+                             '"Unclustered" cluster.')
     parser.add_argument('--name', type=str, default=None,
                         help='Human-friendly title for this cluster run')
     parser.add_argument('--description', type=str, default=None,
@@ -69,6 +79,8 @@ def main():
               method=args.method, cluster_on=args.cluster_on,
               n_neighbors=args.n_neighbors, noise_level=args.noise_level,
               approx_n_clusters=args.approx_n_clusters,
+              base_n_clusters=args.base_n_clusters, seed=args.seed,
+              assign_noise=args.assign_noise,
               name=args.name, description=args.description)
 
 
@@ -105,7 +117,8 @@ def _evoc_node_embedding_dim(n_features, n_neighbors):
     return None
 
 
-def _run_evoc(embeddings, samples, n_neighbors=15, noise_level=0.5, approx_n_clusters=None):
+def _run_evoc(embeddings, samples, min_samples=5, n_neighbors=15, noise_level=0.5,
+              approx_n_clusters=None, base_n_clusters=None, seed=None):
     """Run EVoC clustering on the input vectors (always CPU — no cuML equivalent)."""
     import evoc
     kwargs = {}
@@ -114,11 +127,17 @@ def _run_evoc(embeddings, samples, n_neighbors=15, noise_level=0.5, approx_n_clu
         kwargs['node_embedding_dim'] = node_dim
     if approx_n_clusters is not None:
         kwargs['approx_n_clusters'] = approx_n_clusters
+    if base_n_clusters is not None:
+        kwargs['base_n_clusters'] = base_n_clusters
+    if seed is not None:
+        kwargs['random_state'] = seed
     print(f"Running EVoC clustering with base_min_cluster_size={samples}, "
-          f"n_neighbors={n_neighbors}, noise_level={noise_level}"
+          f"min_samples={min_samples}, n_neighbors={n_neighbors}, "
+          f"noise_level={noise_level}"
           + (f", {kwargs}" if kwargs else ""))
     clusterer = evoc.EVoC(
         base_min_cluster_size=samples,
+        min_samples=min_samples,
         n_neighbors=n_neighbors,
         noise_level=noise_level,
         **kwargs,
@@ -159,18 +178,19 @@ def _run_hdbscan(embeddings, samples, min_samples, cluster_selection_epsilon, us
     return clusterer.labels_
 
 
-def _run_kmeans(embeddings, n_clusters, use_cuml=False):
+def _run_kmeans(embeddings, n_clusters, use_cuml=False, seed=None):
     """Run KMeans clustering, on the GPU (cuML) when available, else sklearn.
 
     ``n_clusters`` is mapped from the ``samples`` positional CLI argument.
     """
     import numpy as np
 
+    random_state = 42 if seed is None else seed
     if use_cuml:
         try:
             from cuml.cluster import KMeans as cuKMeans
             print(f"Running cuML KMeans clustering with n_clusters={n_clusters}")
-            km = cuKMeans(n_clusters=n_clusters, random_state=42)
+            km = cuKMeans(n_clusters=n_clusters, random_state=random_state)
             labels = km.fit_predict(np.asarray(embeddings, dtype=np.float32))
             return _as_numpy_labels(labels)
         except Exception as e:
@@ -178,25 +198,27 @@ def _run_kmeans(embeddings, n_clusters, use_cuml=False):
 
     from sklearn.cluster import KMeans
     print(f"Running KMeans clustering with n_clusters={n_clusters} (sklearn/CPU)")
-    km = KMeans(n_clusters=n_clusters, n_init=10, random_state=42)
+    km = KMeans(n_clusters=n_clusters, n_init=10, random_state=random_state)
     return km.fit_predict(embeddings)
 
 
-def _run_gmm(embeddings, n_clusters):
+def _run_gmm(embeddings, n_clusters, seed=None):
     """Run Gaussian Mixture Model clustering (sklearn/CPU — no stable cuML equivalent).
 
     ``n_clusters`` (number of mixture components) is mapped from the ``samples``
     positional CLI argument.
     """
     from sklearn.mixture import GaussianMixture
+    random_state = 42 if seed is None else seed
     print(f"Running GMM clustering with n_components={n_clusters} (sklearn/CPU)")
-    gmm = GaussianMixture(n_components=n_clusters, random_state=42)
+    gmm = GaussianMixture(n_components=n_clusters, random_state=random_state)
     return gmm.fit_predict(embeddings)
 
 
 def clusterer(dataset_id, umap_id, samples, min_samples, cluster_selection_epsilon, column,
               method='evoc', cluster_on=None, n_neighbors=15, noise_level=0.5,
-              approx_n_clusters=None, name=None, description=None):
+              approx_n_clusters=None, base_n_clusters=None, seed=None,
+              assign_noise=False, name=None, description=None):
     DATA_DIR = get_data_dir()
     cluster_dir = os.path.join(DATA_DIR, dataset_id, "clusters")
     # Check if clusters directory exists, if not, create it
@@ -258,39 +280,69 @@ def clusterer(dataset_id, umap_id, samples, min_samples, cluster_selection_epsil
             cluster_input = umap_embeddings
 
         if method == 'evoc':
-            cluster_labels = _run_evoc(cluster_input, samples,
+            cluster_labels = _run_evoc(cluster_input, samples, min_samples=min_samples,
                                        n_neighbors=n_neighbors, noise_level=noise_level,
-                                       approx_n_clusters=approx_n_clusters)
+                                       approx_n_clusters=approx_n_clusters,
+                                       base_n_clusters=base_n_clusters, seed=seed)
         elif method == 'kmeans':
-            cluster_labels = _run_kmeans(cluster_input, samples, use_cuml=res.use_cuml)
+            cluster_labels = _run_kmeans(cluster_input, samples, use_cuml=res.use_cuml,
+                                         seed=seed)
         elif method == 'gmm':
-            cluster_labels = _run_gmm(cluster_input, samples)
+            cluster_labels = _run_gmm(cluster_input, samples, seed=seed)
         else:  # hdbscan
             cluster_labels = _run_hdbscan(cluster_input, samples, min_samples,
                                           cluster_selection_epsilon, use_cuml=res.use_cuml)
 
     # copy cluster labels to another array
+    cluster_labels = np.asarray(cluster_labels).copy()
     raw_cluster_labels = cluster_labels.copy()
 
-    # Determine points with no assigned cluster
+    # Determine points with no assigned cluster. kmeans/gmm never emit -1, so
+    # noise handling cleanly no-ops for them.
     unique_labels = np.unique(cluster_labels)
     non_noise_labels = unique_labels[unique_labels != -1]
-    centroids = [umap_embeddings[cluster_labels == label].mean(axis=0) for label in non_noise_labels]
-
-    # Assign noise points to the closest cluster centroid. kmeans/gmm never emit
-    # -1, so noise_points is empty and this block cleanly no-ops for them.
     noise_points = umap_embeddings[cluster_labels == -1]
-    if non_noise_labels.shape[0] > 0 and noise_points.shape[0] > 0:
-        closest_centroid_indices = np.argmin(cdist(noise_points, centroids), axis=1)
+    n_noise = noise_points.shape[0]
 
-        # Update cluster_labels with the new assignments for noise points
-        noise_indices = np.where(cluster_labels == -1)[0]
-        new_assignments = [non_noise_labels[index] for index in closest_centroid_indices]
-        cluster_labels[noise_indices] = new_assignments
+    # Noise handling (issue #143). Default: keep noise honest as an explicit
+    # extra "Unclustered" cluster with the next dense id, so downstream code
+    # (positional label lookup in scope.py, LLM labeling) still sees dense ids
+    # 0..n with no -1. --assign-noise restores the pre-1.0 behavior of
+    # reassigning every noise point to its nearest non-noise cluster centroid.
+    unclustered_cluster = None
+    if n_noise > 0:
+        noise_pct = 100.0 * n_noise / cluster_labels.shape[0]
+        if assign_noise and non_noise_labels.shape[0] > 0:
+            centroids = [umap_embeddings[cluster_labels == label].mean(axis=0)
+                         for label in non_noise_labels]
+            closest_centroid_indices = np.argmin(cdist(noise_points, centroids), axis=1)
 
+            # Update cluster_labels with the new assignments for noise points
+            noise_indices = np.where(cluster_labels == -1)[0]
+            new_assignments = [non_noise_labels[index] for index in closest_centroid_indices]
+            cluster_labels[noise_indices] = new_assignments
+            print(f"NOISE: {n_noise} points ({noise_pct:.1f}% of "
+                  f"{cluster_labels.shape[0]}) reassigned to their nearest "
+                  "cluster centroid (--assign-noise); omit the flag to keep "
+                  "them as a separate 'Unclustered' cluster instead")
+        else:
+            # All-noise runs (non_noise_labels empty) also land here — even
+            # with --assign-noise there are no centroids to reassign to, so
+            # everything becomes one big Unclustered cluster with id 0.
+            unclustered_cluster = int(non_noise_labels.shape[0])
+            cluster_labels[cluster_labels == -1] = unclustered_cluster
+            if assign_noise:
+                hint = ("--assign-noise had no effect: there are no non-noise "
+                        "clusters to reassign to")
+            else:
+                hint = ("pass --assign-noise to reassign them to their nearest "
+                        "cluster centroid instead")
+            print(f"NOISE: {n_noise} points ({noise_pct:.1f}% of "
+                  f"{cluster_labels.shape[0]}) kept as a separate 'Unclustered' "
+                  f"cluster (id {unclustered_cluster}); {hint}")
 
     print("n_clusters:", len(non_noise_labels))
-    print("noise points assigned to clusters:", len(noise_points))
+    print("noise points:", n_noise)
 
     # save umap embeddings to a parquet file with columns x,y
     df = pd.DataFrame({"cluster": cluster_labels, "raw_cluster": raw_cluster_labels})
@@ -349,13 +401,20 @@ def clusterer(dataset_id, umap_id, samples, min_samples, cluster_selection_epsil
         "min_samples": min_samples,
         "cluster_selection_epsilon": cluster_selection_epsilon,
         "n_clusters": len(non_noise_labels),
-        "n_noise": len(noise_points),
+        "n_noise": n_noise,
+        "assign_noise": assign_noise,
     }
+    if unclustered_cluster is not None:
+        meta["unclustered_cluster"] = unclustered_cluster
     if method == 'evoc':
         meta["n_neighbors"] = n_neighbors
         meta["noise_level"] = noise_level
         if approx_n_clusters is not None:
             meta["approx_n_clusters"] = approx_n_clusters
+        if base_n_clusters is not None:
+            meta["base_n_clusters"] = base_n_clusters
+    if seed is not None and method in ('evoc', 'kmeans', 'gmm'):
+        meta["seed"] = seed
     if name is not None:
         meta["name"] = name
     if description is not None:
@@ -371,9 +430,17 @@ def clusterer(dataset_id, umap_id, samples, min_samples, cluster_selection_epsil
     # iterate over the clusters and create a row for each in a new dataframe with a label, description and array of indicies
     slides_df = pd.DataFrame(columns=['label', 'description', 'indices'])
     for cluster_label, indices in tqdm(cluster_indices.items()):
-        label = f"Cluster {cluster_label}"
-        description = f"This is cluster {cluster_label} with {len(indices)} items."
-        hull = hulls_by_label.get(cluster_label, [])
+        if unclustered_cluster is not None and cluster_label == unclustered_cluster:
+            # The noise bucket: give it an honest label and no hull — a convex
+            # hull around scattered noise would cover most of the map.
+            label = "Unclustered"
+            description = (f"{len(indices)} noise points the clustering "
+                           "algorithm did not assign to any cluster.")
+            hull = []
+        else:
+            label = f"Cluster {cluster_label}"
+            description = f"This is cluster {cluster_label} with {len(indices)} items."
+            hull = hulls_by_label.get(cluster_label, [])
         new_row = pd.DataFrame({'label': [label], 'description': [description], 'indices': [list(indices)], 'hull': [hull]})
         slides_df = pd.concat([slides_df, new_row], ignore_index=True)
 

--- a/latentscope/scripts/embed.py
+++ b/latentscope/scripts/embed.py
@@ -212,6 +212,21 @@ def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_si
         except AttributeError:
             print("Warning: This model does not support setting max_seq_length. Continuing with default length.")
 
+    # OOM preflight (#143): report the effective sequence cap and warn when the
+    # model is effectively uncapped and the user didn't cap it themselves.
+    # Never silently cap — that would change the embedding results.
+    effective_max_seq_length = getattr(getattr(model, "model", None),
+                                       "max_seq_length", None)
+    if isinstance(effective_max_seq_length, int):
+        print(f"effective max_seq_length: {effective_max_seq_length}")
+        if max_seq_length is None and effective_max_seq_length > 2048:
+            print("WARNING: this model accepts sequences up to "
+                  f"{effective_max_seq_length} tokens. Long documents times "
+                  f"batch_size={batch_size} can exhaust MPS/CUDA memory. If you "
+                  "hit an out-of-memory error, re-run with something like "
+                  "--max_seq_length 512 --batch_size 32 (note: capping the "
+                  "sequence length changes the resulting embeddings).")
+
     if prefix is None:
         prefix = ""
     # Prompt precedence: an explicit --prefix (user intent) wins over a model's
@@ -320,6 +335,9 @@ def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_si
             print("wrote original data for batch along with processed inputs in _ls_sentences_ column to\n", batch_path)
             print("debug with command:")
             print("ls-embed-debug", batch_path, model_id)
+            print("already-embedded batches are preserved; resume from the last "
+                  "completed batch with:")
+            print(f"ls-embed {dataset_id} {text_column} {model_id} --rerun {embedding_id}")
 
             sys.exit(1)
 
@@ -386,6 +404,14 @@ def embed(dataset_id, text_column, model_id, prefix, rerun, dimensions, batch_si
 
     with open(os.path.join(embedding_dir, f"{embedding_id}.json"), 'w') as f:
         json.dump(meta, f, indent=2)
+
+    # The run completed: any debug batch parquet left behind by an earlier
+    # failed attempt (see the except block above) is now stale — clean it up.
+    debug_pattern = re.compile(rf"{re.escape(embedding_id)}-batch-\d+\.parquet$")
+    stale_debug = [f for f in os.listdir(embedding_dir) if debug_pattern.match(f)]
+    for stale in stale_debug:
+        os.remove(os.path.join(embedding_dir, stale))
+        print("cleaned up stale debug batch file", stale)
 
     print("done with", embedding_id)
 

--- a/latentscope/scripts/label_clusters.py
+++ b/latentscope/scripts/label_clusters.py
@@ -73,6 +73,9 @@ def labeler(dataset_id, text_column="text", cluster_id="cluster-001", model_id="
     with open(os.path.join(cluster_dir, f"{cluster_id}.json")) as f:
         cluster_meta = json.load(f)
     umap_id = cluster_meta["umap_id"]
+    # Cluster id of the noise bucket when noise reassignment was off (#143);
+    # it keeps the literal label "Unclustered" instead of an LLM summary.
+    unclustered_cluster = cluster_meta.get("unclustered_cluster")
     umap = pd.read_parquet(os.path.join(DATA_DIR, dataset_id, "umaps", f"{umap_id}.parquet"))
     df["x"] = umap["x"]
     df["y"] = umap["y"]
@@ -196,6 +199,16 @@ def labeler(dataset_id, text_column="text", cluster_id="cluster-001", model_id="
                 tqdm.write(f"skipping {i} already labeled {clusters.loc[i, 'label']}")
                 time.sleep(0.01)
                 continue
+
+        if unclustered_cluster is not None and i == unclustered_cluster:
+            # Noise bucket: don't ask the LLM to summarize what is by
+            # definition unrelated content; keep the honest label.
+            tqdm.write(f"cluster {i} is the noise bucket; keeping label 'Unclustered'")
+            clusters.loc[i, 'label'] = "Unclustered"
+            clusters.loc[i, 'label_raw'] = "Unclustered"
+            clusters.loc[i, 'labeled'] = True
+            clusters.to_parquet(os.path.join(cluster_dir, f"{label_id}.parquet"))
+            continue
 
         try:
             time.sleep(0.01)

--- a/latentscope/scripts/label_clusters.py
+++ b/latentscope/scripts/label_clusters.py
@@ -125,6 +125,13 @@ def labeler(dataset_id, text_column="text", cluster_id="cluster-001", model_id="
     extracts = []
     for i, row in tqdm(clusters.iterrows(), total=clusters.shape[0], desc="Preparing extracts"):
     # for i, row in clusters.iterrows():
+        if unclustered_cluster is not None and i == unclustered_cluster:
+            # The noise bucket is never sent to the LLM (skipped again below),
+            # so don't spend time/memory loading and tokenizing what can be a
+            # very large set of rows; the empty placeholder keeps extracts
+            # index-aligned with clusters.
+            extracts.append([])
+            continue
         indices = row['indices']
         # items = df.loc[list(indices), text_column]
         items = df.loc[list(indices)]

--- a/latentscope/server/jobs.py
+++ b/latentscope/server/jobs.py
@@ -612,6 +612,11 @@ def run_cluster():
     n_neighbors = request.values.get('n_neighbors')
     noise_level = request.values.get('noise_level')
     approx_n_clusters = request.values.get('approx_n_clusters')
+    base_n_clusters = request.values.get('base_n_clusters')
+    seed = request.values.get('seed')
+    # Opt back in to the pre-1.0 behavior of reassigning noise points to their
+    # nearest cluster centroid (#143). Default keeps them as "Unclustered".
+    assign_noise = request.values.get('assign_noise')
     # Input space to cluster on: 2D umap projection or high-dim embeddings.
     # Consumed by ls-cluster (WP-B). Optional; the script defaults per method
     # (evoc->embedding, hdbscan/kmeans/gmm->umap) when omitted here.
@@ -648,6 +653,12 @@ def run_cluster():
             command.append(f'--noise_level={noise_level}')
         if approx_n_clusters and approx_n_clusters not in ('null', '0'):
             command.append(f'--approx_n_clusters={approx_n_clusters}')
+        if base_n_clusters and base_n_clusters not in ('null', '0'):
+            command.append(f'--base_n_clusters={base_n_clusters}')
+    if seed and seed != 'null':
+        command.append(f'--seed={seed}')
+    if assign_noise and assign_noise not in ('null', 'false', 'False', '0'):
+        command.append('--assign-noise')
     if cluster_on:
         command.append(f'--cluster_on={cluster_on}')
     if name:

--- a/tests/test_cluster_methods.py
+++ b/tests/test_cluster_methods.py
@@ -237,6 +237,29 @@ def test_noise_kept_as_unclustered_cluster_by_default(umapped_dataset, monkeypat
     assert unclustered_lookup[0]["hull"] == []
 
 
+def test_unclustered_id_never_collides_with_non_dense_labels(umapped_dataset, monkeypatch):
+    """Non-dense label sets (a gap at 0 — possible via the `column` path or an
+    unexpected backend) must not merge noise into a real cluster: the
+    Unclustered id is max(labels)+1, not len(labels)."""
+    data_dir, dataset_id = umapped_dataset
+    from latentscope.scripts.cluster import clusterer
+
+    # real clusters 1 and 2 (0 unused) + noise: len(non_noise)=2 would collide
+    # with real cluster 2; max+1=3 must be chosen instead
+    labels = [1] * 50 + [2] * 50 + [-1] * 20
+    _plant_noise_labels(monkeypatch, labels)
+    clusterer(dataset_id, "umap-001", samples=5, min_samples=3,
+              cluster_selection_epsilon=0.0, column=None, method="hdbscan")
+
+    df = _read_cluster_df(data_dir, dataset_id)
+    assert df["cluster"].tolist() == [1] * 50 + [2] * 50 + [3] * 20
+    # real cluster 2 kept exactly its own 50 points
+    assert (df["cluster"] == 2).sum() == 50
+
+    meta = _read_cluster_meta(data_dir, dataset_id)
+    assert meta["unclustered_cluster"] == 3
+
+
 def test_assign_noise_flag_restores_centroid_reassignment(umapped_dataset,
                                                           monkeypatch, capsys):
     data_dir, dataset_id = umapped_dataset

--- a/tests/test_cluster_methods.py
+++ b/tests/test_cluster_methods.py
@@ -167,6 +167,251 @@ def test_cluster_on_explicit_umap_recorded(umapped_dataset):
     assert meta["n_clusters"] == 4
 
 
+# ---------------------------------------------------------------------------
+# Noise handling (#143): default keeps noise as an "Unclustered" cluster;
+# --assign-noise restores the old nearest-centroid reassignment.
+# ---------------------------------------------------------------------------
+
+def _plant_noise_labels(monkeypatch, labels):
+    """Force _run_hdbscan to return a fixed label array so noise is deterministic."""
+    import numpy as np
+
+    import latentscope.scripts.cluster as cluster_mod
+    fixed = np.asarray(labels)
+    monkeypatch.setattr(cluster_mod, "_run_hdbscan",
+                        lambda *args, **kwargs: fixed.copy())
+
+
+def _read_default_labels(data_dir, dataset_id, cluster_id="cluster-001"):
+    return pd.read_parquet(os.path.join(data_dir, dataset_id, "clusters",
+                                        f"{cluster_id}-labels-default.parquet"))
+
+
+def test_noise_kept_as_unclustered_cluster_by_default(umapped_dataset, monkeypatch,
+                                                      capsys):
+    data_dir, dataset_id = umapped_dataset
+    from latentscope.scripts.cluster import clusterer
+
+    # 2 real clusters + 20 noise points -> Unclustered gets dense id 2
+    labels = [0] * 50 + [1] * 50 + [-1] * 20
+    _plant_noise_labels(monkeypatch, labels)
+    clusterer(dataset_id, "umap-001", samples=5, min_samples=3,
+              cluster_selection_epsilon=0.0, column=None, method="hdbscan")
+
+    df = _read_cluster_df(data_dir, dataset_id)
+    # noise became the extra dense cluster id 2; raw labels stay honest
+    assert (df["cluster"] >= 0).all()
+    assert df["cluster"].tolist() == [0] * 50 + [1] * 50 + [2] * 20
+    assert df["raw_cluster"].tolist() == labels
+
+    meta = _read_cluster_meta(data_dir, dataset_id)
+    assert meta["assign_noise"] is False
+    assert meta["unclustered_cluster"] == 2
+    assert meta["n_clusters"] == 2  # real clusters only
+    assert meta["n_noise"] == 20
+
+    labels_df = _read_default_labels(data_dir, dataset_id)
+    assert len(labels_df) == 3
+    assert labels_df.loc[2, "label"] == "Unclustered"
+    assert len(labels_df.loc[2, "hull"]) == 0  # no hull around scattered noise
+    assert sorted(labels_df.loc[2, "indices"]) == list(range(100, 120))
+    assert labels_df.loc[0, "label"] == "Cluster 0"
+
+    out = capsys.readouterr().out
+    assert "NOISE: 20 points (16.7% of 120)" in out
+    assert "--assign-noise" in out
+
+    # scope must handle the Unclustered cluster (positional label lookup) and
+    # its empty hull without errors
+    from latentscope.scripts.scope import scope
+    scope(dataset_id, "embedding-001", "umap-001", "cluster-001",
+          "default", "noise scope", "unclustered end-to-end")
+    scope_df = pd.read_parquet(os.path.join(
+        data_dir, dataset_id, "scopes", "scopes-001.parquet"))
+    assert (scope_df.loc[100:119, "label"] == "Unclustered").all()
+    with open(os.path.join(data_dir, dataset_id, "scopes", "scopes-001.json")) as f:
+        scope_meta = json.load(f)
+    unclustered_lookup = [c for c in scope_meta["cluster_labels_lookup"]
+                          if c["label"] == "Unclustered"]
+    assert len(unclustered_lookup) == 1
+    assert unclustered_lookup[0]["hull"] == []
+
+
+def test_assign_noise_flag_restores_centroid_reassignment(umapped_dataset,
+                                                          monkeypatch, capsys):
+    data_dir, dataset_id = umapped_dataset
+    from latentscope.scripts.cluster import clusterer
+
+    labels = [0] * 50 + [1] * 50 + [-1] * 20
+    _plant_noise_labels(monkeypatch, labels)
+    clusterer(dataset_id, "umap-001", samples=5, min_samples=3,
+              cluster_selection_epsilon=0.0, column=None, method="hdbscan",
+              assign_noise=True)
+
+    df = _read_cluster_df(data_dir, dataset_id)
+    # every noise point went to one of the two real clusters; no extra cluster
+    assert (df["cluster"] >= 0).all()
+    assert set(df["cluster"].unique()) == {0, 1}
+    assert df["raw_cluster"].tolist() == labels
+
+    meta = _read_cluster_meta(data_dir, dataset_id)
+    assert meta["assign_noise"] is True
+    assert "unclustered_cluster" not in meta
+    assert meta["n_clusters"] == 2
+    assert meta["n_noise"] == 20
+
+    labels_df = _read_default_labels(data_dir, dataset_id)
+    assert len(labels_df) == 2
+    assert "Unclustered" not in labels_df["label"].tolist()
+
+    out = capsys.readouterr().out
+    assert "NOISE: 20 points (16.7% of 120) reassigned" in out
+
+
+def test_all_noise_becomes_single_unclustered_cluster(umapped_dataset, monkeypatch):
+    data_dir, dataset_id = umapped_dataset
+    from latentscope.scripts.cluster import clusterer
+
+    _plant_noise_labels(monkeypatch, [-1] * N_TOTAL)
+    clusterer(dataset_id, "umap-001", samples=5, min_samples=3,
+              cluster_selection_epsilon=0.0, column=None, method="hdbscan")
+
+    df = _read_cluster_df(data_dir, dataset_id)
+    assert (df["cluster"] == 0).all()
+    assert (df["raw_cluster"] == -1).all()
+
+    meta = _read_cluster_meta(data_dir, dataset_id)
+    assert meta["unclustered_cluster"] == 0
+    assert meta["n_clusters"] == 0
+    assert meta["n_noise"] == N_TOTAL
+
+    labels_df = _read_default_labels(data_dir, dataset_id)
+    assert len(labels_df) == 1
+    assert labels_df.loc[0, "label"] == "Unclustered"
+    assert len(labels_df.loc[0, "hull"]) == 0
+
+
+def test_zero_noise_adds_no_unclustered_cluster(umapped_dataset):
+    """kmeans never emits -1: no Unclustered cluster and no meta key."""
+    data_dir, dataset_id = umapped_dataset
+    from latentscope.scripts.cluster import clusterer
+
+    clusterer(dataset_id, "umap-001", samples=3, min_samples=3,
+              cluster_selection_epsilon=0.0, column=None, method="kmeans")
+    meta = _read_cluster_meta(data_dir, dataset_id)
+    assert meta["assign_noise"] is False
+    assert "unclustered_cluster" not in meta
+    labels_df = _read_default_labels(data_dir, dataset_id)
+    assert "Unclustered" not in labels_df["label"].tolist()
+
+
+def test_labeler_skips_llm_for_unclustered_cluster(umapped_dataset, monkeypatch):
+    """LLM labeling must not summarize the noise bucket: it keeps the literal
+    label "Unclustered" and the model is only called for real clusters."""
+    data_dir, dataset_id = umapped_dataset
+    from latentscope.scripts.cluster import clusterer
+
+    labels = [0] * 50 + [1] * 50 + [-1] * 20
+    _plant_noise_labels(monkeypatch, labels)
+    clusterer(dataset_id, "umap-001", samples=5, min_samples=3,
+              cluster_selection_epsilon=0.0, column=None, method="hdbscan")
+
+    import latentscope.scripts.label_clusters as label_mod
+
+    calls = []
+
+    class FakeChatModel:
+        encoder = None
+
+        def load_model(self):
+            pass
+
+        def summarize(self, items, context):
+            calls.append(items)
+            return "Fake Topic Label"
+
+    monkeypatch.setattr(label_mod, "get_chat_model",
+                        lambda model_id: FakeChatModel())
+    label_mod.labeler(dataset_id, "text", "cluster-001", "fake-chat",
+                      samples=0, context="", rerun=None)
+
+    labeled = pd.read_parquet(os.path.join(
+        data_dir, dataset_id, "clusters", "cluster-001-labels-001.parquet"))
+    assert labeled.loc[0, "label"] == "Fake Topic Label"
+    assert labeled.loc[1, "label"] == "Fake Topic Label"
+    assert labeled.loc[2, "label"] == "Unclustered"
+    assert bool(labeled.loc[2, "labeled"]) is True
+    # the LLM was only called for the two real clusters, never the noise bucket
+    assert len(calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Remaining EVoC knobs + seed (#143)
+# ---------------------------------------------------------------------------
+
+def test_run_evoc_forwards_new_knobs(monkeypatch):
+    """base_n_clusters / min_samples / seed(random_state) reach evoc.EVoC."""
+    import sys
+    import types
+
+    import numpy as np
+
+    captured = {}
+
+    class FakeEVoC:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def fit_predict(self, X):
+            return np.zeros(len(X), dtype=int)
+
+    fake_evoc = types.ModuleType("evoc")
+    fake_evoc.EVoC = FakeEVoC
+    monkeypatch.setitem(sys.modules, "evoc", fake_evoc)
+
+    from latentscope.scripts.cluster import _run_evoc
+    embeddings = np.random.default_rng(0).normal(size=(10, 32))
+    _run_evoc(embeddings, samples=7, min_samples=3, n_neighbors=20,
+              noise_level=0.4, approx_n_clusters=6, base_n_clusters=12, seed=99)
+
+    assert captured["base_min_cluster_size"] == 7
+    assert captured["min_samples"] == 3
+    assert captured["n_neighbors"] == 20
+    assert captured["noise_level"] == 0.4
+    assert captured["approx_n_clusters"] == 6
+    assert captured["base_n_clusters"] == 12
+    assert captured["random_state"] == 99
+
+
+def test_seed_recorded_in_meta_and_reproducible_kmeans(umapped_dataset):
+    data_dir, dataset_id = umapped_dataset
+    from latentscope.scripts.cluster import clusterer
+
+    clusterer(dataset_id, "umap-001", samples=3, min_samples=3,
+              cluster_selection_epsilon=0.0, column=None, method="kmeans",
+              seed=123)
+    clusterer(dataset_id, "umap-001", samples=3, min_samples=3,
+              cluster_selection_epsilon=0.0, column=None, method="kmeans",
+              seed=123)
+
+    meta = _read_cluster_meta(data_dir, dataset_id, "cluster-001")
+    assert meta["seed"] == 123
+    # same seed -> identical assignments across runs
+    first = _read_cluster_df(data_dir, dataset_id, "cluster-001")
+    second = _read_cluster_df(data_dir, dataset_id, "cluster-002")
+    assert first["cluster"].tolist() == second["cluster"].tolist()
+
+
+def test_seed_omitted_from_meta_when_unset(umapped_dataset):
+    data_dir, dataset_id = umapped_dataset
+    from latentscope.scripts.cluster import clusterer
+
+    clusterer(dataset_id, "umap-001", samples=3, min_samples=3,
+              cluster_selection_epsilon=0.0, column=None, method="gmm")
+    meta = _read_cluster_meta(data_dir, dataset_id)
+    assert "seed" not in meta
+
+
 def test_evoc_node_embedding_dim_caps_low_dim_input():
     """EVoC PCA-inits its node embedding with up to 15 components; on 2-D umap
     input the dim must be capped at the feature count or PCA raises."""

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -269,6 +269,44 @@ class TestPostCompat:
         assert response.get_json()["status"] == "dead"
 
 
+class TestClusterCommand:
+    """The /cluster route must forward the #143 flags to ls-cluster."""
+
+    def _capture_command(self, client, monkeypatch, query):
+        import latentscope.server.jobs as jobs_mod
+        captured = {}
+        done = threading.Event()
+
+        def fake_run_job(data_dir, dataset, job_id, command):
+            captured["command"] = command
+            done.set()
+
+        monkeypatch.setattr(jobs_mod, "run_job", fake_run_job)
+        res = client.get(f"/api/jobs/cluster?{query}")
+        assert res.status_code == 200
+        assert done.wait(5)
+        return captured["command"]
+
+    def test_new_flags_forwarded(self, client, monkeypatch):
+        cmd = self._capture_command(
+            client, monkeypatch,
+            "dataset=ds1&umap_id=umap-001&samples=5&min_samples=3"
+            "&cluster_selection_epsilon=0.0&method=evoc"
+            "&assign_noise=true&seed=7&base_n_clusters=12")
+        assert "--assign-noise" in cmd
+        assert "--seed=7" in cmd
+        assert "--base_n_clusters=12" in cmd
+
+    def test_flags_omitted_by_default(self, client, monkeypatch):
+        cmd = self._capture_command(
+            client, monkeypatch,
+            "dataset=ds1&umap_id=umap-001&samples=5&min_samples=3"
+            "&cluster_selection_epsilon=0.0&method=hdbscan")
+        assert "--assign-noise" not in cmd
+        assert not any(c.startswith("--seed") for c in cmd)
+        assert not any(c.startswith("--base_n_clusters") for c in cmd)
+
+
 def test_readonly_app_does_not_reconcile_jobs(tmp_data_dir):
     """Codex review on #119: read-only deployments must not mutate the data
     dir — starting the app in read_only mode must leave stale 'running' job

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -127,7 +127,8 @@ def test_full_pipeline_small_dataset(pipeline_env):
     assert len(cluster_df) == n_total
     n_clusters = cluster_df["cluster"].nunique()
     assert n_clusters >= 2, "expected the 3 planted topics to form >=2 clusters"
-    # noise points must all have been reassigned
+    # no -1 survives: by default noise becomes an explicit "Unclustered"
+    # cluster (#143); --assign-noise would reassign to nearest centroids
     assert (cluster_df["cluster"] >= 0).all()
     labels_path = os.path.join(
         data_dir, dataset_id, "clusters", "cluster-001-labels-default.parquet")
@@ -688,6 +689,105 @@ class FakeTokenizingProvider(FakeEmbedProvider):
     def __init__(self, dim=DIM):
         super().__init__(dim)
         self.tokenizer = self._WordTokenizer()
+
+
+def test_embed_failure_leaves_debug_parquet_and_rerun_cleans_it(pipeline_env,
+                                                                monkeypatch,
+                                                                capsys):
+    """#143: a failed batch writes a debug parquet and points at --rerun; a
+    subsequent successful --rerun completes and removes the stale debug file."""
+    data_dir = pipeline_env
+    dataset_id = "e2e-test"
+
+    from latentscope.scripts.ingest import ingest
+    ingest(dataset_id, make_input_df(), text_column="text")
+
+    import latentscope.scripts.embed as embed_mod
+
+    class CrashingProvider(FakeEmbedProvider):
+        calls = 0
+
+        def embed(self, batch, dimensions=None):
+            CrashingProvider.calls += 1
+            if CrashingProvider.calls > 1:
+                raise RuntimeError("simulated crash")
+            return super().embed(batch, dimensions)
+
+    monkeypatch.setattr(embed_mod, "get_embedding_model",
+                        lambda model_id: CrashingProvider())
+    with pytest.raises(SystemExit):
+        embed_mod.embed(dataset_id, "text", "fake-test-model", prefix=None,
+                        rerun=None, dimensions=None, batch_size=50)
+
+    embedding_dir = os.path.join(data_dir, dataset_id, "embeddings")
+    debug_path = os.path.join(embedding_dir, "embedding-001-batch-1.parquet")
+    assert os.path.exists(debug_path)
+    out = capsys.readouterr().out
+    # the failure message names the exact resume command
+    assert "ls-embed e2e-test text fake-test-model --rerun embedding-001" in out
+
+    # resume with a healthy provider: run completes and cleans the debug file
+    monkeypatch.setattr(embed_mod, "get_embedding_model",
+                        lambda model_id: FakeEmbedProvider())
+    embed_mod.embed(dataset_id, "text", "fake-test-model", prefix=None,
+                    rerun="embedding-001", dimensions=None, batch_size=50)
+    assert not os.path.exists(debug_path)
+    out = capsys.readouterr().out
+    assert "cleaned up stale debug batch file embedding-001-batch-1.parquet" in out
+    assert os.path.exists(os.path.join(embedding_dir, "embedding-001.json"))
+
+    from latentscope.util.embedding_store import get_embedding_count
+    n_total = N_PER_TOPIC * len(TOPICS)
+    assert get_embedding_count(data_dir, dataset_id, "embedding-001") == n_total
+
+
+# ---------------------------------------------------------------------------
+# max_seq_length OOM preflight (#143)
+# ---------------------------------------------------------------------------
+
+class FakeUncappedProvider(FakeEmbedProvider):
+    """FakeEmbedProvider whose inner model advertises a huge max_seq_length,
+    like sentence-transformers models with no practical sequence cap."""
+
+    class _InnerModel:
+        max_seq_length = 8192
+
+    def __init__(self, dim=DIM):
+        super().__init__(dim)
+        self.model = self._InnerModel()
+
+
+def test_embed_warns_when_max_seq_length_uncapped(pipeline_env, monkeypatch, capsys):
+    """#143: an uncapped model without --max_seq_length gets a prominent OOM
+    warning (print-only; the sequence length is never silently capped)."""
+    dataset_id = "preflight"
+    import latentscope.scripts.embed as embed_mod
+    from latentscope.scripts.ingest import ingest
+
+    ingest(dataset_id, make_input_df(n_per_topic=2), text_column="text")
+    monkeypatch.setattr(embed_mod, "get_embedding_model",
+                        lambda model_id: FakeUncappedProvider())
+    embed_mod.embed(dataset_id, "text", "fake-uncapped", prefix=None, rerun=None,
+                    dimensions=None, batch_size=5)
+    out = capsys.readouterr().out
+    assert "effective max_seq_length: 8192" in out
+    assert "WARNING" in out
+    assert "--max_seq_length 512 --batch_size 32" in out
+
+
+def test_embed_no_warning_when_user_caps_max_seq_length(pipeline_env, monkeypatch,
+                                                        capsys):
+    dataset_id = "preflight-capped"
+    import latentscope.scripts.embed as embed_mod
+    from latentscope.scripts.ingest import ingest
+
+    ingest(dataset_id, make_input_df(n_per_topic=2), text_column="text")
+    monkeypatch.setattr(embed_mod, "get_embedding_model",
+                        lambda model_id: FakeUncappedProvider())
+    embed_mod.embed(dataset_id, "text", "fake-uncapped", prefix=None, rerun=None,
+                    dimensions=None, batch_size=5, max_seq_length=512)
+    out = capsys.readouterr().out
+    assert "can exhaust MPS/CUDA memory" not in out
 
 
 def test_make_token_counter_uses_provider_tokenizer():


### PR DESCRIPTION
Closes #143.

## ⚠️ Behavior change: noise is no longer silently reassigned

HDBSCAN/EVoC noise (`-1`) points are no longer reassigned to their nearest centroid by default — they become an explicit **"Unclustered"** cluster (next dense id, empty hull, LLM labeling skips it and keeps the literal label), so downstream positional lookups and the UI work unchanged while labels stay honest. `--assign-noise` restores the exact previous behavior. Both modes print a loud `NOISE: N points (P%)` line naming the switching flag. Meta records `assign_noise` and `unclustered_cluster`. Edge cases covered: all-noise (one Unclustered cluster id 0, even under `--assign-noise` since there are no centroids), zero noise, kmeans/gmm (never emit -1).

## Also in this PR

- **Docs** (`docs/clustering.md`): the new noise semantics; an "HDBSCAN parameter sensitivity" section with the issue's cliff numbers (53→3 clusters between mcs 150→160; 55→5 between 110→120 — per-embedding, sweep in small steps) and `min_samples=1` as a noise-reduction lever (33%→~25% in the report).
- **EVoC knobs** (completing what #141 started): `--base_n_clusters <int>` (evoc 0.3.1's constructor takes a plain int, not a list), the existing `min_samples` positional now forwards to EVoC, and `--seed` → `random_state` for evoc + kmeans (sklearn & cuML) + gmm. New params recorded in cluster meta; server job route forwards `assign_noise`/`seed`/`base_n_clusters`. (Setup UI fields for these are a follow-up — the route already accepts them.)
- **Embed**: prints the effective `max_seq_length` after model load and a prominent OOM warning when it's uncapped (>2048) and `--max_seq_length` wasn't passed (never caps silently — that would change embedding results); the failure path prints the exact `--rerun` resume command; successful completion (including reruns) deletes stale `{embedding_id}-batch-*.parquet` debug files. The deliberate run-id burn and partial LanceDB table (which powers `--rerun`) are untouched.

## Test plan

- `uv run pytest tests/ -q` — 232 passed (13 new: noise default / `--assign-noise` / all-noise / zero-noise, labeler skips LLM for Unclustered, EVoC kwarg forwarding via a fake evoc module, seed reproducibility + meta, jobs-route forwarding, embed crash → debug parquet → rerun cleanup, preflight warn/no-warn)
- End-to-end test runs `scope()` and confirms the Unclustered empty hull round-trips as `[]` (the frontend HullPlot already filters empty hulls) and noise rows get the "Unclustered" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)