### PR TITLE
Amber Console restyle of 3d components (follow-up to #154)

### DIFF
--- a/web/src/components/Explore/CellDetail.jsx
+++ b/web/src/components/Explore/CellDetail.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
-import { Button } from 'react-element-forge';
 
+import { Pagination } from '../ui';
 import { apiService } from '../../lib/apiService';
 import { useScope } from '../../contexts/ScopeContext';
 import { clusterColorHex } from '../../lib/clusterColor';
@@ -116,15 +116,18 @@ function CellDetail({ selectedCell, onClose, onOpenPoint }) {
     });
   }, []);
 
-  const headerColor = summary ? clusterColorHex(summary.dominantCluster, numClusters) : '#999';
+  // data-driven swatch: dominant-cluster hue from the shared palette
+  const headerColor = summary ? clusterColorHex(summary.dominantCluster, numClusters) : null;
 
   return (
     <div className={`${styles.drawer} ${isOpen ? styles.open : ''}`}>
       <div className={styles.header}>
         <div className={styles.headerText}>
           <span className={styles.title}>
-            {summary ? summary.count.toLocaleString() : 0} datapoint
-            {summary && summary.count === 1 ? '' : 's'} in cell
+            <span className={styles.titleCount}>
+              {summary ? summary.count.toLocaleString() : 0}
+            </span>{' '}
+            datapoint{summary && summary.count === 1 ? '' : 's'} in cell
           </span>
           {summary && (
             <span className={styles.cluster}>
@@ -133,14 +136,25 @@ function CellDetail({ selectedCell, onClose, onOpenPoint }) {
             </span>
           )}
         </div>
-        <Button
-          className={styles.closeButton}
+        <button
+          type="button"
+          className={`ls-icon-btn ${styles.closeButton}`}
           onClick={onClose}
           aria-label="Close cell detail"
-          icon="x"
-          variant="outline"
-          size="small"
-        />
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
       </div>
 
       <div className={styles.content}>
@@ -164,7 +178,19 @@ function CellDetail({ selectedCell, onClose, onOpenPoint }) {
                   onClick={() => toggle(pos)}
                   aria-expanded={isExp}
                 >
-                  <span className={styles.caret}>{isExp ? '▾' : '▸'}</span>
+                  <span className={`${styles.caret} ${isExp ? styles.caretOpen : ''}`}>
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <polyline points="9 18 15 12 9 6" />
+                    </svg>
+                  </span>
                   <span className={styles.entryIndex}>Row {row?.ls_index ?? pos}</span>
                   {cl?.label && <span className={styles.entryCluster}>{cl.label}</span>}
                 </button>
@@ -192,26 +218,7 @@ function CellDetail({ selectedCell, onClose, onOpenPoint }) {
 
       {pageCount > 1 && (
         <div className={styles.pager}>
-          <Button
-            size="small"
-            variant="outline"
-            icon="chevron-left"
-            disabled={page === 0}
-            onClick={() => setPage((p) => Math.max(0, p - 1))}
-            aria-label="Previous page"
-          />
-          <span className={styles.pagerLabel}>
-            {pageStart + 1}–{Math.min(pageStart + PAGE_SIZE, members.length)} of{' '}
-            {members.length.toLocaleString()}
-          </span>
-          <Button
-            size="small"
-            variant="outline"
-            icon="chevron-right"
-            disabled={page >= pageCount - 1}
-            onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
-            aria-label="Next page"
-          />
+          <Pagination page={page + 1} totalPages={pageCount} onPage={(p) => setPage(p - 1)} />
         </div>
       )}
     </div>

--- a/web/src/components/Explore/CellDetail.module.scss
+++ b/web/src/components/Explore/CellDetail.module.scss
@@ -1,21 +1,23 @@
+// Cell-detail drawer — same visual language as the PointDetail drawer.
+// All values are tokens; see DESIGN.md §5 (modals/drawers).
 .drawer {
   position: absolute;
   top: 0;
   right: 0;
   bottom: 0;
-  width: 400px;
+  width: var(--ls-drawer-width);
   max-width: 85%;
   display: flex;
   flex-direction: column;
-  background: var(--neutrals-color-neutral-0, #ffffff);
-  border-left: 1px solid var(--borders-color-border-1, #e6e6e6);
-  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.15);
-  z-index: 1100;
+  background: var(--ls-surface-panel);
+  border-left: 1px solid var(--borders-color-border-2);
+  box-shadow: var(--ls-shadow-3);
+  z-index: var(--ls-z-drawer);
   transform: translateX(105%);
   visibility: hidden;
   transition:
-    transform 0.25s ease,
-    visibility 0.25s;
+    transform var(--ls-dur-slow) var(--ls-ease-in-out),
+    visibility var(--ls-dur-slow);
 
   &.open {
     transform: translateX(0);
@@ -27,39 +29,46 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 8px;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--borders-color-border-1, #e6e6e6);
+  gap: var(--ls-space-2);
+  padding: var(--ls-space-3) var(--ls-space-4);
+  border-bottom: 1px solid var(--borders-color-border-1);
   flex-shrink: 0;
 }
 
 .headerText {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
   min-width: 0;
 }
 
 .title {
-  font-size: 15px;
+  font-size: var(--ls-text-sm);
   font-weight: 600;
-  color: var(--text-color-text-main, #262a30);
+  color: var(--text-color-text-main);
+}
+
+// the member count is a machine fact
+.titleCount {
+  font-family: var(--ls-font-mono);
+  font-variant-numeric: tabular-nums;
 }
 
 .cluster {
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  color: var(--text-color-text-subtle, #757575);
+  gap: var(--ls-space-1);
+  font-size: var(--ls-text-xs);
+  color: var(--text-color-text-subtle);
   overflow-wrap: anywhere;
 }
 
+// dominant-cluster swatch: background color is data-driven (cluster palette)
 .dot {
   display: inline-block;
   width: 10px;
   height: 10px;
-  border-radius: 50%;
+  border-radius: var(--ls-radius-round);
   flex-shrink: 0;
 }
 
@@ -70,25 +79,26 @@
 .content {
   flex: 1;
   overflow-y: auto;
-  padding: 4px 0;
+  padding: var(--ls-space-1) 0;
 }
 
 .entry {
-  padding: 8px 16px;
-  border-bottom: 1px solid var(--borders-color-border-1, #eee);
+  padding: var(--ls-space-2) var(--ls-space-4);
+  border-bottom: 1px solid var(--borders-color-border-1);
 }
 
 .entryHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--ls-space-2);
 }
 
 .entryToggle {
+  appearance: none;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--ls-space-1);
   background: none;
   border: none;
   padding: 0;
@@ -96,45 +106,73 @@
   min-width: 0;
   flex: 1;
   text-align: left;
+
+  &:focus-visible {
+    outline: var(--ls-focus-ring);
+    outline-offset: var(--ls-focus-ring-offset);
+  }
 }
 
 .caret {
-  color: var(--text-color-text-subtle, #999);
-  font-size: 11px;
-  width: 10px;
+  display: inline-flex;
   flex-shrink: 0;
+  color: var(--text-color-text-subtle);
+  transition: transform var(--ls-dur-fast) var(--ls-ease-out);
+
+  svg {
+    width: 12px;
+    height: 12px;
+  }
 }
 
+.caretOpen {
+  transform: rotate(90deg);
+}
+
+// the row id is a machine fact
 .entryIndex {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-color-text-main, #262a30);
+  font-family: var(--ls-font-mono);
+  font-size: var(--ls-text-xs);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-color-text-main);
   flex-shrink: 0;
 }
 
 .entryCluster {
-  font-size: 11px;
-  color: var(--text-color-text-subtle, #757575);
+  font-size: var(--ls-text-2xs);
+  color: var(--text-color-text-subtle);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .openLink {
+  appearance: none;
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 11px;
-  color: var(--text-color-text-primary, #a36022);
-  flex-shrink: 0;
   padding: 0;
+  font-family: var(--ls-font-ui);
+  font-size: var(--ls-text-xs);
+  color: var(--text-color-text-primary);
+  flex-shrink: 0;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: var(--ls-focus-ring);
+    outline-offset: var(--ls-focus-ring-offset);
+  }
 }
 
 .entryText {
-  margin-top: 4px;
-  font-size: 13px;
-  line-height: 1.45;
-  color: var(--text-color-text-main, #33373d);
+  margin-top: var(--ls-space-1);
+  font-size: var(--ls-text-sm);
+  line-height: var(--ls-leading-body);
+  color: var(--text-color-text-main);
   overflow-wrap: anywhere;
 
   &.expanded {
@@ -144,7 +182,7 @@
 }
 
 .muted {
-  color: var(--text-color-text-subtle, #999);
+  color: var(--text-color-text-subtle);
   font-style: italic;
 }
 
@@ -152,15 +190,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 12px;
-  padding: 8px 16px;
-  border-top: 1px solid var(--borders-color-border-1, #e6e6e6);
+  padding: var(--ls-space-2) var(--ls-space-4);
+  border-top: 1px solid var(--borders-color-border-1);
   flex-shrink: 0;
-}
-
-.pagerLabel {
-  font-size: 12px;
-  color: var(--text-color-text-subtle, #757575);
 }
 
 // Narrow screens: full-width drawer so the cell list is readable on a phone.

--- a/web/src/components/Explore/MembersTooltip.jsx
+++ b/web/src/components/Explore/MembersTooltip.jsx
@@ -1,5 +1,7 @@
 import { createPortal } from 'react-dom';
 
+import styles from './MembersTooltip.module.scss';
+
 // Presentation for the members-in-cell tooltip (2D heatmap + 3D voxels).
 // Controlled: given a viewport position + the active cell summary/snippets from
 // useCellMembers, renders a floating card "N datapoints · dominant label" plus a
@@ -15,45 +17,19 @@ function MembersTooltip({ x, y, summary, snippets, loading }) {
   const top = Math.max(8, y - 12);
 
   return createPortal(
-    <div
-      className="members-tooltip"
-      style={{
-        position: 'fixed',
-        left,
-        top,
-        width,
-        maxWidth: '90vw',
-        pointerEvents: 'none',
-        zIndex: 10000,
-        background: '#D3965E',
-        color: '#1c1204',
-        borderRadius: 6,
-        padding: '8px 10px',
-        boxShadow: '0 4px 16px rgba(0,0,0,0.35)',
-        fontSize: 12,
-        lineHeight: 1.35,
-      }}
-    >
-      <div style={{ fontWeight: 700, marginBottom: 4 }}>
-        {summary.count.toLocaleString()} datapoint{summary.count === 1 ? '' : 's'}
-        <span style={{ fontWeight: 400 }}> · {summary.label}</span>
+    <div className={styles.tooltip} style={{ left, top, width }}>
+      <div className={styles.header}>
+        <span className={styles.count}>{summary.count.toLocaleString()}</span> datapoint
+        {summary.count === 1 ? '' : 's'}
+        <span className={styles.label}> · {summary.label}</span>
       </div>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <div className={styles.snippets}>
         {loading && snippets.length === 0 && (
-          <em style={{ opacity: 0.75 }}>loading snippets…</em>
+          <span className={styles.muted}>loading snippets…</span>
         )}
         {snippets.map((t, i) => (
-          <div
-            key={i}
-            style={{
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              borderTop: i === 0 ? 'none' : '1px solid rgba(0,0,0,0.12)',
-              paddingTop: i === 0 ? 0 : 3,
-            }}
-          >
-            {t == null || t === '' ? <span style={{ opacity: 0.5 }}>(empty)</span> : String(t)}
+          <div key={i} className={styles.snippet}>
+            {t == null || t === '' ? <span className={styles.muted}>(empty)</span> : String(t)}
           </div>
         ))}
       </div>

--- a/web/src/components/Explore/Scatter3D.jsx
+++ b/web/src/components/Explore/Scatter3D.jsx
@@ -6,6 +6,12 @@ import { useColorMode } from '../../hooks/useColorMode';
 
 CameraControls.install({ THREE });
 
+// Chrome colors live in the token layer; the WebGL clear color is read at
+// build time and the scene rebuilds when the color mode flips (CrosshairPlot
+// pattern). Point palettes themselves are data-driven and stay in JS.
+const readToken = (name) =>
+  getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+
 // ---------------------------------------------------------------------------
 // Soft-splat billboard shader, ported/adapted from latent-renders pointset.js:
 // FOV-correct size attenuation with min/max pixel clamps, energy-preserving
@@ -147,7 +153,8 @@ function Scatter3D({
   // hover/select wiring, no tooltip fetch. Used by the umap preview panel.
   lightweight = false,
 }) {
-  const { isDark } = useColorMode();
+  // useColorMode re-renders on theme flips, which re-reads the chrome tokens.
+  useColorMode();
   const mountRef = useRef(null);
   const stateRef = useRef(null); // holds three.js objects across renders
   const onHoverRef = useRef(onHover);
@@ -174,7 +181,9 @@ function Scatter3D({
     return Math.max(max + 1, clusterLabels?.length || 0, 1);
   }, [scopeRows, clusterLabels]);
 
-  const bg = isDark ? 0x111111 : 0xfafafa;
+  // Map surface token (the darkest surface in dark mode). A primitive string,
+  // so the build effect below only re-runs when the theme actually changes.
+  const bg = readToken('--ls-surface-map');
 
   // Build the scene once (renderer, camera, controls, mesh). Rebuilds when the
   // point data or canvas size changes.

--- a/web/src/components/Explore/VoxelView.jsx
+++ b/web/src/components/Explore/VoxelView.jsx
@@ -1,12 +1,21 @@
 import { useEffect, useRef, useMemo, useState, useCallback } from 'react';
 import * as THREE from 'three';
 import CameraControls from 'camera-controls';
+import { Button } from 'react-element-forge';
 import { clusterColorHex } from '../../lib/clusterColor';
 import { useColorMode } from '../../hooks/useColorMode';
 import { useCellMembers } from '../../hooks/useCellMembers';
 import MembersTooltip from './MembersTooltip';
+import { Readout } from '../ui';
+import styles from './VoxelView.module.scss';
 
 CameraControls.install({ THREE });
+
+// Chrome colors live in the token layer; the WebGL clear color is read at
+// build time and the scene rebuilds when the color mode flips (CrosshairPlot
+// pattern). Voxel/point colors themselves are data-driven and stay in JS.
+const readToken = (name) =>
+  getComputedStyle(document.documentElement).getPropertyValue(name).trim();
 
 // Scale a color's luminance by cell density so denser cells glow brighter,
 // keeping a floor so sparse cells still read on a dark bg.
@@ -24,6 +33,7 @@ function voxelColor(hex, density) {
 }
 
 function VoxelView({ scopeRows, width, height, scope, clusterLabels, pointColors = null, onCellSelect }) {
+  // useColorMode re-renders on theme flips, which re-reads the chrome tokens.
   const { isDark } = useColorMode();
   const [resolution, setResolution] = useState(64); // voxel_index_64 default
   const [sliceT, setSliceT] = useState(0.5); // 0..1 depth along the FIXED view axis
@@ -127,7 +137,9 @@ function VoxelView({ scopeRows, width, height, scope, clusterLabels, pointColors
   const cellColorsRef = useRef(cellColors);
   cellColorsRef.current = cellColors;
 
-  const bg = isDark ? 0x0a0c12 : 0xf2f2f4;
+  // Map surface token (the darkest surface in dark mode). A primitive string,
+  // so the build effect below only re-runs when the theme actually changes.
+  const bg = readToken('--ls-surface-map');
 
   // Build the scene (renderer, lights, instanced cubes, camera, controls).
   useEffect(() => {
@@ -419,39 +431,18 @@ function VoxelView({ scopeRows, width, height, scope, clusterLabels, pointColors
     stateRef.current?.recomputePlaneAxis();
   }, []);
 
-  const btn = (active) => ({
-    background: active ? '#5a4fcf' : 'transparent',
-    color: '#eee',
-    border: '1px solid #666',
-    borderRadius: 4,
-    padding: '1px 8px',
-    cursor: 'pointer',
-  });
-
   return (
     <div style={{ position: 'absolute', inset: 0, width, height }}>
       <div ref={mountRef} style={{ position: 'absolute', inset: 0 }} />
       {/* slice + resolution controls. On touch/small screens the bottom is
           occupied by the data-table sheet, so the controls anchor to the top. */}
       <div
-        style={{
-          position: 'absolute',
-          left: 12,
-          ...(isTouch ? { top: 56 } : { bottom: 12 }),
-          background: 'rgba(20,22,30,0.72)',
-          color: '#eee',
-          padding: '8px 12px',
-          borderRadius: 8,
-          fontSize: 12,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 6,
-          width: 'min(260px, calc(100vw - 24px))',
-          boxSizing: 'border-box',
-        }}
+        className={`ls-panel ls-panel--floating ${styles.hud} ${
+          isTouch ? styles.hudTop : styles.hudBottom
+        }`}
       >
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <span style={{ width: 44 }}>Slice</span>
+        <div className={styles.row}>
+          <span className={styles.rowLabel}>Slice</span>
           <input
             type="range"
             min={0}
@@ -459,24 +450,44 @@ function VoxelView({ scopeRows, width, height, scope, clusterLabels, pointColors
             step={0.005}
             value={sliceT}
             onChange={(e) => setSliceT(Number(e.target.value))}
-            style={{ flex: 1 }}
+            className={styles.slider}
+            aria-label="Slice depth"
           />
-          <button onClick={alignToView} style={btn(false)} title="Re-align the slice plane to the current view">
-            Align to view
-          </button>
+          <Button
+            size="small"
+            variant="outline"
+            color="secondary"
+            text="Align"
+            onClick={alignToView}
+            title="Re-align the slice plane to the current view"
+          />
         </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <span style={{ width: 44 }}>Res</span>
-          <button onClick={() => setResolution(32)} style={btn(resolution === 32)}>
+        <div className={styles.row}>
+          <span className={styles.rowLabel}>Res</span>
+          <button
+            type="button"
+            className={`ls-chip ${styles.chipBtn} ${resolution === 32 ? 'ls-badge--selected' : ''}`}
+            aria-pressed={resolution === 32}
+            onClick={() => setResolution(32)}
+          >
             32
           </button>
-          <button onClick={() => setResolution(64)} style={btn(resolution === 64)}>
+          <button
+            type="button"
+            className={`ls-chip ${styles.chipBtn} ${resolution === 64 ? 'ls-badge--selected' : ''}`}
+            aria-pressed={resolution === 64}
+            onClick={() => setResolution(64)}
+          >
             64
           </button>
-          <span style={{ opacity: 0.6, marginLeft: 'auto' }}>{cells.length} cells</span>
+          <span className={styles.cellCount}>
+            <Readout label="Cells" value={cells.length.toLocaleString()} />
+          </span>
         </div>
-        <div style={{ opacity: 0.55, fontSize: 11 }}>
-          {isTouch ? 'tap a cell for its contents' : 'shift + wheel to move slice · click a cell for its contents'}
+        <div className={styles.hint}>
+          {isTouch
+            ? 'tap a cell for its contents'
+            : 'shift + wheel to move slice · click a cell for its contents'}
         </div>
       </div>
       {!isTouch && tooltipPos && active && (


### PR DESCRIPTION
The restyle of CellDetail, MembersTooltip, VoxelView, and Scatter3D was in the working tree during the #154 merge but never staged, so it missed the merge commit. This is that work: token-driven drawer/tooltip/HUD chrome and theme-reactive canvas clear colors, with data-viz palettes untouched. Build, eslint, and vitest verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)