### PR TITLE
Fix build: add missing MembersTooltip.module.scss

### DIFF
--- a/web/src/components/Explore/MembersTooltip.module.scss
+++ b/web/src/components/Explore/MembersTooltip.module.scss
@@ -1,0 +1,50 @@
+// Floating members-in-cell tooltip (2D heatmap + 3D voxels). Rendered into a
+// portal with viewport coordinates from the component, so position: fixed.
+// Same visual language as the drawers; see DESIGN.md §5.
+.tooltip {
+  position: fixed;
+  z-index: var(--ls-z-tooltip);
+  background: var(--ls-surface-panel);
+  border: 1px solid var(--borders-color-border-2);
+  box-shadow: var(--ls-shadow-3);
+  border-radius: 4px;
+  padding: var(--ls-space-2) var(--ls-space-3);
+  pointer-events: none;
+  font-size: var(--ls-text-sm);
+}
+
+.header {
+  font-family: var(--ls-font-ui);
+  color: var(--text-color-text-1);
+  margin-bottom: var(--ls-space-1);
+}
+
+.count {
+  font-family: var(--ls-font-mono);
+  font-weight: 600;
+}
+
+.label {
+  color: var(--text-color-text-2);
+}
+
+.snippets {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ls-space-1);
+}
+
+.snippet {
+  font-size: var(--ls-text-xs);
+  color: var(--text-color-text-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.muted {
+  color: var(--text-color-text-3);
+  font-style: italic;
+}


### PR DESCRIPTION
`vite build` fails on main with `Could not resolve "./MembersTooltip.module.scss"` — the component has imported this file since it landed (ab8bcee, restyled in ef89b05) but the scss module was never committed on any branch. Vitest passes because CSS modules are mocked, so the suite doesn't catch it.

This adds the missing module using the Amber Console token vocabulary from the sibling CellDetail/PointDetail modules (`--ls-surface-panel`, `--ls-z-tooltip`, spacing/shadow tokens; fixed-position floating card, pointer-events none, 2-line snippet clamp).

Verified: `npm run production` builds clean with this commit on top of main.

Blocks build verification for every open PR, so probably worth merging first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)